### PR TITLE
Update PluginDescriptor to include the`target` field as part of the contract

### DIFF
--- a/config/types/clientconfig.go
+++ b/config/types/clientconfig.go
@@ -15,15 +15,20 @@ type Target string
 
 const (
 	// TargetK8s is a kubernetes target of the CLI
+	// This target applies if the plugin is interacting with a Kubernetes cluster
 	TargetK8s Target = "kubernetes"
 	targetK8s Target = "k8s"
 
 	// TargetTMC is a Tanzu Mission Control target of the CLI
+	// This target applies if the plugin is interacting with a Tanzu Mission Control endpoint
 	TargetTMC Target = "mission-control"
 	targetTMC Target = "tmc"
 
-	// TargetNone is used for plugins that are not associated with any target
-	TargetNone Target = ""
+	// TargetGlobal is used for plugins that are not associated with any target
+	TargetGlobal Target = "global"
+
+	// TargetUnknown specifies that the target is not currently known
+	TargetUnknown Target = ""
 )
 
 var (

--- a/config/types/clientconfig_helper.go
+++ b/config/types/clientconfig_helper.go
@@ -9,16 +9,22 @@ func StringToTarget(target string) Target {
 		return TargetK8s
 	} else if target == string(targetTMC) || target == string(TargetTMC) {
 		return TargetTMC
-	} else if target == string(TargetNone) {
-		return TargetNone
+	} else if target == string(TargetGlobal) {
+		return TargetGlobal
+	} else if target == string(TargetUnknown) {
+		return TargetUnknown
 	}
-	return TargetNone
+	return TargetUnknown
 }
 
-func IsValidTarget(target string) bool {
+// IsValidTarget validates the target string specified is valid or not
+// TargetGlobal and TargetUnknown are special targets and hence this function
+// provide flexibility additional arguments to allow them based on the requirement
+func IsValidTarget(target string, allowGlobal, allowUnknown bool) bool {
 	return target == string(targetK8s) ||
 		target == string(TargetK8s) ||
 		target == string(targetTMC) ||
 		target == string(TargetTMC) ||
-		target == string(TargetNone)
+		(allowGlobal && target == string(TargetGlobal)) ||
+		(allowUnknown && target == string(TargetUnknown))
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -8,13 +8,39 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
+
+func TestValidatePlugin(t *testing.T) {
+	assert := assert.New(t)
+
+	descriptor := PluginDescriptor{
+		Name:            "Test Plugin",
+		DocURL:          "https://docs.example.com",
+		Hidden:          false,
+		PostInstallHook: func() error { return nil },
+	}
+
+	err := ValidatePlugin(&descriptor)
+	assert.ErrorContains(err, "target is not valid")
+	assert.ErrorContains(err, "version cannot be empty")
+	assert.ErrorContains(err, "description cannot be empty")
+	assert.ErrorContains(err, "group cannot be empty")
+
+	descriptor.Name = ""
+	descriptor.Version = "non-semver"
+	err = ValidatePlugin(&descriptor)
+	assert.ErrorContains(err, "plugin name cannot be empty")
+	assert.ErrorContains(err, "is not a valid semantic version")
+}
 
 func TestNewPlugin(t *testing.T) {
 	assert := assert.New(t)
 
 	descriptor := PluginDescriptor{
 		Name:            "Test Plugin",
+		Target:          types.TargetGlobal,
 		Description:     "Description of the plugin",
 		Version:         "v1.2.3",
 		BuildSHA:        "cafecafe",
@@ -37,6 +63,7 @@ func TestAddCommands(t *testing.T) {
 
 	descriptor := PluginDescriptor{
 		Name:        "Test Plugin",
+		Target:      types.TargetGlobal,
 		Description: "Description of the plugin",
 		Version:     "v1.2.3",
 		BuildSHA:    "cafecafe",
@@ -65,6 +92,7 @@ func TestExecute(t *testing.T) {
 
 	descriptor := PluginDescriptor{
 		Name:        "Test Plugin",
+		Target:      types.TargetGlobal,
 		Description: "Description of the plugin",
 		Version:     "v1.2.3",
 		BuildSHA:    "cafecafe",

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -3,6 +3,8 @@
 
 package plugin
 
+import "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+
 // CmdGroup is a group of CLI commands.
 type CmdGroup string
 
@@ -61,6 +63,9 @@ type PluginDescriptor struct {
 
 	// Description is the plugin's description.
 	Description string `json:"description" yaml:"description"`
+
+	// Target is the target to which plugin is applicable.
+	Target types.Target `json:"target" yaml:"target"`
 
 	// Version of the plugin. Must be a valid semantic version https://semver.org/
 	Version string `json:"version" yaml:"version"`

--- a/test/plugins/helloworld/main.go
+++ b/test/plugins/helloworld/main.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/aunum/log"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/plugin/buildinfo"
 )
 
 var descriptor = plugin.PluginDescriptor{
 	Name:            "helloworld-test",
+	Target:          types.TargetGlobal,
 	Description:     "Hello world test plugin",
 	Group:           plugin.AdminCmdGroup,
 	Version:         "v0.0.1",


### PR DESCRIPTION
### What this PR does / why we need it

This change updates the plugin contract to specify `target` information as part of the plugin descriptor. Old plugins will continue to work but new plugins using the latest plugin runtime will be enforced to provide target information as part of PluginDescriptor.

This change doesn't affect existing plugins because CLI is consuming this `target` field during the build time of the plugins and not during the runtime to determine the `target` of the plugin. So, once the plugins are already built, they should continue to work with the newer version of `tanzu-cli`.

Renames `TargetNone` to `TargetUnknown` and added another target `TargetGlobal`.

While installing the plugin this change will be made backward compatible.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #16

### Describe testing done for PR
- Updated unit tests.
- Verified that the build fails if a user is not providing the `Target` of the plugin as part of the PluginDescriptor.
- Tested the changes along with Tanzu Core CLI

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update PluginDescriptor to include the `target` field as a mandatory field as part of the contract
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
