### PR TITLE
Cross-version API Compatibility Testing- Server APIs

### DIFF
--- a/.github/workflows/compatibility_tests.yaml
+++ b/.github/workflows/compatibility_tests.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main, release-*]
     paths:
       - "*"
+  push:
+    branches: [main, release-*]
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ all: modules test lint ## ## Run all major targets (lint, test, modules)
 .PHONY: test
 test: fmt ## Run Tests
 	make -C test/plugins all
-	${GO} test ./... -timeout 60m -race -coverprofile coverage.txt ## Exclude Compatibility Tests
+	${GO} test ./... -timeout 60m -race -coverprofile coverage.txt
 
 .PHONY: fmt
 fmt: $(GOIMPORTS) ## Run goimports

--- a/config/servers_it_test.go
+++ b/config/servers_it_test.go
@@ -373,3 +373,69 @@ current: test-mc2
 	assert.Equal(t, err.Error(), "could not find server \"test-mc2\"")
 	assert.Nil(t, s)
 }
+
+func TestSetServerAndDeleteServer(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	_, err := GetServer("test-mc")
+	assert.Equal(t, "could not find server \"test-mc\"", err.Error())
+
+	// Add new Server
+	newServer := &configtypes.Server{
+		Name: "test-mc2",
+		Type: "managementcluster",
+		ManagementClusterOpts: &configtypes.ManagementClusterServer{
+			Endpoint: "test-endpoint",
+			Path:     "test-path",
+		},
+		DiscoverySources: []configtypes.PluginDiscovery{
+			{
+				GCP: &configtypes.GCPDiscovery{
+					Name:         "test",
+					Bucket:       "test-bucket",
+					ManifestPath: "test-manifest-path",
+				},
+			},
+		},
+	}
+	err = SetServer(newServer, true)
+	assert.NoError(t, err)
+
+	s, err := GetServer("test-mc2")
+	assert.Nil(t, err)
+	assert.Equal(t, newServer, s)
+
+	// Update existing Server
+	updatedServer := &configtypes.Server{
+		Name: "test-mc2",
+		Type: "managementcluster",
+		ManagementClusterOpts: &configtypes.ManagementClusterServer{
+			Endpoint: "test-endpoint-updated",
+			Path:     "test-path",
+		},
+		DiscoverySources: []configtypes.PluginDiscovery{
+			{
+				GCP: &configtypes.GCPDiscovery{
+					Name:         "test",
+					Bucket:       "test-bucket-updated",
+					ManifestPath: "test-manifest-path",
+				},
+			},
+		},
+	}
+	err = SetServer(updatedServer, true)
+	assert.NoError(t, err)
+	s, err = GetServer("test-mc2")
+	assert.Nil(t, err)
+	assert.Equal(t, updatedServer, s)
+	err = DeleteServer("test-mc2")
+	assert.NoError(t, err)
+	s, err = GetServer("test-mc2")
+	assert.Equal(t, err.Error(), "could not find server \"test-mc2\"")
+	assert.Nil(t, s)
+}

--- a/test/compatibility/framework/compatibilitytests/common/test_helpers.go
+++ b/test/compatibility/framework/compatibilitytests/common/test_helpers.go
@@ -1,0 +1,14 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package common contains all the cross version api compatibility tests
+package common
+
+const (
+	DefaultEndpoint = "default-compatibility-test-endpoint"
+)
+
+const (
+	CtxCompatibilityOne string = "compatibility-one"
+	CtxCompatibilityTwo string = "compatibility-two"
+)

--- a/test/compatibility/framework/compatibilitytests/context/context_test.go
+++ b/test/compatibility/framework/compatibilitytests/context/context_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework/compatibilitytests/common"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework/compatibilitytests/context"
+
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework"
-	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework/compatibilitytests"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework/executer"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
@@ -30,42 +32,42 @@ var _ = ginkgo.Describe("Cross-version Context APIs compatibility tests", func()
 
 		ginkgo.It("Run SetContext, SetCurrentContext latest then GetContext, GetCurrentContext v0.25.4, v0.28.0, latest then DeleteContext, RemoveCurrentContext v0.28.0 then GetContext, GetCurrentContext v0.25.4, v0.28.0, latest", func() {
 			// Input and Output Parameters for SetContext latest
-			setContextInputOptions := compatibilitytests.DefaultSetContextInputOptions(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
+			setContextInputOptions := context.DefaultSetContextInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
 
 			// Input and Output Parameters for SetCurrentContext latest
-			setCurrentContextInputOptions := compatibilitytests.DefaultSetCurrentContextInputOptions(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
+			setCurrentContextInputOptions := context.DefaultSetCurrentContextInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
 
 			// Input and Output Parameters for GetCurrentContext
-			getCurrentContextInputOptionsForRuntime100 := compatibilitytests.DefaultGetCurrentContextInputOptions(core.VersionLatest)
-			getCurrentContextOutputOptionsForRuntime100 := compatibilitytests.DefaultGetCurrentContextOutputOptions(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
-			getCurrentContextOutputOptionsForRuntime100WithError := compatibilitytests.DefaultGetCurrentContextOutputOptionsWithError(core.VersionLatest)
+			getCurrentContextInputOptionsForRuntime100 := context.DefaultGetCurrentContextInputOptions(core.VersionLatest)
+			getCurrentContextOutputOptionsForRuntime100 := context.DefaultGetCurrentContextOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getCurrentContextOutputOptionsForRuntime100WithError := context.DefaultGetCurrentContextOutputOptionsWithError(core.VersionLatest)
 
-			getCurrentContextInputOptionsForRuntime0280 := compatibilitytests.DefaultGetCurrentContextInputOptions(core.Version0280)
-			getCurrentContextOutputOptionsForRuntime0280 := compatibilitytests.DefaultGetCurrentContextOutputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
-			getCurrentContextOutputOptionsForRuntime0280WithError := compatibilitytests.DefaultGetCurrentContextOutputOptionsWithError(core.VersionLatest)
+			getCurrentContextInputOptionsForRuntime0280 := context.DefaultGetCurrentContextInputOptions(core.Version0280)
+			getCurrentContextOutputOptionsForRuntime0280 := context.DefaultGetCurrentContextOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getCurrentContextOutputOptionsForRuntime0280WithError := context.DefaultGetCurrentContextOutputOptionsWithError(core.VersionLatest)
 
-			getCurrentContextInputOptionsForRuntime0254 := compatibilitytests.DefaultGetCurrentContextInputOptions(core.Version0254)
-			getCurrentContextOutputOptionsForRuntime0254 := compatibilitytests.DefaultGetCurrentContextOutputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
-			getCurrentContextOutputOptionsForRuntime0254WithError := compatibilitytests.DefaultGetCurrentContextOutputOptionsWithError(core.Version0254)
+			getCurrentContextInputOptionsForRuntime0254 := context.DefaultGetCurrentContextInputOptions(core.Version0254)
+			getCurrentContextOutputOptionsForRuntime0254 := context.DefaultGetCurrentContextOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getCurrentContextOutputOptionsForRuntime0254WithError := context.DefaultGetCurrentContextOutputOptionsWithError(core.Version0254)
 
 			// Input and Output params for GetContext
-			getContextInputOptionsForRuntime100 := compatibilitytests.DefaultGetContextInputOptions(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime100 := compatibilitytests.DefaultGetContextOutputOptions(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime100WithError := compatibilitytests.DefaultGetContextOutputOptionsWithError(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
+			getContextInputOptionsForRuntime100 := context.DefaultGetContextInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime100 := context.DefaultGetContextOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime100WithError := context.DefaultGetContextOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
 
-			getContextInputOptionsForRuntime0280 := compatibilitytests.DefaultGetContextInputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime0280 := compatibilitytests.DefaultGetContextOutputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime0280WithError := compatibilitytests.DefaultGetContextOutputOptionsWithError(core.Version0280, compatibilitytests.CtxCompatibilityOne)
+			getContextInputOptionsForRuntime0280 := context.DefaultGetContextInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime0280 := context.DefaultGetContextOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime0280WithError := context.DefaultGetContextOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
 
-			getContextInputOptionsForRuntime0254 := compatibilitytests.DefaultGetContextInputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime0254 := compatibilitytests.DefaultGetContextOutputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime0254WithError := compatibilitytests.DefaultGetContextOutputOptionsWithError(core.Version0254, compatibilitytests.CtxCompatibilityOne)
+			getContextInputOptionsForRuntime0254 := context.DefaultGetContextInputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime0254 := context.DefaultGetContextOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime0254WithError := context.DefaultGetContextOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
 
 			// Input params for DeleteContext v0.28.0
-			deleteContextInputOptions := compatibilitytests.DefaultDeleteContextInputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
+			deleteContextInputOptions := context.DefaultDeleteContextInputOptions(core.Version0280, common.CtxCompatibilityOne)
 
 			// Input params for RemoveCurrentContext v0.28.0
-			removeCurrentContextInputOptions := compatibilitytests.DefaultRemoveCurrentContextInputOptions(core.Version0280)
+			removeCurrentContextInputOptions := context.DefaultRemoveCurrentContextInputOptions(core.Version0280)
 
 			// Create SetContext latest Command with input and output options
 			setContextCmd, err := framework.NewSetContextCommand(setContextInputOptions, nil)
@@ -140,36 +142,36 @@ var _ = ginkgo.Describe("Cross-version Context APIs compatibility tests", func()
 		ginkgo.It("Run SetContext, SetCurrentContext v0.25.4 then GetContext, GetCurrentContext v0.25.4, v0.28.0, latest then DeleteContext, RemoveCurrentContext v0.28.0 then GetContext, GetCurrentContext v0.25.4, v0.28.0, latest", func() {
 			// Setting up the input and output parameters data for various APIs
 			// Input and Output Parameters for SetContext v0.25.4
-			setContextInputOptions := compatibilitytests.DefaultSetContextInputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
+			setContextInputOptions := context.DefaultSetContextInputOptions(core.Version0254, common.CtxCompatibilityOne)
 
 			// Input Parameters for SetCurrentContext v0.25.4
-			setCurrentContextInputOptions := compatibilitytests.DefaultSetCurrentContextInputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
+			setCurrentContextInputOptions := context.DefaultSetCurrentContextInputOptions(core.Version0254, common.CtxCompatibilityOne)
 
 			// Input and Output Parameters for GetCurrentContext
-			getCurrentContextInputOptionsForRuntime100 := compatibilitytests.DefaultGetCurrentContextInputOptions(core.VersionLatest)
-			getCurrentContextInputOptionsForRuntime0280 := compatibilitytests.DefaultGetCurrentContextInputOptions(core.Version0280)
-			getCurrentContextInputOptionsForRuntime0254 := compatibilitytests.DefaultGetCurrentContextInputOptions(core.Version0254)
+			getCurrentContextInputOptionsForRuntime100 := context.DefaultGetCurrentContextInputOptions(core.VersionLatest)
+			getCurrentContextInputOptionsForRuntime0280 := context.DefaultGetCurrentContextInputOptions(core.Version0280)
+			getCurrentContextInputOptionsForRuntime0254 := context.DefaultGetCurrentContextInputOptions(core.Version0254)
 
-			getCurrentContextOutputOptionsForRuntime100WithError := compatibilitytests.DefaultGetCurrentContextOutputOptionsWithError(core.VersionLatest)
-			getCurrentContextOutputOptionsForRuntime0280WithError := compatibilitytests.DefaultGetCurrentContextOutputOptionsWithError(core.VersionLatest)
-			getCurrentContextOutputOptionsForRuntime0254 := compatibilitytests.DefaultGetCurrentContextOutputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
+			getCurrentContextOutputOptionsForRuntime100WithError := context.DefaultGetCurrentContextOutputOptionsWithError(core.VersionLatest)
+			getCurrentContextOutputOptionsForRuntime0280WithError := context.DefaultGetCurrentContextOutputOptionsWithError(core.VersionLatest)
+			getCurrentContextOutputOptionsForRuntime0254 := context.DefaultGetCurrentContextOutputOptions(core.Version0254, common.CtxCompatibilityOne)
 
 			// Input and Output params for GetContext
-			getContextInputOptionsForRuntime100 := compatibilitytests.DefaultGetContextInputOptions(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
-			getContextInputOptionsForRuntime0280 := compatibilitytests.DefaultGetContextInputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
-			getContextInputOptionsForRuntime0254 := compatibilitytests.DefaultGetContextInputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
+			getContextInputOptionsForRuntime100 := context.DefaultGetContextInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getContextInputOptionsForRuntime0280 := context.DefaultGetContextInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getContextInputOptionsForRuntime0254 := context.DefaultGetContextInputOptions(core.Version0254, common.CtxCompatibilityOne)
 
-			getContextOutputOptionsForRuntime100WithError := compatibilitytests.DefaultGetContextOutputOptionsWithError(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime0280WithError := compatibilitytests.DefaultGetContextOutputOptionsWithError(core.Version0280, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime0254 := compatibilitytests.DefaultGetContextOutputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime100WithError := context.DefaultGetContextOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime0280WithError := context.DefaultGetContextOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime0254 := context.DefaultGetContextOutputOptions(core.Version0254, common.CtxCompatibilityOne)
 
 			// Input and Output params for RemoveCurrentContext v0.28.0
-			removeCurrentContextInputOptions := compatibilitytests.DefaultRemoveCurrentContextInputOptions(core.Version0280)
-			removeCurrentContextOutputOptionsWithError := compatibilitytests.DefaultRemoveCurrentContextOutputOptionsWithError(core.Version0280)
+			removeCurrentContextInputOptions := context.DefaultRemoveCurrentContextInputOptions(core.Version0280)
+			removeCurrentContextOutputOptionsWithError := context.DefaultRemoveCurrentContextOutputOptionsWithError(core.Version0280)
 
 			// Input and Output params for DeleteContext v0.28.0
-			deleteContextInputOptions := compatibilitytests.DefaultDeleteContextInputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
-			deleteContextOutputOptionsWithError := compatibilitytests.DefaultDeleteContextOutputOptionsWithError(core.Version0280, compatibilitytests.CtxCompatibilityOne)
+			deleteContextInputOptions := context.DefaultDeleteContextInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			deleteContextOutputOptionsWithError := context.DefaultDeleteContextOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
 
 			// Creating Commands to trigger Runtime APIs
 
@@ -236,33 +238,33 @@ var _ = ginkgo.Describe("Cross-version Context APIs compatibility tests", func()
 			// Setting up the input and output parameters data for various APIs
 
 			// Input Parameters for SetContext v0.28.0
-			setContextInputOptions := compatibilitytests.DefaultSetContextInputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
+			setContextInputOptions := context.DefaultSetContextInputOptions(core.Version0280, common.CtxCompatibilityOne)
 
 			// Input Parameters for SetCurrentContext v0.28.0
-			setCurrentContextInputOptions := compatibilitytests.DefaultSetCurrentContextInputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
+			setCurrentContextInputOptions := context.DefaultSetCurrentContextInputOptions(core.Version0280, common.CtxCompatibilityOne)
 
 			// Input and Output Parameters for GetCurrentContext
-			getCurrentContextInputOptionsForRuntime100 := compatibilitytests.DefaultGetCurrentContextInputOptions(core.VersionLatest)
-			getCurrentContextInputOptionsForRuntime0280 := compatibilitytests.DefaultGetCurrentContextInputOptions(core.Version0280)
-			getCurrentContextInputOptionsForRuntime0254 := compatibilitytests.DefaultGetCurrentContextInputOptions(core.Version0254)
+			getCurrentContextInputOptionsForRuntime100 := context.DefaultGetCurrentContextInputOptions(core.VersionLatest)
+			getCurrentContextInputOptionsForRuntime0280 := context.DefaultGetCurrentContextInputOptions(core.Version0280)
+			getCurrentContextInputOptionsForRuntime0254 := context.DefaultGetCurrentContextInputOptions(core.Version0254)
 
-			getCurrentContextOutputOptionsForRuntime100 := compatibilitytests.DefaultGetCurrentContextOutputOptions(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
-			getCurrentContextOutputOptionsForRuntime0280 := compatibilitytests.DefaultGetCurrentContextOutputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
-			getCurrentContextOutputOptionsForRuntime0254 := compatibilitytests.DefaultGetCurrentContextOutputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
-			getCurrentContextOutputOptionsForRuntime0254WithError := compatibilitytests.DefaultGetCurrentContextOutputOptionsWithError(core.Version0254)
+			getCurrentContextOutputOptionsForRuntime100 := context.DefaultGetCurrentContextOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getCurrentContextOutputOptionsForRuntime0280 := context.DefaultGetCurrentContextOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getCurrentContextOutputOptionsForRuntime0254 := context.DefaultGetCurrentContextOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getCurrentContextOutputOptionsForRuntime0254WithError := context.DefaultGetCurrentContextOutputOptionsWithError(core.Version0254)
 
 			// Input and Output params for GetContext
-			getContextInputOptionsForRuntime100 := compatibilitytests.DefaultGetContextInputOptions(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
-			getContextInputOptionsForRuntime0280 := compatibilitytests.DefaultGetContextInputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
-			getContextInputOptionsForRuntime0254 := compatibilitytests.DefaultGetContextInputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
+			getContextInputOptionsForRuntime100 := context.DefaultGetContextInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getContextInputOptionsForRuntime0280 := context.DefaultGetContextInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getContextInputOptionsForRuntime0254 := context.DefaultGetContextInputOptions(core.Version0254, common.CtxCompatibilityOne)
 
-			getContextOutputOptionsForRuntime100 := compatibilitytests.DefaultGetContextOutputOptions(core.VersionLatest, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime0280 := compatibilitytests.DefaultGetContextOutputOptions(core.Version0280, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime0254 := compatibilitytests.DefaultGetContextOutputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
-			getContextOutputOptionsForRuntime0254WithError := compatibilitytests.DefaultGetContextOutputOptionsWithError(core.Version0254, compatibilitytests.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime100 := context.DefaultGetContextOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime0280 := context.DefaultGetContextOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime0254 := context.DefaultGetContextOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getContextOutputOptionsForRuntime0254WithError := context.DefaultGetContextOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
 
 			// Input params for DeleteContext v0.25.4
-			deleteContextInputOptions := compatibilitytests.DefaultDeleteContextInputOptions(core.Version0254, compatibilitytests.CtxCompatibilityOne)
+			deleteContextInputOptions := context.DefaultDeleteContextInputOptions(core.Version0254, common.CtxCompatibilityOne)
 
 			// Creating Commands to trigger Runtime APIs
 

--- a/test/compatibility/framework/compatibilitytests/context/context_test_helpers.go
+++ b/test/compatibility/framework/compatibilitytests/context/context_test_helpers.go
@@ -1,23 +1,15 @@
 // Copyright 2023 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package compatibilitytests contains all the cross version api compatibility tests
-package compatibilitytests
+// Package context contains all the cross version api compatibility tests for context apis
+package context
 
 import (
 	"fmt"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework"
-)
-
-const (
-	DefaultEndpoint = "default-compatibility-test-endpoint"
-)
-
-const (
-	CtxCompatibilityOne string = "compatibility-one"
-	CtxCompatibilityTwo string = "compatibility-two"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework/compatibilitytests/common"
 )
 
 // DefaultSetContextInputOptions helper method to construct SetContext API input options
@@ -89,7 +81,7 @@ func DefaultGetContextOutputOptions(version core.RuntimeVersion, contextName str
 				Name:   contextName,
 				Target: framework.TargetK8s,
 				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: DefaultEndpoint,
+					Endpoint: common.DefaultEndpoint,
 				},
 			},
 			ValidationStrategy: core.ValidationStrategyStrict,
@@ -103,7 +95,7 @@ func DefaultGetContextOutputOptions(version core.RuntimeVersion, contextName str
 				Name:   contextName,
 				Target: framework.TargetK8s,
 				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: DefaultEndpoint,
+					Endpoint: common.DefaultEndpoint,
 				},
 			},
 			ValidationStrategy: core.ValidationStrategyStrict,
@@ -117,7 +109,7 @@ func DefaultGetContextOutputOptions(version core.RuntimeVersion, contextName str
 				Name: contextName,
 				Type: framework.CtxTypeK8s,
 				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: DefaultEndpoint,
+					Endpoint: common.DefaultEndpoint,
 				},
 			},
 		}
@@ -205,7 +197,7 @@ func DefaultGetCurrentContextOutputOptions(version core.RuntimeVersion, contextN
 				Name:   contextName,
 				Target: framework.TargetK8s,
 				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: DefaultEndpoint,
+					Endpoint: common.DefaultEndpoint,
 				},
 			},
 			ValidationStrategy: core.ValidationStrategyStrict,
@@ -219,7 +211,7 @@ func DefaultGetCurrentContextOutputOptions(version core.RuntimeVersion, contextN
 				Name:   contextName,
 				Target: framework.TargetK8s,
 				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: DefaultEndpoint,
+					Endpoint: common.DefaultEndpoint,
 				},
 			},
 			ValidationStrategy: core.ValidationStrategyStrict,
@@ -233,7 +225,7 @@ func DefaultGetCurrentContextOutputOptions(version core.RuntimeVersion, contextN
 				Name: contextName,
 				Type: framework.CtxTypeK8s,
 				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: DefaultEndpoint,
+					Endpoint: common.DefaultEndpoint,
 				},
 			},
 		}

--- a/test/compatibility/framework/compatibilitytests/server/server_test.go
+++ b/test/compatibility/framework/compatibilitytests/server/server_test.go
@@ -322,7 +322,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 
 	ginkgo.Context("using single server", func() {
 
-		ginkgo.It("Trigger SetServer and SetCurrentServer of Runtime Latest version then GetServer, GetCurrentServer on all supported Runtime versions then DeleteServer, RemoveCurrentServer of Runtime v0.28.0 then GetServer, GetCurrentServer on all supported Runtime versions", func() {
+		ginkgo.It("Run SetServer, SetCurrentServer of Runtime latest then GetServer, GetCurrentServer on all supported Runtime library versions and then DeleteServer, RemoveCurrentServer of Runtime v0.28.0 then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add SetServer and SetCurrentServer Commands of Runtime Latest version
 			testCase := core.NewTestCase().Add(setServerCmdForRuntimeLatest).Add(setCurrentServerCmdForRuntimeLatest)
 
@@ -348,7 +348,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 			executer.Execute(testCase)
 		})
 
-		ginkgo.It("SetServer, SetCurrentServer latest then GetServer, GetCurrentServer v0.11.6, v0.25.4, v0.28.0, latest then DeleteServer v0.11.6 then GetServer, GetCurrentServer v0.11.6, v0.25.4, v0.28.0, latest", func() {
+		ginkgo.It("Run SetServer, SetCurrentServer of Runtime latest then GetServer, GetCurrentServer on all supported Runtime library versions and then DeleteServer of Runtime v0.11.6 then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add SetServer and SetCurrentServer Commands of Runtime Latest version
 			testCase := core.NewTestCase().Add(setServerCmdForRuntimeLatest).Add(setCurrentServerCmdForRuntimeLatest)
 
@@ -371,7 +371,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 			executer.Execute(testCase)
 		})
 
-		ginkgo.It("SetServer, SetCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+		ginkgo.It("Run SetServer, SetCurrentServer of Runtime v0.28.0 then GetServer, GetCurrentServer on all supported Runtime library versions and then DeleteServer of Runtime v0.25.4 then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add SetServer and SetCurrentServer Commands of Runtime v0.28.0
 			testCase := core.NewTestCase().Add(setServerCmdForRuntime0280).Add(setCurrentServerCmdForRuntime0280)
 
@@ -394,7 +394,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 			executer.Execute(testCase)
 		})
 
-		ginkgo.It("SetServer, SetCurrentServer v0.25.4 then GetServer, GetCurrentServer v0.11.6, v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.11.6, v0.25.4, v0.28.0, latest", func() {
+		ginkgo.It("Run SetServer, SetCurrentServer of Runtime v0.25.4 then GetServer, GetCurrentServer on all supported Runtime library versions and then DeleteServer, RemoveCurrentServer of Runtime v0.28.0 then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add SetServer and SetCurrentServer Commands of Runtime v0.25.4
 			testCase := core.NewTestCase().Add(setServerCmdForRuntime0254).Add(setCurrentServerCmdForRuntime0254)
 
@@ -420,7 +420,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 			executer.Execute(testCase)
 		})
 
-		ginkgo.It("SetServer, SetCurrentServer v0.11.6 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest, v0.11.6 then DeleteServer 0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest, v0.11.6", func() {
+		ginkgo.It("Run SetServer, SetCurrentServer of Runtime v0.11.6 then GetServer, GetCurrentServer on all supported Runtime library versions and then DeleteServer of Runtime 0.25.4 then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add SetServer and SetCurrentServer Commands of Runtime v0.11.6
 			testCase := core.NewTestCase().Add(setServerCmdForRuntime0116).Add(setCurrentServerCmdForRuntime0116)
 
@@ -443,7 +443,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 			executer.Execute(testCase)
 		})
 
-		ginkgo.It("SetServer, SetCurrentServer v0.11.6 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest, v0.11.6 then DeleteServer latest then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest, v0.11.6", func() {
+		ginkgo.It("Run SetServer, SetCurrentServer of Runtime v0.11.6 then GetServer, GetCurrentServer on all supported Runtime library versions and then DeleteServer of Runtime latest then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add SetServer and SetCurrentServer Commands of Runtime v0.11.6
 			testCase := core.NewTestCase().Add(setServerCmdForRuntime0116).Add(setCurrentServerCmdForRuntime0116)
 
@@ -469,7 +469,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 
 	ginkgo.Context("using multiple servers", func() {
 
-		ginkgo.It("Run SetServer, SetCurrentServer on Runtime latest then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+		ginkgo.It("Run two SetServer of Runtime latest then SetCurrentServer of Runtime latest then GetServer, GetCurrentServer on all supported Runtime library versions and then DeleteServer, RemoveCurrentServer of Runtime v0.28.0 then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add two SetServer Commands of Runtime Latest
 			testCase := core.NewTestCase().Add(setServerCmdForRuntimeLatest).Add(setServerTwoCmdForRuntimeLatest)
 
@@ -500,7 +500,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 			executer.Execute(testCase)
 		})
 
-		ginkgo.It("Run SetServer, SetCurrentServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+		ginkgo.It("Run two SetServer of Runtime v0.25.4 then SetCurrentServer of Runtime v0.25.4 then GetServer, GetCurrentServer on v0.11.6, v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer of Runtime v0.28.0 then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add two SetServer Commands of Runtime v0.25.4
 			testCase := core.NewTestCase().Add(setServerCmdForRuntime0254).Add(setServerTwoCmdForRuntime0254)
 
@@ -531,7 +531,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 			executer.Execute(testCase)
 		})
 
-		ginkgo.It("Run SetServer, SetCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+		ginkgo.It("Run two SetServer of Runtime v0.28.0 then SetCurrentServer of Runtime v0.28.0 then GetServer, GetCurrentServer on v0.11.6, v0.25.4, v0.28.0, latest then DeleteServer of Runtime v0.25.4 then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 
 			// Add two SetServer Commands of Runtime v0.28.0
 			testCase := core.NewTestCase().Add(setServerCmdForRuntime0280).Add(setServerTwoCmdForRuntime0280)
@@ -560,7 +560,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 			executer.Execute(testCase)
 		})
 
-		ginkgo.It("Run SetServer, SetCurrentServer v0.11.6 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer latest then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+		ginkgo.It("Run two SetServer of Runtime v0.11.6 then SetCurrentServer of Runtime v0.11.6 then GetServer, GetCurrentServer on v0.11.6, v0.25.4, v0.28.0, latest then DeleteServer of Runtime latest then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add two SetServer Commands of Runtime v0.11.6
 			testCase := core.NewTestCase().Add(setServerCmdForRuntime0116).Add(setServerTwoCmdForRuntime0116)
 
@@ -588,7 +588,7 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 			executer.Execute(testCase)
 		})
 
-		ginkgo.It("Run SetServer, SetCurrentServer v0.11.6 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+		ginkgo.It("Run two SetServer of Runtime v0.11.6 then SetCurrentServer of Runtime v0.11.6 then GetServer, GetCurrentServer on v0.11.6, v0.25.4, v0.28.0, latest then DeleteServer of Runtime v0.25.4 then GetServer, GetCurrentServer on all supported Runtime library versions", func() {
 			// Add two SetServer Commands of Runtime v0.11.6
 			testCase := core.NewTestCase().Add(setServerCmdForRuntime0116).Add(setServerTwoCmdForRuntime0116)
 

--- a/test/compatibility/framework/compatibilitytests/server/server_test.go
+++ b/test/compatibility/framework/compatibilitytests/server/server_test.go
@@ -27,478 +27,473 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 		ginkgo.DeferCleanup(func() {
 			cleanup()
 		})
+
+	})
+	// Input and Output Options for Server APIs
+	var setServerInputOptionsForRuntime0116 *framework.SetServerInputOptions
+	var setServerInputOptionsForRuntime0254 *framework.SetServerInputOptions
+	var setServerInputOptionsForRuntime0280 *framework.SetServerInputOptions
+	var setServerInputOptionsForRuntimeLatest *framework.SetServerInputOptions
+
+	var setServerTwoInputOptionsForRuntime0116 *framework.SetServerInputOptions
+	var setServerTwoInputOptionsForRuntime0254 *framework.SetServerInputOptions
+	var setServerTwoInputOptionsForRuntime0280 *framework.SetServerInputOptions
+	var setServerTwoInputOptionsForRuntimeLatest *framework.SetServerInputOptions
+
+	var setCurrentServerInputOptionsForRuntime0116 *framework.SetCurrentServerInputOptions
+	var setCurrentServerInputOptionsForRuntime0254 *framework.SetCurrentServerInputOptions
+	var setCurrentServerInputOptionsForRuntime0280 *framework.SetCurrentServerInputOptions
+	var setCurrentServerInputOptionsForRuntimeLatest *framework.SetCurrentServerInputOptions
+
+	var getServerInputOptionsForRuntimeLatest *framework.GetServerInputOptions
+	var getServerInputOptionsForRuntime0280 *framework.GetServerInputOptions
+	var getServerInputOptionsForRuntime0254 *framework.GetServerInputOptions
+	var getServerInputOptionsForRuntime0116 *framework.GetServerInputOptions
+
+	var getServerTwoInputOptionsForRuntimeLatest *framework.GetServerInputOptions
+	var getServerTwoInputOptionsForRuntime0280 *framework.GetServerInputOptions
+	var getServerTwoInputOptionsForRuntime0254 *framework.GetServerInputOptions
+	var getServerTwoInputOptionsForRuntime0116 *framework.GetServerInputOptions
+
+	var getServerOutputOptionsForRuntime0116 *framework.GetServerOutputOptions
+	var getServerOutputOptionsForRuntime0254 *framework.GetServerOutputOptions
+	var getServerOutputOptionsForRuntime0280 *framework.GetServerOutputOptions
+	var getServerOutputOptionsForRuntimeLatest *framework.GetServerOutputOptions
+
+	var getServerTwoOutputOptionsForRuntime0116 *framework.GetServerOutputOptions
+	var getServerTwoOutputOptionsForRuntime0254 *framework.GetServerOutputOptions
+	var getServerTwoOutputOptionsForRuntime0280 *framework.GetServerOutputOptions
+	var getServerTwoOutputOptionsForRuntimeLatest *framework.GetServerOutputOptions
+
+	var getServerOutputOptionsForRuntimeLatestWithError *framework.GetServerOutputOptions
+	var getServerOutputOptionsForRuntime0280WithError *framework.GetServerOutputOptions
+	var getServerOutputOptionsForRuntime0254WithError *framework.GetServerOutputOptions
+	var getServerOutputOptionsForRuntime0116WithError *framework.GetServerOutputOptions
+
+	var getCurrentServerInputOptionsForRuntime0116 *framework.GetCurrentServerInputOptions
+	var getCurrentServerInputOptionsForRuntime0254 *framework.GetCurrentServerInputOptions
+	var getCurrentServerInputOptionsForRuntime0280 *framework.GetCurrentServerInputOptions
+	var getCurrentServerInputOptionsForRuntimeLatest *framework.GetCurrentServerInputOptions
+
+	var getCurrentServerOutputOptionsForRuntime0116 *framework.GetCurrentServerOutputOptions
+	var getCurrentServerOutputOptionsForRuntime0254 *framework.GetCurrentServerOutputOptions
+	var getCurrentServerOutputOptionsForRuntime0280 *framework.GetCurrentServerOutputOptions
+	var getCurrentServerOutputOptionsForRuntimeLatest *framework.GetCurrentServerOutputOptions
+
+	var getCurrentServerOutputOptionsForRuntimeLatestWithError *framework.GetCurrentServerOutputOptions
+	var getCurrentServerOutputOptionsForRuntime0280WithError *framework.GetCurrentServerOutputOptions
+	var getCurrentServerOutputOptionsForRuntime0254WithError *framework.GetCurrentServerOutputOptions
+	var getCurrentServerOutputOptionsForRuntime0116WithError *framework.GetCurrentServerOutputOptions
+
+	var deleteServerInputOptionsForRuntime0254 *framework.DeleteServerInputOptions
+	var deleteServerInputOptionsForRuntime0280 *framework.DeleteServerInputOptions
+	var deleteServerInputOptionsForRuntimeLatest *framework.DeleteServerInputOptions
+	var deleteServerInputOptionsForRuntime0116 *framework.DeleteServerInputOptions
+
+	var deleteServerOutputOptionsForRuntime0280WithError *framework.DeleteServerOutputOptions
+	var deleteServerOutputOptionsForRuntimeLatestWithError *framework.DeleteServerOutputOptions
+
+	var removeCurrentServerInputOptionsForRuntime0280 *framework.RemoveCurrentServerInputOptions
+	var removeCurrentServerOutputOptionsForRuntime0280WithError *framework.RemoveCurrentServerOutputOptions
+
+	// Server API Commands
+	var setServerCmdForRuntimeLatest *core.Command
+	var setServerCmdForRuntime0280 *core.Command
+	var setServerCmdForRuntime0254 *core.Command
+	var setServerCmdForRuntime0116 *core.Command
+
+	var setServerTwoCmdForRuntimeLatest *core.Command
+	var setServerTwoCmdForRuntime0280 *core.Command
+	var setServerTwoCmdForRuntime0254 *core.Command
+	var setServerTwoCmdForRuntime0116 *core.Command
+
+	var setCurrentServerCmdForRuntime0116 *core.Command
+	var setCurrentServerCmdForRuntime0254 *core.Command
+	var setCurrentServerCmdForRuntime0280 *core.Command
+	var setCurrentServerCmdForRuntimeLatest *core.Command
+
+	var getServerCmdForRuntimeLatest *core.Command
+	var getServerCmdForRuntime0280 *core.Command
+	var getServerCmdForRuntime0254 *core.Command
+	var getServerCmdForRuntime0116 *core.Command
+
+	var getServerTwoCmdForRuntimeLatest *core.Command
+	var getServerTwoCmdForRuntime0280 *core.Command
+	var getServerTwoCmdForRuntime0254 *core.Command
+	var getServerTwoCmdForRuntime0116 *core.Command
+
+	var getServerCmdForRuntimeLatestWithError *core.Command
+	var getServerCmdForRuntime0280WithError *core.Command
+	var getServerCmdForRuntime0254WithError *core.Command
+	var getServerCmdForRuntime0116WithError *core.Command
+
+	var getCurrentServerCmdForRuntimeLatest *core.Command
+	var getCurrentServerCmdForRuntime0280 *core.Command
+	var getCurrentServerCmdForRuntime0254 *core.Command
+	var getCurrentServerCmdForRuntime0116 *core.Command
+
+	var getCurrentServerCmdForRuntimeLatestWithError *core.Command
+	var getCurrentServerCmdForRuntime0280WithError *core.Command
+	var getCurrentServerCmdForRuntime0254WithError *core.Command
+	var getCurrentServerCmdForRuntime0116WithError *core.Command
+
+	var deleteServerCmdForRuntime0280 *core.Command
+	var deleteServerCmdForRuntime0116 *core.Command
+	var deleteServerCmdForRuntime0254 *core.Command
+
+	var deleteServerCmdForRuntime0280WithError *core.Command
+	var deleteServerCmdForRuntimeLatestWithError *core.Command
+
+	var removeCurrentServerCmdForRuntime0280 *core.Command
+	var removeCurrentServerCmdForRuntime0280WithError *core.Command
+
+	var err error
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Setup Input and Output Options for Servers APIs")
+
+		// Input and Output Parameters for SetServer
+		setServerInputOptionsForRuntimeLatest = server.DefaultSetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+		setServerInputOptionsForRuntime0280 = server.DefaultSetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+		setServerInputOptionsForRuntime0254 = server.DefaultSetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+		setServerInputOptionsForRuntime0116 = server.DefaultSetServerInputOptions(core.Version0116, common.CtxCompatibilityOne)
+
+		setServerTwoInputOptionsForRuntimeLatest = server.DefaultSetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+		setServerTwoInputOptionsForRuntime0280 = server.DefaultSetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
+		setServerTwoInputOptionsForRuntime0254 = server.DefaultSetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
+		setServerTwoInputOptionsForRuntime0116 = server.DefaultSetServerInputOptions(core.Version0116, common.CtxCompatibilityTwo)
+
+		// Input and Output Parameters for SetCurrentServer
+		setCurrentServerInputOptionsForRuntimeLatest = server.DefaultSetCurrentServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+		setCurrentServerInputOptionsForRuntime0280 = server.DefaultSetCurrentServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+		setCurrentServerInputOptionsForRuntime0254 = server.DefaultSetCurrentServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+		setCurrentServerInputOptionsForRuntime0116 = server.DefaultSetCurrentServerInputOptions(core.Version0116, common.CtxCompatibilityOne)
+
+		// Input and Output Parameters for GetCurrentServer
+		getCurrentServerInputOptionsForRuntimeLatest = server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
+		getCurrentServerInputOptionsForRuntime0280 = server.DefaultGetCurrentServerInputOptions(core.Version0280)
+		getCurrentServerInputOptionsForRuntime0254 = server.DefaultGetCurrentServerInputOptions(core.Version0254)
+		getCurrentServerInputOptionsForRuntime0116 = server.DefaultGetCurrentServerInputOptions(core.Version0116)
+
+		getCurrentServerOutputOptionsForRuntime0280 = server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+		getCurrentServerOutputOptionsForRuntime0254 = server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+		getCurrentServerOutputOptionsForRuntime0116 = server.DefaultGetCurrentServerOutputOptions(core.Version0116, common.CtxCompatibilityOne)
+		getCurrentServerOutputOptionsForRuntimeLatest = server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+
+		getCurrentServerOutputOptionsForRuntimeLatestWithError = server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+		getCurrentServerOutputOptionsForRuntime0280WithError = server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0280)
+		getCurrentServerOutputOptionsForRuntime0254WithError = server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0254)
+		getCurrentServerOutputOptionsForRuntime0116WithError = server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0116)
+
+		// Input and Output params for GetServer
+		getServerInputOptionsForRuntimeLatest = server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+		getServerInputOptionsForRuntime0280 = server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+		getServerInputOptionsForRuntime0254 = server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+		getServerInputOptionsForRuntime0116 = server.DefaultGetServerInputOptions(core.Version0116, common.CtxCompatibilityOne)
+
+		getServerTwoInputOptionsForRuntimeLatest = server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+		getServerTwoInputOptionsForRuntime0280 = server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
+		getServerTwoInputOptionsForRuntime0254 = server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
+		getServerTwoInputOptionsForRuntime0116 = server.DefaultGetServerInputOptions(core.Version0116, common.CtxCompatibilityTwo)
+
+		getServerTwoOutputOptionsForRuntimeLatest = server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+		getServerTwoOutputOptionsForRuntime0280 = server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityTwo)
+		getServerTwoOutputOptionsForRuntime0254 = server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityTwo)
+		getServerTwoOutputOptionsForRuntime0116 = server.DefaultGetServerOutputOptions(core.Version0116, common.CtxCompatibilityTwo)
+
+		getServerOutputOptionsForRuntime0280 = server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+		getServerOutputOptionsForRuntime0254 = server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+		getServerOutputOptionsForRuntime0116 = server.DefaultGetServerOutputOptions(core.Version0116, common.CtxCompatibilityOne)
+		getServerOutputOptionsForRuntimeLatest = server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+
+		getServerOutputOptionsForRuntimeLatestWithError = server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
+		getServerOutputOptionsForRuntime0280WithError = server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+		getServerOutputOptionsForRuntime0254WithError = server.DefaultGetServerOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
+		getServerOutputOptionsForRuntime0116WithError = server.DefaultGetServerOutputOptionsWithError(core.Version0116, common.CtxCompatibilityOne)
+
+		// Input and Output Options for DeleteServer
+		deleteServerInputOptionsForRuntime0280 = server.DefaultDeleteServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+		deleteServerInputOptionsForRuntime0254 = server.DefaultDeleteServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+		deleteServerInputOptionsForRuntime0116 = server.DefaultDeleteServerInputOptions(core.Version0116, common.CtxCompatibilityOne)
+		deleteServerInputOptionsForRuntimeLatest = server.DefaultDeleteServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+
+		deleteServerOutputOptionsForRuntime0280WithError = server.DefaultDeleteServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+		deleteServerOutputOptionsForRuntimeLatestWithError = server.DefaultDeleteServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
+
+		// Input and Output Options for RemoveCurrentServer
+		removeCurrentServerInputOptionsForRuntime0280 = server.DefaultRemoveCurrentServerInputOptions(core.Version0280)
+
+		removeCurrentServerOutputOptionsForRuntime0280WithError = server.DefaultRemoveCurrentServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+		ginkgo.By("Setup Server API commands")
+
+		// Create SetServer Commands with input and output options
+		setServerCmdForRuntimeLatest, err = framework.NewSetServerCommand(setServerInputOptionsForRuntimeLatest, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		setServerCmdForRuntime0254, err = framework.NewSetServerCommand(setServerInputOptionsForRuntime0254, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		setServerCmdForRuntime0280, err = framework.NewSetServerCommand(setServerInputOptionsForRuntime0280, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		setServerCmdForRuntime0116, err = framework.NewSetServerCommand(setServerInputOptionsForRuntime0116, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		setServerTwoCmdForRuntimeLatest, err = framework.NewSetServerCommand(setServerTwoInputOptionsForRuntimeLatest, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		setServerTwoCmdForRuntime0254, err = framework.NewSetServerCommand(setServerTwoInputOptionsForRuntime0254, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		setServerTwoCmdForRuntime0280, err = framework.NewSetServerCommand(setServerTwoInputOptionsForRuntime0280, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		setServerTwoCmdForRuntime0116, err = framework.NewSetServerCommand(setServerTwoInputOptionsForRuntime0116, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		// Create SetCurrentServer Commands with input and output options
+		setCurrentServerCmdForRuntimeLatest, err = framework.NewSetCurrentServerCommand(setCurrentServerInputOptionsForRuntimeLatest, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		setCurrentServerCmdForRuntime0280, err = framework.NewSetCurrentServerCommand(setCurrentServerInputOptionsForRuntime0280, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		setCurrentServerCmdForRuntime0254, err = framework.NewSetCurrentServerCommand(setCurrentServerInputOptionsForRuntime0254, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		setCurrentServerCmdForRuntime0116, err = framework.NewSetCurrentServerCommand(setCurrentServerInputOptionsForRuntime0116, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		// Create GetServer Commands with input and output options
+		getServerCmdForRuntimeLatest, err = framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
+		gomega.Expect(err).To(gomega.BeNil())
+		getServerCmdForRuntime0280, err = framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
+		gomega.Expect(err).To(gomega.BeNil())
+		getServerCmdForRuntime0254, err = framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
+		gomega.Expect(err).To(gomega.BeNil())
+		getServerCmdForRuntime0116, err = framework.NewGetServerCommand(getServerInputOptionsForRuntime0116, getServerOutputOptionsForRuntime0116)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		getServerTwoCmdForRuntimeLatest, err = framework.NewGetServerCommand(getServerTwoInputOptionsForRuntimeLatest, getServerTwoOutputOptionsForRuntimeLatest)
+		gomega.Expect(err).To(gomega.BeNil())
+		getServerTwoCmdForRuntime0280, err = framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0280, getServerTwoOutputOptionsForRuntime0280)
+		gomega.Expect(err).To(gomega.BeNil())
+		getServerTwoCmdForRuntime0254, err = framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0254, getServerTwoOutputOptionsForRuntime0254)
+		gomega.Expect(err).To(gomega.BeNil())
+		getServerTwoCmdForRuntime0116, err = framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0116, getServerTwoOutputOptionsForRuntime0116)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		getServerCmdForRuntimeLatestWithError, err = framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatestWithError)
+		gomega.Expect(err).To(gomega.BeNil())
+		getServerCmdForRuntime0280WithError, err = framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280WithError)
+		gomega.Expect(err).To(gomega.BeNil())
+		getServerCmdForRuntime0254WithError, err = framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254WithError)
+		gomega.Expect(err).To(gomega.BeNil())
+		getServerCmdForRuntime0116WithError, err = framework.NewGetServerCommand(getServerInputOptionsForRuntime0116, getServerOutputOptionsForRuntime0116WithError)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		// Create GetCurrentServer Commands with input and output options
+		getCurrentServerCmdForRuntimeLatest, err = framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
+		gomega.Expect(err).To(gomega.BeNil())
+		getCurrentServerCmdForRuntime0280, err = framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
+		gomega.Expect(err).To(gomega.BeNil())
+		getCurrentServerCmdForRuntime0254, err = framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
+		gomega.Expect(err).To(gomega.BeNil())
+		getCurrentServerCmdForRuntime0116, err = framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0116, getCurrentServerOutputOptionsForRuntime0116)
+		gomega.Expect(err).To(gomega.BeNil())
+		getCurrentServerCmdForRuntimeLatestWithError, err = framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
+		gomega.Expect(err).To(gomega.BeNil())
+		getCurrentServerCmdForRuntime0280WithError, err = framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
+		gomega.Expect(err).To(gomega.BeNil())
+		getCurrentServerCmdForRuntime0254WithError, err = framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254WithError)
+		gomega.Expect(err).To(gomega.BeNil())
+		getCurrentServerCmdForRuntime0116WithError, err = framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0116, getCurrentServerOutputOptionsForRuntime0116WithError)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		// Create DeleteServer Commands with input and output options
+		deleteServerCmdForRuntime0280, err = framework.NewDeleteServerCommand(deleteServerInputOptionsForRuntime0280, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		deleteServerCmdForRuntime0254, err = framework.NewDeleteServerCommand(deleteServerInputOptionsForRuntime0254, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		deleteServerCmdForRuntime0116, err = framework.NewDeleteServerCommand(deleteServerInputOptionsForRuntime0116, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		deleteServerCmdForRuntime0280WithError, err = framework.NewDeleteServerCommand(deleteServerInputOptionsForRuntime0280, deleteServerOutputOptionsForRuntime0280WithError)
+		gomega.Expect(err).To(gomega.BeNil())
+		deleteServerCmdForRuntimeLatestWithError, err = framework.NewDeleteServerCommand(deleteServerInputOptionsForRuntimeLatest, deleteServerOutputOptionsForRuntimeLatestWithError)
+		gomega.Expect(err).To(gomega.BeNil())
+
+		// Create RemoveCurrentServer Commands with input and output options
+		removeCurrentServerCmdForRuntime0280, err = framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptionsForRuntime0280, nil)
+		gomega.Expect(err).To(gomega.BeNil())
+		removeCurrentServerCmdForRuntime0280WithError, err = framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptionsForRuntime0280, removeCurrentServerOutputOptionsForRuntime0280WithError)
+		gomega.Expect(err).To(gomega.BeNil())
 	})
 
 	ginkgo.Context("using single server", func() {
 
-		ginkgo.It("SetServer, SetCurrentServer latest then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
-			ginkgo.By("Setting up the input and output parameters data for various APIs")
-			// Input and Output Parameters for SetServer latest
-			setServerInputOptions := server.DefaultSetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+		ginkgo.It("Trigger SetServer and SetCurrentServer of Runtime Latest version then GetServer, GetCurrentServer on all supported Runtime versions then DeleteServer, RemoveCurrentServer of Runtime v0.28.0 then GetServer, GetCurrentServer on all supported Runtime versions", func() {
+			// Add SetServer and SetCurrentServer Commands of Runtime Latest version
+			testCase := core.NewTestCase().Add(setServerCmdForRuntimeLatest).Add(setCurrentServerCmdForRuntimeLatest)
 
-			// Input and Output Parameters for SetCurrentServer latest
-			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
 
-			// Input and Output Parameters for GetCurrentServer
-			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
-			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
-
-			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
-			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
-
-			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
-			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0254WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0254)
-
-			// Input and Output params for GetServer
-			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
-
-			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
-
-			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0254WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
-
-			// Input params for DeleteServer v0.28.0
-			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-
-			// Input params for RemoveCurrentServer v0.28.0
-			removeCurrentServerInputOptions := server.DefaultRemoveCurrentServerInputOptions(core.Version0280)
-
-			ginkgo.By("Creating Commands to trigger Runtime APIs")
-
-			// Create SetServer latest Command with input and output options
-			setServerCmd, err := framework.NewSetServerCommand(setServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create SetCurrentServer latest Command with input and output options
-			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetServer Commands with input and output options
-			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatestWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0254WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetCurrentServer Commands
-			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0254WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create DeleteServer Command
-			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create RemoveCurrentServer Command
-			removeCurrentCtxCmd, err := framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			ginkgo.By("Build test case with commands")
-
-			// Add SetServer and SetCurrentServer Commands
-			testCase := core.NewTestCase().Add(setServerCmd).Add(setCurrentServerCmd)
-
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
-
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
 
 			// Add RemoveCurrentServer v0.28.0 Command
-			testCase.Add(removeCurrentCtxCmd)
+			testCase.Add(removeCurrentServerCmdForRuntime0280)
 
 			// Add DeleteServer v0.28.0 Command
-			testCase.Add(deleteCtxCmd)
+			testCase.Add(deleteServerCmdForRuntime0280)
 
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError).Add(getServerCmdForRuntime0116WithError)
 
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError)
-
-			ginkgo.By("Execute the testcase")
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError).Add(getCurrentServerCmdForRuntime0116WithError)
 
 			// Run all the commands
 			executer.Execute(testCase)
 		})
-		ginkgo.It("SetServer, SetCurrentServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
-			ginkgo.By("Setting up the input and output parameters data for various APIs")
-			// Input and Output Parameters for SetServer v0.25.4
-			setServerInputOptions := server.DefaultSetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
 
-			// Input Parameters for SetCurrentServer v0.25.4
-			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+		ginkgo.It("SetServer, SetCurrentServer latest then GetServer, GetCurrentServer v0.11.6, v0.25.4, v0.28.0, latest then DeleteServer v0.11.6 then GetServer, GetCurrentServer v0.11.6, v0.25.4, v0.28.0, latest", func() {
+			// Add SetServer and SetCurrentServer Commands of Runtime Latest version
+			testCase := core.NewTestCase().Add(setServerCmdForRuntimeLatest).Add(setCurrentServerCmdForRuntimeLatest)
 
-			// Input and Output Parameters for GetCurrentServer
-			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
-			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
-			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
 
-			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
 
-			//getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
-			//getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+			// Add DeleteServer v0.11.6 Command
+			testCase.Add(deleteServerCmdForRuntime0116)
 
-			// Input and Output params for GetServer
-			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError).Add(getServerCmdForRuntime0116WithError)
 
-			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError).Add(getCurrentServerCmdForRuntime0116WithError)
 
-			//getServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
-			//getServerOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
-
-			// Input and Output params for RemoveCurrentServer v0.28.0
-			removeCurrentServerInputOptions := server.DefaultRemoveCurrentServerInputOptions(core.Version0280)
-			removeCurrentServerOutputOptionsWithError := server.DefaultRemoveCurrentServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
-
-			// Input and Output params for DeleteServer v0.28.0
-			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-			deleteServerOutputOptionsWithError := server.DefaultDeleteServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
-
-			ginkgo.By("Creating Commands to trigger Runtime APIs")
-
-			// Create SetServer latest Command with input and output options
-			setServerCmd, err := framework.NewSetServerCommand(setServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create SetCurrentServer latest Command with input and output options
-			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetServer Commands with input and output options
-			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			//getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatestWithError)
-			//gomega.Expect(err).To(gomega.BeNil())
-			//getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280WithError)
-			//gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetCurrentServer Commands
-			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			//getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
-			//gomega.Expect(err).To(gomega.BeNil())
-			//getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
-			//gomega.Expect(err).To(gomega.BeNil())
-
-			// Create DeleteServer Command
-			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, deleteServerOutputOptionsWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create RemoveCurrentServer Command
-			removeCurrentCtxCmd, err := framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptions, removeCurrentServerOutputOptionsWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			ginkgo.By("Build test case with commands")
-
-			// Add SetServer and SetCurrentServer Commands
-			testCase := core.NewTestCase().Add(setServerCmd).Add(setCurrentServerCmd)
-
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
-
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
-
-			// Add RemoveCurrentServer v0.28.0 Command
-			testCase.Add(removeCurrentCtxCmd)
-
-			// Add DeleteServer v0.28.0 Command
-			testCase.Add(deleteCtxCmd)
-
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
-
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
-
-			ginkgo.By("Execute the test case")
 			// Run all the commands
 			executer.Execute(testCase)
 		})
+
 		ginkgo.It("SetServer, SetCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
-			ginkgo.By("Setting up the input and output parameters data for various APIs")
+			// Add SetServer and SetCurrentServer Commands of Runtime v0.28.0
+			testCase := core.NewTestCase().Add(setServerCmdForRuntime0280).Add(setCurrentServerCmdForRuntime0280)
 
-			// Input Parameters for SetServer v0.28.0
-			setServerInputOptions := server.DefaultSetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
 
-			// Input Parameters for SetCurrentServer v0.28.0
-			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-
-			// Input and Output Parameters for GetCurrentServer
-			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
-			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
-
-			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
-			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
-
-			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
-			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0254WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0254)
-
-			// Input and Output params for GetServer
-			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
-
-			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
-
-			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0254WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
-
-			// Input params for DeleteServer v0.25.4
-			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
-
-			ginkgo.By("Creating Commands to trigger Runtime APIs")
-
-			// Create SetServer v0.28.0 Command with input and output options
-			setServerCmd, err := framework.NewSetServerCommand(setServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create SetCurrentServer v0.28.0 Command with input and output options
-			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetServer Commands with input and output options
-			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatestWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0254WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetCurrentServer Commands
-			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0254WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create DeleteServer v0.25.4 Command
-			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			ginkgo.By("Build test case with commands")
-
-			// Add SetServer and SetCurrentServer Commands
-			testCase := core.NewTestCase().Add(setServerCmd).Add(setCurrentServerCmd)
-
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
-
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
 
 			// Add DeleteServer v0.25.4 Command
-			testCase.Add(deleteCtxCmd)
+			testCase.Add(deleteServerCmdForRuntime0254)
 
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError).Add(getServerCmdForRuntime0116WithError)
 
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError).Add(getCurrentServerCmdForRuntime0116WithError)
 
-			ginkgo.By("Execute the test case")
 			// Run all the commands
 			executer.Execute(testCase)
 		})
 
+		ginkgo.It("SetServer, SetCurrentServer v0.25.4 then GetServer, GetCurrentServer v0.11.6, v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.11.6, v0.25.4, v0.28.0, latest", func() {
+			// Add SetServer and SetCurrentServer Commands of Runtime v0.25.4
+			testCase := core.NewTestCase().Add(setServerCmdForRuntime0254).Add(setCurrentServerCmdForRuntime0254)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
+
+			// Add RemoveCurrentServer v0.28.0 Command
+			testCase.Add(removeCurrentServerCmdForRuntime0280WithError)
+
+			// Add DeleteServer v0.28.0 Command
+			testCase.Add(deleteServerCmdForRuntime0280WithError)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+
+		ginkgo.It("SetServer, SetCurrentServer v0.11.6 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest, v0.11.6 then DeleteServer 0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest, v0.11.6", func() {
+			// Add SetServer and SetCurrentServer Commands of Runtime v0.11.6
+			testCase := core.NewTestCase().Add(setServerCmdForRuntime0116).Add(setCurrentServerCmdForRuntime0116)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
+
+			// Add DeleteServer v0.25.4 Command
+			testCase.Add(deleteServerCmdForRuntime0254)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError).Add(getServerCmdForRuntime0116WithError)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError).Add(getCurrentServerCmdForRuntime0116WithError)
+
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+
+		ginkgo.It("SetServer, SetCurrentServer v0.11.6 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest, v0.11.6 then DeleteServer latest then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest, v0.11.6", func() {
+			// Add SetServer and SetCurrentServer Commands of Runtime v0.11.6
+			testCase := core.NewTestCase().Add(setServerCmdForRuntime0116).Add(setCurrentServerCmdForRuntime0116)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
+
+			// Add DeleteServer latest Command
+			testCase.Add(deleteServerCmdForRuntimeLatestWithError)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
+
+			// Run all the commands
+			executer.Execute(testCase)
+		})
 	})
 
 	ginkgo.Context("using multiple servers", func() {
 
 		ginkgo.It("Run SetServer, SetCurrentServer on Runtime latest then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
-			// Input and Output Parameters for SetServer latest
-			setServerOneInputOptions := server.DefaultSetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			setServerTwoInputOptions := server.DefaultSetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+			// Add two SetServer Commands of Runtime Latest
+			testCase := core.NewTestCase().Add(setServerCmdForRuntimeLatest).Add(setServerTwoCmdForRuntimeLatest)
 
-			// Input and Output Parameters for SetCurrentServer latest
-			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			// Add SetCurrentServer Command of Runtime Latest
+			testCase.Add(setCurrentServerCmdForRuntimeLatest)
 
-			// Input and Output Parameters for GetCurrentServer
-			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
 
-			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-
-			getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
-
-			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
-
-			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-
-			getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
-
-			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
-
-			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-
-			getCurrentServerOutputOptionsForRuntime0254WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0254)
-
-			// Input and Output params for GetServer
-			getServerOneInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOneOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOneOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
-
-			getServerTwoInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
-			getServerTwoOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
-
-			getServerOneInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerOneOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerOneOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
-
-			getServerTwoInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
-			getServerTwoOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityTwo)
-
-			getServerOneInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
-			getServerOneOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-			getServerOneOutputOptionsForRuntime0254WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
-
-			getServerTwoInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
-			getServerTwoOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityTwo)
-
-			// Input params for DeleteServer v0.28.0
-			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-
-			// Input params for RemoveCurrentServer v0.28.0
-			removeCurrentServerInputOptions := server.DefaultRemoveCurrentServerInputOptions(core.Version0280)
-
-			// Create SetServer latest Command with input and output options
-			setServerOneCmd, err := framework.NewSetServerCommand(setServerOneInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			setServerTwoCmd, err := framework.NewSetServerCommand(setServerTwoInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create SetCurrentServer latest Command with input and output options
-			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetServer Commands with input and output options
-			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntimeLatest, getServerOneOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntime0280, getServerOneOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntime0254, getServerOneOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntimeLatest, getServerOneOutputOptionsForRuntimeLatestWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntime0280, getServerOneOutputOptionsForRuntime0280WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0254WithError, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntime0254, getServerOneOutputOptionsForRuntime0254WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getServerTwoCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntimeLatest, getServerTwoOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerTwoCmdForRuntime0280, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0280, getServerTwoOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerTwoCmdForRuntime0254, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0254, getServerTwoOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetCurrentServer Commands
-			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0254WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create DeleteServer Command
-			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create RemoveCurrentServer Command
-			removeCurrentCtxCmd, err := framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Build test case with commands
-
-			// Add SetServer and SetCurrentServer Commands
-			testCase := core.NewTestCase().Add(setServerOneCmd).Add(setServerTwoCmd).Add(setCurrentServerCmd)
-
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
-			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
-
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
 
 			// Add RemoveCurrentServer v0.28.0 Command
-			testCase.Add(removeCurrentCtxCmd)
+			testCase.Add(removeCurrentServerCmdForRuntime0280)
 
 			// Add DeleteServer v0.28.0 Command
-			testCase.Add(deleteCtxCmd)
+			testCase.Add(deleteServerCmdForRuntime0280)
 
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError)
-			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError).Add(getServerCmdForRuntime0116WithError)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
 
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			// Add GetCurrentServer Commands on all supported Runtime library versions
 			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError)
 
 			// Run all the commands
@@ -506,243 +501,116 @@ var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for suppo
 		})
 
 		ginkgo.It("Run SetServer, SetCurrentServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
-			// Setting up the input and output parameters data for various APIs
-			// Input and Output Parameters for SetServer v0.25.4
-			setServerOneInputOptions := server.DefaultSetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
-			setServerTwoInputOptions := server.DefaultSetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
+			// Add two SetServer Commands of Runtime v0.25.4
+			testCase := core.NewTestCase().Add(setServerCmdForRuntime0254).Add(setServerTwoCmdForRuntime0254)
 
-			// Input Parameters for SetCurrentServer v0.25.4
-			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+			// Add SetCurrentServer Command of Runtime v0.25.4
+			testCase.Add(setCurrentServerCmdForRuntime0254)
 
-			// Input and Output Parameters for GetCurrentServer
-			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
-			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
-			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
 
-			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-
-			// Input and Output params for GetServer
-			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
-
-			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-
-			getServerTwoInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
-			getServerTwoInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
-			getServerTwoInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
-
-			getServerTwoOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
-			getServerTwoOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityTwo)
-			getServerTwoOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityTwo)
-
-			// Input and Output params for RemoveCurrentServer v0.28.0
-			removeCurrentServerInputOptions := server.DefaultRemoveCurrentServerInputOptions(core.Version0280)
-			removeCurrentServerOutputOptionsWithError := server.DefaultRemoveCurrentServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
-
-			// Input and Output params for DeleteServer v0.28.0
-			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-			deleteServerOutputOptionsWithError := server.DefaultDeleteServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
-
-			// Creating Commands to trigger Runtime APIs
-
-			// Create SetServer latest Command with input and output options
-			setServerOneCmd, err := framework.NewSetServerCommand(setServerOneInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-			setServerTwoCmd, err := framework.NewSetServerCommand(setServerTwoInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create SetCurrentServer latest Command with input and output options
-			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetServer Commands with input and output options
-			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getServerTwoCmdForRuntime0254, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0254, getServerTwoOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerTwoCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntimeLatest, getServerTwoOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getServerTwoCmdForRuntime0280, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0280, getServerTwoOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetCurrentServer Commands
-			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create DeleteServer Command
-			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, deleteServerOutputOptionsWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create RemoveCurrentServer Command
-			removeCurrentCtxCmd, err := framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptions, removeCurrentServerOutputOptionsWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Build test case with commands
-
-			// Add SetServer and SetCurrentServer Commands
-			testCase := core.NewTestCase().Add(setServerOneCmd).Add(setServerTwoCmd).Add(setCurrentServerCmd)
-
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
-
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
 
 			// Add RemoveCurrentServer v0.28.0 Command
-			testCase.Add(removeCurrentCtxCmd)
+			testCase.Add(removeCurrentServerCmdForRuntime0280WithError)
 
 			// Add DeleteServer v0.28.0 Command
-			testCase.Add(deleteCtxCmd)
+			testCase.Add(deleteServerCmdForRuntime0280WithError)
 
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
-			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
 
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
 
-			// Execute the test case
 			// Run all the commands
 			executer.Execute(testCase)
 		})
 
 		ginkgo.It("Run SetServer, SetCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
-			// Setting up the input and output parameters data for various APIs
 
-			// Input Parameters for SetServer v0.28.0
-			setServerOneInputOptions := server.DefaultSetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-			setServerTwoInputOptions := server.DefaultSetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
+			// Add two SetServer Commands of Runtime v0.28.0
+			testCase := core.NewTestCase().Add(setServerCmdForRuntime0280).Add(setServerTwoCmdForRuntime0280)
 
-			// Input Parameters for SetCurrentServer v0.28.0
-			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			// Add SetCurrentServer Command of Runtime v0.28.0
+			testCase.Add(setCurrentServerCmdForRuntime0280)
 
-			// Input and Output Parameters for GetCurrentServer
-			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
-			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
-			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
 
-			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-			getCurrentServerOutputOptionsForRuntime0254WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0254)
-			getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
-			getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0280)
-
-			// Input and Output params for GetServer
-			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
-
-			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0254WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
-			getServerOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
-
-			getServerTwoInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
-			getServerTwoInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
-			getServerTwoInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
-
-			getServerTwoOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
-			getServerTwoOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityTwo)
-			getServerTwoOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityTwo)
-
-			// Input params for DeleteServer v0.25.4
-			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
-
-			// Creating Commands to trigger Runtime APIs
-
-			// Create SetServer v0.28.0 Command with input and output options
-			setServerOneCmd, err := framework.NewSetServerCommand(setServerOneInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-			setServerTwoCmd, err := framework.NewSetServerCommand(setServerTwoInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create SetCurrentServer v0.28.0 Command with input and output options
-			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetServer Commands with input and output options
-			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0254WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatestWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			getServerTwoCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntimeLatest, getServerTwoOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerTwoCmdForRuntime0280, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0280, getServerTwoOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getServerTwoCmdForRuntime0254, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0254, getServerTwoOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create GetCurrentServer Commands
-			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0254WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
-			gomega.Expect(err).To(gomega.BeNil())
-			getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Create DeleteServer v0.25.4 Command
-			deleteServerCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, nil)
-			gomega.Expect(err).To(gomega.BeNil())
-
-			// Build test case with commands
-
-			// Add SetServer and SetCurrentServer Commands
-			testCase := core.NewTestCase().Add(setServerOneCmd).Add(setServerTwoCmd).Add(setCurrentServerCmd)
-
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
-			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
-
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
 
 			// Add DeleteServer v0.25.4 Command
-			testCase.Add(deleteServerCmd)
+			testCase.Add(deleteServerCmdForRuntime0254)
 
-			// Add GetServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError)
-			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError).Add(getServerCmdForRuntime0116WithError)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
 
-			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
-			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError)
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError).Add(getCurrentServerCmdForRuntime0116WithError)
+
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+
+		ginkgo.It("Run SetServer, SetCurrentServer v0.11.6 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer latest then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+			// Add two SetServer Commands of Runtime v0.11.6
+			testCase := core.NewTestCase().Add(setServerCmdForRuntime0116).Add(setServerTwoCmdForRuntime0116)
+
+			// Add SetCurrentServer Command of Runtime v0.11.6
+			testCase.Add(setCurrentServerCmdForRuntime0116)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
+
+			// Add DeleteServer latest Command
+			testCase.Add(deleteServerCmdForRuntimeLatestWithError)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
+
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+
+		ginkgo.It("Run SetServer, SetCurrentServer v0.11.6 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+			// Add two SetServer Commands of Runtime v0.11.6
+			testCase := core.NewTestCase().Add(setServerCmdForRuntime0116).Add(setServerTwoCmdForRuntime0116)
+
+			// Add SetCurrentServer Command of Runtime v0.11.6
+			testCase.Add(setCurrentServerCmdForRuntime0116)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254).Add(getServerCmdForRuntime0116)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254).Add(getCurrentServerCmdForRuntime0116)
+
+			// Add DeleteServer v0.25.4 Command
+			testCase.Add(deleteServerCmdForRuntime0254)
+
+			// Add GetServer Commands on all supported Runtime library versions
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError).Add(getServerCmdForRuntime0116WithError)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254).Add(getServerTwoCmdForRuntime0116)
+
+			// Add GetCurrentServer Commands on all supported Runtime library versions
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError).Add(getCurrentServerCmdForRuntime0116WithError)
 
 			// Run all the commands
 			executer.Execute(testCase)

--- a/test/compatibility/framework/compatibilitytests/server/server_test.go
+++ b/test/compatibility/framework/compatibilitytests/server/server_test.go
@@ -1,0 +1,751 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework/compatibilitytests/server"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework/compatibilitytests/common"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework/executer"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework"
+)
+
+var _ = ginkgo.Describe("Cross-version Server APIs Compatibility Tests for supported Runtime versions v0.11.6, v0.25.4, v0.28.0, latest", func() {
+	// Description on the Tests
+	ginkgo.GinkgoWriter.Println("Get/Set/Delete Server and CurrentServer API methods are tested for cross-version API compatibility with supported Runtime versions v0.11.6, v0.25.4, v0.28.0, latest")
+
+	ginkgo.BeforeEach(func() {
+		// Setup mock temporary config files for testing
+		_, cleanup := core.SetupTempCfgFiles()
+		ginkgo.DeferCleanup(func() {
+			cleanup()
+		})
+	})
+
+	ginkgo.Context("using single server", func() {
+
+		ginkgo.It("SetServer, SetCurrentServer latest then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+			ginkgo.By("Setting up the input and output parameters data for various APIs")
+			// Input and Output Parameters for SetServer latest
+			setServerInputOptions := server.DefaultSetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+
+			// Input and Output Parameters for SetCurrentServer latest
+			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+
+			// Input and Output Parameters for GetCurrentServer
+			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
+			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+
+			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
+			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+
+			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
+			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0254WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0254)
+
+			// Input and Output params for GetServer
+			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
+
+			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0254WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
+
+			// Input params for DeleteServer v0.28.0
+			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+
+			// Input params for RemoveCurrentServer v0.28.0
+			removeCurrentServerInputOptions := server.DefaultRemoveCurrentServerInputOptions(core.Version0280)
+
+			ginkgo.By("Creating Commands to trigger Runtime APIs")
+
+			// Create SetServer latest Command with input and output options
+			setServerCmd, err := framework.NewSetServerCommand(setServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create SetCurrentServer latest Command with input and output options
+			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetServer Commands with input and output options
+			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatestWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0254WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetCurrentServer Commands
+			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0254WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create DeleteServer Command
+			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create RemoveCurrentServer Command
+			removeCurrentCtxCmd, err := framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			ginkgo.By("Build test case with commands")
+
+			// Add SetServer and SetCurrentServer Commands
+			testCase := core.NewTestCase().Add(setServerCmd).Add(setCurrentServerCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+
+			// Add RemoveCurrentServer v0.28.0 Command
+			testCase.Add(removeCurrentCtxCmd)
+
+			// Add DeleteServer v0.28.0 Command
+			testCase.Add(deleteCtxCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError)
+
+			ginkgo.By("Execute the testcase")
+
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+		ginkgo.It("SetServer, SetCurrentServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+			ginkgo.By("Setting up the input and output parameters data for various APIs")
+			// Input and Output Parameters for SetServer v0.25.4
+			setServerInputOptions := server.DefaultSetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			// Input Parameters for SetCurrentServer v0.25.4
+			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			// Input and Output Parameters for GetCurrentServer
+			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
+			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
+			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
+
+			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			//getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+			//getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+
+			// Input and Output params for GetServer
+			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			//getServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
+			//getServerOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+			// Input and Output params for RemoveCurrentServer v0.28.0
+			removeCurrentServerInputOptions := server.DefaultRemoveCurrentServerInputOptions(core.Version0280)
+			removeCurrentServerOutputOptionsWithError := server.DefaultRemoveCurrentServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+			// Input and Output params for DeleteServer v0.28.0
+			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			deleteServerOutputOptionsWithError := server.DefaultDeleteServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+			ginkgo.By("Creating Commands to trigger Runtime APIs")
+
+			// Create SetServer latest Command with input and output options
+			setServerCmd, err := framework.NewSetServerCommand(setServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create SetCurrentServer latest Command with input and output options
+			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetServer Commands with input and output options
+			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			//getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatestWithError)
+			//gomega.Expect(err).To(gomega.BeNil())
+			//getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280WithError)
+			//gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetCurrentServer Commands
+			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			//getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
+			//gomega.Expect(err).To(gomega.BeNil())
+			//getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
+			//gomega.Expect(err).To(gomega.BeNil())
+
+			// Create DeleteServer Command
+			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, deleteServerOutputOptionsWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create RemoveCurrentServer Command
+			removeCurrentCtxCmd, err := framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptions, removeCurrentServerOutputOptionsWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			ginkgo.By("Build test case with commands")
+
+			// Add SetServer and SetCurrentServer Commands
+			testCase := core.NewTestCase().Add(setServerCmd).Add(setCurrentServerCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+
+			// Add RemoveCurrentServer v0.28.0 Command
+			testCase.Add(removeCurrentCtxCmd)
+
+			// Add DeleteServer v0.28.0 Command
+			testCase.Add(deleteCtxCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+
+			ginkgo.By("Execute the test case")
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+		ginkgo.It("SetServer, SetCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+			ginkgo.By("Setting up the input and output parameters data for various APIs")
+
+			// Input Parameters for SetServer v0.28.0
+			setServerInputOptions := server.DefaultSetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+
+			// Input Parameters for SetCurrentServer v0.28.0
+			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+
+			// Input and Output Parameters for GetCurrentServer
+			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
+			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+
+			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
+			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+
+			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
+			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0254WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0254)
+
+			// Input and Output params for GetServer
+			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0254WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
+
+			// Input params for DeleteServer v0.25.4
+			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			ginkgo.By("Creating Commands to trigger Runtime APIs")
+
+			// Create SetServer v0.28.0 Command with input and output options
+			setServerCmd, err := framework.NewSetServerCommand(setServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create SetCurrentServer v0.28.0 Command with input and output options
+			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetServer Commands with input and output options
+			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatestWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0254WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetCurrentServer Commands
+			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0254WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create DeleteServer v0.25.4 Command
+			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			ginkgo.By("Build test case with commands")
+
+			// Add SetServer and SetCurrentServer Commands
+			testCase := core.NewTestCase().Add(setServerCmd).Add(setCurrentServerCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+
+			// Add DeleteServer v0.25.4 Command
+			testCase.Add(deleteCtxCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError)
+
+			ginkgo.By("Execute the test case")
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+
+	})
+
+	ginkgo.Context("using multiple servers", func() {
+
+		ginkgo.It("Run SetServer, SetCurrentServer on Runtime latest then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+			// Input and Output Parameters for SetServer latest
+			setServerOneInputOptions := server.DefaultSetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			setServerTwoInputOptions := server.DefaultSetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+
+			// Input and Output Parameters for SetCurrentServer latest
+			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+
+			// Input and Output Parameters for GetCurrentServer
+			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
+
+			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+
+			getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+
+			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
+
+			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+
+			getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+
+			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
+
+			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			getCurrentServerOutputOptionsForRuntime0254WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0254)
+
+			// Input and Output params for GetServer
+			getServerOneInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOneOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOneOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
+
+			getServerTwoInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+			getServerTwoOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+
+			getServerOneInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerOneOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerOneOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+			getServerTwoInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
+			getServerTwoOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityTwo)
+
+			getServerOneInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getServerOneOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getServerOneOutputOptionsForRuntime0254WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
+
+			getServerTwoInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
+			getServerTwoOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityTwo)
+
+			// Input params for DeleteServer v0.28.0
+			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+
+			// Input params for RemoveCurrentServer v0.28.0
+			removeCurrentServerInputOptions := server.DefaultRemoveCurrentServerInputOptions(core.Version0280)
+
+			// Create SetServer latest Command with input and output options
+			setServerOneCmd, err := framework.NewSetServerCommand(setServerOneInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			setServerTwoCmd, err := framework.NewSetServerCommand(setServerTwoInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create SetCurrentServer latest Command with input and output options
+			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetServer Commands with input and output options
+			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntimeLatest, getServerOneOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntime0280, getServerOneOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntime0254, getServerOneOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntimeLatest, getServerOneOutputOptionsForRuntimeLatestWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntime0280, getServerOneOutputOptionsForRuntime0280WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0254WithError, err := framework.NewGetServerCommand(getServerOneInputOptionsForRuntime0254, getServerOneOutputOptionsForRuntime0254WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getServerTwoCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntimeLatest, getServerTwoOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerTwoCmdForRuntime0280, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0280, getServerTwoOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerTwoCmdForRuntime0254, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0254, getServerTwoOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetCurrentServer Commands
+			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0254WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create DeleteServer Command
+			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create RemoveCurrentServer Command
+			removeCurrentCtxCmd, err := framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Build test case with commands
+
+			// Add SetServer and SetCurrentServer Commands
+			testCase := core.NewTestCase().Add(setServerOneCmd).Add(setServerTwoCmd).Add(setCurrentServerCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+
+			// Add RemoveCurrentServer v0.28.0 Command
+			testCase.Add(removeCurrentCtxCmd)
+
+			// Add DeleteServer v0.28.0 Command
+			testCase.Add(deleteCtxCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError)
+
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+
+		ginkgo.It("Run SetServer, SetCurrentServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer, RemoveCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+			// Setting up the input and output parameters data for various APIs
+			// Input and Output Parameters for SetServer v0.25.4
+			setServerOneInputOptions := server.DefaultSetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+			setServerTwoInputOptions := server.DefaultSetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
+
+			// Input Parameters for SetCurrentServer v0.25.4
+			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			// Input and Output Parameters for GetCurrentServer
+			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
+			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
+			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
+
+			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			// Input and Output params for GetServer
+			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			getServerTwoInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+			getServerTwoInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
+			getServerTwoInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
+
+			getServerTwoOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+			getServerTwoOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityTwo)
+			getServerTwoOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityTwo)
+
+			// Input and Output params for RemoveCurrentServer v0.28.0
+			removeCurrentServerInputOptions := server.DefaultRemoveCurrentServerInputOptions(core.Version0280)
+			removeCurrentServerOutputOptionsWithError := server.DefaultRemoveCurrentServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+			// Input and Output params for DeleteServer v0.28.0
+			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			deleteServerOutputOptionsWithError := server.DefaultDeleteServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+			// Creating Commands to trigger Runtime APIs
+
+			// Create SetServer latest Command with input and output options
+			setServerOneCmd, err := framework.NewSetServerCommand(setServerOneInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+			setServerTwoCmd, err := framework.NewSetServerCommand(setServerTwoInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create SetCurrentServer latest Command with input and output options
+			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetServer Commands with input and output options
+			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getServerTwoCmdForRuntime0254, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0254, getServerTwoOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerTwoCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntimeLatest, getServerTwoOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getServerTwoCmdForRuntime0280, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0280, getServerTwoOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetCurrentServer Commands
+			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create DeleteServer Command
+			deleteCtxCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, deleteServerOutputOptionsWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create RemoveCurrentServer Command
+			removeCurrentCtxCmd, err := framework.NewRemoveCurrentServerCommand(removeCurrentServerInputOptions, removeCurrentServerOutputOptionsWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Build test case with commands
+
+			// Add SetServer and SetCurrentServer Commands
+			testCase := core.NewTestCase().Add(setServerOneCmd).Add(setServerTwoCmd).Add(setCurrentServerCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+
+			// Add RemoveCurrentServer v0.28.0 Command
+			testCase.Add(removeCurrentCtxCmd)
+
+			// Add DeleteServer v0.28.0 Command
+			testCase.Add(deleteCtxCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+
+			// Execute the test case
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+
+		ginkgo.It("Run SetServer, SetCurrentServer v0.28.0 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest then DeleteServer v0.25.4 then GetServer, GetCurrentServer v0.25.4, v0.28.0, latest", func() {
+			// Setting up the input and output parameters data for various APIs
+
+			// Input Parameters for SetServer v0.28.0
+			setServerOneInputOptions := server.DefaultSetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			setServerTwoInputOptions := server.DefaultSetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
+
+			// Input Parameters for SetCurrentServer v0.28.0
+			setCurrentServerInputOptions := server.DefaultSetCurrentServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+
+			// Input and Output Parameters for GetCurrentServer
+			getCurrentServerInputOptionsForRuntimeLatest := server.DefaultGetCurrentServerInputOptions(core.VersionLatest)
+			getCurrentServerInputOptionsForRuntime0280 := server.DefaultGetCurrentServerInputOptions(core.Version0280)
+			getCurrentServerInputOptionsForRuntime0254 := server.DefaultGetCurrentServerInputOptions(core.Version0254)
+
+			getCurrentServerOutputOptionsForRuntimeLatest := server.DefaultGetCurrentServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0280 := server.DefaultGetCurrentServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0254 := server.DefaultGetCurrentServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getCurrentServerOutputOptionsForRuntime0254WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0254)
+			getCurrentServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.VersionLatest)
+			getCurrentServerOutputOptionsForRuntime0280WithError := server.DefaultGetCurrentServerOutputOptionsWithError(core.Version0280)
+
+			// Input and Output params for GetServer
+			getServerInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			getServerOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0254WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0254, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntimeLatestWithError := server.DefaultGetServerOutputOptionsWithError(core.VersionLatest, common.CtxCompatibilityOne)
+			getServerOutputOptionsForRuntime0280WithError := server.DefaultGetServerOutputOptionsWithError(core.Version0280, common.CtxCompatibilityOne)
+
+			getServerTwoInputOptionsForRuntimeLatest := server.DefaultGetServerInputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+			getServerTwoInputOptionsForRuntime0280 := server.DefaultGetServerInputOptions(core.Version0280, common.CtxCompatibilityTwo)
+			getServerTwoInputOptionsForRuntime0254 := server.DefaultGetServerInputOptions(core.Version0254, common.CtxCompatibilityTwo)
+
+			getServerTwoOutputOptionsForRuntimeLatest := server.DefaultGetServerOutputOptions(core.VersionLatest, common.CtxCompatibilityTwo)
+			getServerTwoOutputOptionsForRuntime0280 := server.DefaultGetServerOutputOptions(core.Version0280, common.CtxCompatibilityTwo)
+			getServerTwoOutputOptionsForRuntime0254 := server.DefaultGetServerOutputOptions(core.Version0254, common.CtxCompatibilityTwo)
+
+			// Input params for DeleteServer v0.25.4
+			deleteServerInputOptions := server.DefaultDeleteServerInputOptions(core.Version0254, common.CtxCompatibilityOne)
+
+			// Creating Commands to trigger Runtime APIs
+
+			// Create SetServer v0.28.0 Command with input and output options
+			setServerOneCmd, err := framework.NewSetServerCommand(setServerOneInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+			setServerTwoCmd, err := framework.NewSetServerCommand(setServerTwoInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create SetCurrentServer v0.28.0 Command with input and output options
+			setCurrentServerCmd, err := framework.NewSetCurrentServerCommand(setCurrentServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetServer Commands with input and output options
+			getServerCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0280, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0254, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0254WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0254, getServerOutputOptionsForRuntime0254WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getServerCmdForRuntimeLatestWithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntimeLatest, getServerOutputOptionsForRuntimeLatestWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerCmdForRuntime0280WithError, err := framework.NewGetServerCommand(getServerInputOptionsForRuntime0280, getServerOutputOptionsForRuntime0280WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			getServerTwoCmdForRuntimeLatest, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntimeLatest, getServerTwoOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerTwoCmdForRuntime0280, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0280, getServerTwoOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getServerTwoCmdForRuntime0254, err := framework.NewGetServerCommand(getServerTwoInputOptionsForRuntime0254, getServerTwoOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create GetCurrentServer Commands
+			getCurrentServerCmdForRuntimeLatest, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatest)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0280, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0254, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0254WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0254, getCurrentServerOutputOptionsForRuntime0254WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntimeLatestWithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntimeLatest, getCurrentServerOutputOptionsForRuntimeLatestWithError)
+			gomega.Expect(err).To(gomega.BeNil())
+			getCurrentServerCmdForRuntime0280WithError, err := framework.NewGetCurrentServerCommand(getCurrentServerInputOptionsForRuntime0280, getCurrentServerOutputOptionsForRuntime0280WithError)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Create DeleteServer v0.25.4 Command
+			deleteServerCmd, err := framework.NewDeleteServerCommand(deleteServerInputOptions, nil)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			// Build test case with commands
+
+			// Add SetServer and SetCurrentServer Commands
+			testCase := core.NewTestCase().Add(setServerOneCmd).Add(setServerTwoCmd).Add(setCurrentServerCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatest).Add(getServerCmdForRuntime0280).Add(getServerCmdForRuntime0254)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatest).Add(getCurrentServerCmdForRuntime0280).Add(getCurrentServerCmdForRuntime0254)
+
+			// Add DeleteServer v0.25.4 Command
+			testCase.Add(deleteServerCmd)
+
+			// Add GetServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getServerCmdForRuntimeLatestWithError).Add(getServerCmdForRuntime0280WithError).Add(getServerCmdForRuntime0254WithError)
+			testCase.Add(getServerTwoCmdForRuntimeLatest).Add(getServerTwoCmdForRuntime0280).Add(getServerTwoCmdForRuntime0254)
+
+			// Add GetCurrentServer latest, v0.28.0, v0.25.4 Commands
+			testCase.Add(getCurrentServerCmdForRuntimeLatestWithError).Add(getCurrentServerCmdForRuntime0280WithError).Add(getCurrentServerCmdForRuntime0254WithError)
+
+			// Run all the commands
+			executer.Execute(testCase)
+		})
+	})
+})

--- a/test/compatibility/framework/compatibilitytests/server/server_test_helpers.go
+++ b/test/compatibility/framework/compatibilitytests/server/server_test_helpers.go
@@ -46,7 +46,6 @@ func DefaultGetServerInputOptions(version core.RuntimeVersion, serverName string
 }
 
 // DefaultGetServerOutputOptions helper method to construct GetServer API output options
-//nolint: dupl
 func DefaultGetServerOutputOptions(version core.RuntimeVersion, serverName string) *framework.GetServerOutputOptions {
 	switch version {
 	case core.VersionLatest, core.Version0280:
@@ -81,7 +80,6 @@ func DefaultGetServerOutputOptions(version core.RuntimeVersion, serverName strin
 }
 
 // DefaultGetServerOutputOptionsWithError helper method to construct GetServer API output options with error
-//nolint: dupl
 func DefaultGetServerOutputOptionsWithError(version core.RuntimeVersion, serverName string) *framework.GetServerOutputOptions {
 	switch version {
 	case core.VersionLatest, core.Version0280, core.Version0254, core.Version0116:
@@ -119,7 +117,6 @@ func DefaultGetCurrentServerInputOptions(version core.RuntimeVersion) *framework
 }
 
 // DefaultGetCurrentServerOutputOptions helper method to construct GetCurrentServer API output options
-//nolint: dupl
 func DefaultGetCurrentServerOutputOptions(version core.RuntimeVersion, serverName string) *framework.GetCurrentServerOutputOptions {
 	switch version {
 	case core.VersionLatest, core.Version0254, core.Version0116:
@@ -207,7 +204,6 @@ func DefaultDeleteServerInputOptions(version core.RuntimeVersion, serverName str
 }
 
 // DefaultDeleteServerOutputOptionsWithError helper method to construct DeleteServer API output options
-//nolint: dupl
 func DefaultDeleteServerOutputOptionsWithError(version core.RuntimeVersion, serverName string) *framework.DeleteServerOutputOptions {
 	switch version {
 	case core.VersionLatest, core.Version0280, core.Version0254, core.Version0116:

--- a/test/compatibility/framework/compatibilitytests/server/server_test_helpers.go
+++ b/test/compatibility/framework/compatibilitytests/server/server_test_helpers.go
@@ -17,36 +17,10 @@ const ServerNotFound = "current server \"\" not found in tanzu config"
 // DefaultSetServerInputOptions helper method to construct SetServer API input options
 func DefaultSetServerInputOptions(version core.RuntimeVersion, serverName string) *framework.SetServerInputOptions {
 	switch version {
-	case core.VersionLatest:
+	case core.VersionLatest, core.Version0280, core.Version0254, core.Version0116:
 		return &framework.SetServerInputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.VersionLatest,
-			},
-			ServerOpts: &framework.ServerOpts{
-				Name: serverName,
-				Type: framework.ManagementClusterServerType,
-				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: common.DefaultEndpoint,
-				},
-			},
-		}
-	case core.Version0280:
-		return &framework.SetServerInputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0280,
-			},
-			ServerOpts: &framework.ServerOpts{
-				Name: serverName,
-				Type: framework.ManagementClusterServerType,
-				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: common.DefaultEndpoint,
-				},
-			},
-		}
-	case core.Version0254:
-		return &framework.SetServerInputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0254,
+				RuntimeVersion: version,
 			},
 			ServerOpts: &framework.ServerOpts{
 				Name: serverName,
@@ -57,6 +31,7 @@ func DefaultSetServerInputOptions(version core.RuntimeVersion, serverName string
 			},
 		}
 	}
+
 	return nil
 }
 
@@ -74,10 +49,10 @@ func DefaultGetServerInputOptions(version core.RuntimeVersion, serverName string
 //nolint: dupl
 func DefaultGetServerOutputOptions(version core.RuntimeVersion, serverName string) *framework.GetServerOutputOptions {
 	switch version {
-	case core.VersionLatest:
+	case core.VersionLatest, core.Version0280:
 		return &framework.GetServerOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.VersionLatest,
+				RuntimeVersion: version,
 			},
 			ServerOpts: &framework.ServerOpts{
 				Name: serverName,
@@ -88,24 +63,10 @@ func DefaultGetServerOutputOptions(version core.RuntimeVersion, serverName strin
 			},
 			ValidationStrategy: core.ValidationStrategyStrict,
 		}
-	case core.Version0280:
+	case core.Version0254, core.Version0116:
 		return &framework.GetServerOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0280,
-			},
-			ServerOpts: &framework.ServerOpts{
-				Name: serverName,
-				Type: framework.ManagementClusterServerType,
-				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: common.DefaultEndpoint,
-				},
-			},
-			ValidationStrategy: core.ValidationStrategyStrict,
-		}
-	case core.Version0254:
-		return &framework.GetServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0254,
+				RuntimeVersion: version,
 			},
 			ServerOpts: &framework.ServerOpts{
 				Name: serverName,
@@ -123,24 +84,10 @@ func DefaultGetServerOutputOptions(version core.RuntimeVersion, serverName strin
 //nolint: dupl
 func DefaultGetServerOutputOptionsWithError(version core.RuntimeVersion, serverName string) *framework.GetServerOutputOptions {
 	switch version {
-	case core.VersionLatest:
+	case core.VersionLatest, core.Version0280, core.Version0254, core.Version0116:
 		return &framework.GetServerOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
 				RuntimeVersion: core.VersionLatest,
-			},
-			Error: fmt.Sprintf("could not find server \"%v\"", serverName),
-		}
-	case core.Version0280:
-		return &framework.GetServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0280,
-			},
-			Error: fmt.Sprintf("could not find server \"%v\"", serverName),
-		}
-	case core.Version0254:
-		return &framework.GetServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0254,
 			},
 			Error: fmt.Sprintf("could not find server \"%v\"", serverName),
 		}
@@ -161,22 +108,10 @@ func DefaultSetCurrentServerInputOptions(version core.RuntimeVersion, serverName
 // DefaultGetCurrentServerInputOptions helper method to construct GetCurrentServer API input options
 func DefaultGetCurrentServerInputOptions(version core.RuntimeVersion) *framework.GetCurrentServerInputOptions {
 	switch version {
-	case core.VersionLatest:
+	case core.VersionLatest, core.Version0280, core.Version0254, core.Version0116:
 		return &framework.GetCurrentServerInputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
 				RuntimeVersion: core.VersionLatest,
-			},
-		}
-	case core.Version0280:
-		return &framework.GetCurrentServerInputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0280,
-			},
-		}
-	case core.Version0254:
-		return &framework.GetCurrentServerInputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0254,
 			},
 		}
 	}
@@ -187,10 +122,10 @@ func DefaultGetCurrentServerInputOptions(version core.RuntimeVersion) *framework
 //nolint: dupl
 func DefaultGetCurrentServerOutputOptions(version core.RuntimeVersion, serverName string) *framework.GetCurrentServerOutputOptions {
 	switch version {
-	case core.VersionLatest:
+	case core.VersionLatest, core.Version0254, core.Version0116:
 		return &framework.GetCurrentServerOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.VersionLatest,
+				RuntimeVersion: version,
 			},
 			ServerOpts: &framework.ServerOpts{
 				Name: serverName,
@@ -215,19 +150,6 @@ func DefaultGetCurrentServerOutputOptions(version core.RuntimeVersion, serverNam
 			},
 			ValidationStrategy: core.ValidationStrategyStrict,
 		}
-	case core.Version0254:
-		return &framework.GetCurrentServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0254,
-			},
-			ServerOpts: &framework.ServerOpts{
-				Name: serverName,
-				Type: framework.ManagementClusterServerType,
-				GlobalOpts: &framework.GlobalServerOpts{
-					Endpoint: common.DefaultEndpoint,
-				},
-			},
-		}
 	}
 	return nil
 }
@@ -235,21 +157,7 @@ func DefaultGetCurrentServerOutputOptions(version core.RuntimeVersion, serverNam
 // DefaultGetCurrentServerOutputOptionsWithError helper method to construct GetCurrentServer API output options with error
 func DefaultGetCurrentServerOutputOptionsWithError(version core.RuntimeVersion) *framework.GetCurrentServerOutputOptions {
 	switch version {
-	case core.VersionLatest:
-		return &framework.GetCurrentServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: version,
-			},
-			Error: ServerNotFound,
-		}
-	case core.Version0280:
-		return &framework.GetCurrentServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: version,
-			},
-			Error: ServerNotFound,
-		}
-	case core.Version0254:
+	case core.VersionLatest, core.Version0280, core.Version0254, core.Version0116:
 		return &framework.GetCurrentServerOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
 				RuntimeVersion: version,
@@ -263,17 +171,10 @@ func DefaultGetCurrentServerOutputOptionsWithError(version core.RuntimeVersion) 
 // DefaultRemoveCurrentServerInputOptions helper method to construct RemoveCurrentServer API input options
 func DefaultRemoveCurrentServerInputOptions(version core.RuntimeVersion) *framework.RemoveCurrentServerInputOptions {
 	switch version {
-	case core.VersionLatest:
+	case core.VersionLatest, core.Version0280:
 		return &framework.RemoveCurrentServerInputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.VersionLatest,
-			},
-			ServerName: common.CtxCompatibilityOne,
-		}
-	case core.Version0280:
-		return &framework.RemoveCurrentServerInputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0280,
+				RuntimeVersion: version,
 			},
 			ServerName: common.CtxCompatibilityOne,
 		}
@@ -282,31 +183,16 @@ func DefaultRemoveCurrentServerInputOptions(version core.RuntimeVersion) *framew
 }
 
 // DefaultRemoveCurrentServerOutputOptionsWithError helper method to construct RemoveCurrentServer API output option
-func DefaultRemoveCurrentServerOutputOptionsWithError(version core.RuntimeVersion, contextName string) *framework.RemoveCurrentServerOutputOptions {
+func DefaultRemoveCurrentServerOutputOptionsWithError(version core.RuntimeVersion, serverName string) *framework.RemoveCurrentServerOutputOptions {
 	switch version {
-	case core.VersionLatest:
+	case core.VersionLatest, core.Version0280, core.Version0254, core.Version0116:
 		return &framework.RemoveCurrentServerOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
 				RuntimeVersion: version,
 			},
-			Error: fmt.Sprintf("context %v not found", contextName),
-		}
-	case core.Version0280:
-		return &framework.RemoveCurrentServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: version,
-			},
-			Error: fmt.Sprintf("context %v not found", contextName),
-		}
-	case core.Version0254:
-		return &framework.RemoveCurrentServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: version,
-			},
-			Error: fmt.Sprintf("context %v not found", contextName),
+			Error: fmt.Sprintf("context %v not found", serverName),
 		}
 	}
-
 	return nil
 }
 
@@ -324,24 +210,10 @@ func DefaultDeleteServerInputOptions(version core.RuntimeVersion, serverName str
 //nolint: dupl
 func DefaultDeleteServerOutputOptionsWithError(version core.RuntimeVersion, serverName string) *framework.DeleteServerOutputOptions {
 	switch version {
-	case core.VersionLatest:
+	case core.VersionLatest, core.Version0280, core.Version0254, core.Version0116:
 		return &framework.DeleteServerOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.VersionLatest,
-			},
-			Error: fmt.Sprintf("context %v not found", serverName),
-		}
-	case core.Version0280:
-		return &framework.DeleteServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0280,
-			},
-			Error: fmt.Sprintf("context %v not found", serverName),
-		}
-	case core.Version0254:
-		return &framework.DeleteServerOutputOptions{
-			RuntimeAPIVersion: &core.RuntimeAPIVersion{
-				RuntimeVersion: core.Version0254,
+				RuntimeVersion: version,
 			},
 			Error: fmt.Sprintf("context %v not found", serverName),
 		}

--- a/test/compatibility/framework/compatibilitytests/server/server_test_helpers.go
+++ b/test/compatibility/framework/compatibilitytests/server/server_test_helpers.go
@@ -1,0 +1,350 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package server provides cross-version Server API compatibility tests
+package server
+
+import (
+	"fmt"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/framework/compatibilitytests/common"
+)
+
+const ServerNotFound = "current server \"\" not found in tanzu config"
+
+// DefaultSetServerInputOptions helper method to construct SetServer API input options
+func DefaultSetServerInputOptions(version core.RuntimeVersion, serverName string) *framework.SetServerInputOptions {
+	switch version {
+	case core.VersionLatest:
+		return &framework.SetServerInputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.VersionLatest,
+			},
+			ServerOpts: &framework.ServerOpts{
+				Name: serverName,
+				Type: framework.ManagementClusterServerType,
+				GlobalOpts: &framework.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+		}
+	case core.Version0280:
+		return &framework.SetServerInputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0280,
+			},
+			ServerOpts: &framework.ServerOpts{
+				Name: serverName,
+				Type: framework.ManagementClusterServerType,
+				GlobalOpts: &framework.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+		}
+	case core.Version0254:
+		return &framework.SetServerInputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0254,
+			},
+			ServerOpts: &framework.ServerOpts{
+				Name: serverName,
+				Type: framework.ManagementClusterServerType,
+				GlobalOpts: &framework.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+		}
+	}
+	return nil
+}
+
+// DefaultGetServerInputOptions helper method to construct GetServer API input options
+func DefaultGetServerInputOptions(version core.RuntimeVersion, serverName string) *framework.GetServerInputOptions {
+	return &framework.GetServerInputOptions{
+		RuntimeAPIVersion: &core.RuntimeAPIVersion{
+			RuntimeVersion: version,
+		},
+		ServerName: serverName,
+	}
+}
+
+// DefaultGetServerOutputOptions helper method to construct GetServer API output options
+//nolint: dupl
+func DefaultGetServerOutputOptions(version core.RuntimeVersion, serverName string) *framework.GetServerOutputOptions {
+	switch version {
+	case core.VersionLatest:
+		return &framework.GetServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.VersionLatest,
+			},
+			ServerOpts: &framework.ServerOpts{
+				Name: serverName,
+				Type: framework.ManagementClusterServerType,
+				GlobalOpts: &framework.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+			ValidationStrategy: core.ValidationStrategyStrict,
+		}
+	case core.Version0280:
+		return &framework.GetServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0280,
+			},
+			ServerOpts: &framework.ServerOpts{
+				Name: serverName,
+				Type: framework.ManagementClusterServerType,
+				GlobalOpts: &framework.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+			ValidationStrategy: core.ValidationStrategyStrict,
+		}
+	case core.Version0254:
+		return &framework.GetServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0254,
+			},
+			ServerOpts: &framework.ServerOpts{
+				Name: serverName,
+				Type: framework.ManagementClusterServerType,
+				GlobalOpts: &framework.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+		}
+	}
+	return nil
+}
+
+// DefaultGetServerOutputOptionsWithError helper method to construct GetServer API output options with error
+//nolint: dupl
+func DefaultGetServerOutputOptionsWithError(version core.RuntimeVersion, serverName string) *framework.GetServerOutputOptions {
+	switch version {
+	case core.VersionLatest:
+		return &framework.GetServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.VersionLatest,
+			},
+			Error: fmt.Sprintf("could not find server \"%v\"", serverName),
+		}
+	case core.Version0280:
+		return &framework.GetServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0280,
+			},
+			Error: fmt.Sprintf("could not find server \"%v\"", serverName),
+		}
+	case core.Version0254:
+		return &framework.GetServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0254,
+			},
+			Error: fmt.Sprintf("could not find server \"%v\"", serverName),
+		}
+	}
+	return nil
+}
+
+// DefaultSetCurrentServerInputOptions helper method to construct SetCurrentServer API input options
+func DefaultSetCurrentServerInputOptions(version core.RuntimeVersion, serverName string) *framework.SetCurrentServerInputOptions {
+	return &framework.SetCurrentServerInputOptions{
+		RuntimeAPIVersion: &core.RuntimeAPIVersion{
+			RuntimeVersion: version,
+		},
+		ServerName: serverName,
+	}
+}
+
+// DefaultGetCurrentServerInputOptions helper method to construct GetCurrentServer API input options
+func DefaultGetCurrentServerInputOptions(version core.RuntimeVersion) *framework.GetCurrentServerInputOptions {
+	switch version {
+	case core.VersionLatest:
+		return &framework.GetCurrentServerInputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.VersionLatest,
+			},
+		}
+	case core.Version0280:
+		return &framework.GetCurrentServerInputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0280,
+			},
+		}
+	case core.Version0254:
+		return &framework.GetCurrentServerInputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0254,
+			},
+		}
+	}
+	return nil
+}
+
+// DefaultGetCurrentServerOutputOptions helper method to construct GetCurrentServer API output options
+//nolint: dupl
+func DefaultGetCurrentServerOutputOptions(version core.RuntimeVersion, serverName string) *framework.GetCurrentServerOutputOptions {
+	switch version {
+	case core.VersionLatest:
+		return &framework.GetCurrentServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.VersionLatest,
+			},
+			ServerOpts: &framework.ServerOpts{
+				Name: serverName,
+				Type: framework.ManagementClusterServerType,
+				GlobalOpts: &framework.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+			ValidationStrategy: core.ValidationStrategyStrict,
+		}
+	case core.Version0280:
+		return &framework.GetCurrentServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0280,
+			},
+			ServerOpts: &framework.ServerOpts{
+				Name: serverName,
+				Type: framework.ManagementClusterServerType,
+				GlobalOpts: &framework.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+			ValidationStrategy: core.ValidationStrategyStrict,
+		}
+	case core.Version0254:
+		return &framework.GetCurrentServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0254,
+			},
+			ServerOpts: &framework.ServerOpts{
+				Name: serverName,
+				Type: framework.ManagementClusterServerType,
+				GlobalOpts: &framework.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+		}
+	}
+	return nil
+}
+
+// DefaultGetCurrentServerOutputOptionsWithError helper method to construct GetCurrentServer API output options with error
+func DefaultGetCurrentServerOutputOptionsWithError(version core.RuntimeVersion) *framework.GetCurrentServerOutputOptions {
+	switch version {
+	case core.VersionLatest:
+		return &framework.GetCurrentServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			Error: ServerNotFound,
+		}
+	case core.Version0280:
+		return &framework.GetCurrentServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			Error: ServerNotFound,
+		}
+	case core.Version0254:
+		return &framework.GetCurrentServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			Error: ServerNotFound,
+		}
+	}
+	return nil
+}
+
+// DefaultRemoveCurrentServerInputOptions helper method to construct RemoveCurrentServer API input options
+func DefaultRemoveCurrentServerInputOptions(version core.RuntimeVersion) *framework.RemoveCurrentServerInputOptions {
+	switch version {
+	case core.VersionLatest:
+		return &framework.RemoveCurrentServerInputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.VersionLatest,
+			},
+			ServerName: common.CtxCompatibilityOne,
+		}
+	case core.Version0280:
+		return &framework.RemoveCurrentServerInputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0280,
+			},
+			ServerName: common.CtxCompatibilityOne,
+		}
+	}
+	return nil
+}
+
+// DefaultRemoveCurrentServerOutputOptionsWithError helper method to construct RemoveCurrentServer API output option
+func DefaultRemoveCurrentServerOutputOptionsWithError(version core.RuntimeVersion, contextName string) *framework.RemoveCurrentServerOutputOptions {
+	switch version {
+	case core.VersionLatest:
+		return &framework.RemoveCurrentServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			Error: fmt.Sprintf("context %v not found", contextName),
+		}
+	case core.Version0280:
+		return &framework.RemoveCurrentServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			Error: fmt.Sprintf("context %v not found", contextName),
+		}
+	case core.Version0254:
+		return &framework.RemoveCurrentServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			Error: fmt.Sprintf("context %v not found", contextName),
+		}
+	}
+
+	return nil
+}
+
+// DefaultDeleteServerInputOptions helper method to construct DeleteServer API input options
+func DefaultDeleteServerInputOptions(version core.RuntimeVersion, serverName string) *framework.DeleteServerInputOptions {
+	return &framework.DeleteServerInputOptions{
+		RuntimeAPIVersion: &core.RuntimeAPIVersion{
+			RuntimeVersion: version,
+		},
+		ServerName: serverName,
+	}
+}
+
+// DefaultDeleteServerOutputOptionsWithError helper method to construct DeleteServer API output options
+//nolint: dupl
+func DefaultDeleteServerOutputOptionsWithError(version core.RuntimeVersion, serverName string) *framework.DeleteServerOutputOptions {
+	switch version {
+	case core.VersionLatest:
+		return &framework.DeleteServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.VersionLatest,
+			},
+			Error: fmt.Sprintf("context %v not found", serverName),
+		}
+	case core.Version0280:
+		return &framework.DeleteServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0280,
+			},
+			Error: fmt.Sprintf("context %v not found", serverName),
+		}
+	case core.Version0254:
+		return &framework.DeleteServerOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.Version0254,
+			},
+			Error: fmt.Sprintf("context %v not found", serverName),
+		}
+	}
+	return nil
+}

--- a/test/compatibility/framework/compatibilitytests/server/servers_suite_test.go
+++ b/test/compatibility/framework/compatibilitytests/server/servers_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestServers(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Cross-version Server API Compatibility Test Suite")
+}

--- a/test/compatibility/framework/context_commands.go
+++ b/test/compatibility/framework/context_commands.go
@@ -17,6 +17,7 @@ import (
 // Return: command to execute or error if any validations fails for SetContextInputOptions or SetContextOutputOptions
 // This method does validate the input parameters  SetContextInputOptions or SetContextOutputOptions based on Runtime API Version
 // For more details about supported parameters refer to SetContextInputOptions or SetContextOutputOptions definition(and ContextOpts struct, which is embedded)
+// nolint:dupl
 func NewSetContextCommand(inputOpts *SetContextInputOptions, outputOpts *SetContextOutputOptions) (*core.Command, error) {
 	// Init the Command object
 	c := &core.Command{}
@@ -145,6 +146,7 @@ func NewGetContextCommand(inputOpts *GetContextInputOptions, outputOpts *GetCont
 // Return: command to execute or error if any validations fails for DeleteContextInputOptions or DeleteContextOutputOptions
 // This method does validate the input parameters  DeleteContextInputOptions or DeleteContextOutputOptions based on Runtime API Version
 // For more details about supported parameters refer to DeleteContextInputOptions or DeleteContextOutputOptions definition(and ContextOpts struct, which is embedded)
+// nolint: dupl
 func NewDeleteContextCommand(inputOpts *DeleteContextInputOptions, outputOpts *DeleteContextOutputOptions) (*core.Command, error) {
 	// Init the Command object
 	c := &core.Command{}

--- a/test/compatibility/framework/server_commands.go
+++ b/test/compatibility/framework/server_commands.go
@@ -1,0 +1,343 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"gopkg.in/yaml.v3"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+)
+
+// NewSetServerCommand constructs a command to make a call to specific runtime version SetServer API
+// Input Parameter inputOpts has all input parameters which are required for Runtime SetServer API
+// Input Parameter: outputOpts has details about expected output from Runtime SetServer API call
+// Return: command to execute or error if any validations fails for SetServerInputOptions or SetServerOutputOptions
+// This method does validate the input parameters  SetServerInputOptions or SetServerOutputOptions based on Runtime API Version
+// For more details about supported parameters refer to SetServerInputOptions or SetServerOutputOptions definition(and ServerOpts struct, which is embedded)
+// nolint:dupl
+func NewSetServerCommand(inputOpts *SetServerInputOptions, outputOpts *SetServerOutputOptions) (*core.Command, error) {
+	// Init the Command object
+	c := &core.Command{}
+
+	// Init the API object
+	api := &core.API{}
+
+	// Set API name
+	api.Name = core.SetServerAPIName
+
+	// Validate the SetServer input arguments
+	_, err := inputOpts.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set API version
+	api.Version = inputOpts.RuntimeVersion
+
+	// Construct the SetServer API arguments
+	bytes, err := yaml.Marshal(inputOpts.ServerOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct the setCurrent Argument
+	var setCurrent = false
+	if inputOpts.SetCurrentServer {
+		setCurrent = true
+	}
+
+	api.Arguments = map[core.APIArgumentType]interface{}{
+		core.Server:     string(bytes),
+		core.SetCurrent: setCurrent,
+	}
+
+	// Construct Output parameters
+	var res = core.Success
+	var content = ""
+
+	if outputOpts != nil && outputOpts.Error != "" {
+		res = core.Failed
+		content = outputOpts.Error
+	}
+
+	api.Output = &core.Output{
+		Result:  res,
+		Content: content,
+	}
+
+	c.APIs = append(c.APIs, api)
+
+	return c, nil
+}
+
+// NewGetServerCommand constructs a command to make a call to specific runtime version GetServer API
+// Input Parameter inputOpts has all input parameters which are required for Runtime GetServer API
+// Input Parameter: outputOpts has details about expected output from Runtime GetServer API call
+// Return: command to execute or error if any validations fails for GetServerInputOptions or GetServerOutputOptions
+// This method does validate the input parameters  GetServerInputOptions or GetServerOutputOptions based on Runtime API Version
+// For more details about supported parameters refer to GetServerInputOptions or GetServerOutputOptions definition(and ServerOpts struct, which is embedded)
+func NewGetServerCommand(inputOpts *GetServerInputOptions, outputOpts *GetServerOutputOptions) (*core.Command, error) {
+	// Init the Command object
+	c := &core.Command{}
+
+	// Init the API object
+	api := &core.API{}
+
+	// Set API name
+	api.Name = core.GetServerAPIName
+
+	// Validate the Input Options
+	_, err := inputOpts.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set API version
+	api.Version = inputOpts.RuntimeVersion
+
+	// Construct the GetServer API arguments
+	api.Arguments = map[core.APIArgumentType]interface{}{
+		core.ServerName: inputOpts.ServerName,
+	}
+
+	// Construct Output parameters
+	var res = core.Success
+	var content = ""
+
+	if outputOpts.Error != "" {
+		res = core.Failed
+		content = outputOpts.Error
+	} else if outputOpts.ServerOpts != nil {
+		// Validate the Output Options
+		_, err = outputOpts.Validate()
+		if err != nil {
+			return nil, err
+		}
+
+		// Construct get server output server opts
+		bytes, err := yaml.Marshal(outputOpts.ServerOpts)
+		if err != nil {
+			return nil, err
+		}
+
+		content = string(bytes)
+		res = core.Success
+	}
+
+	api.Output = &core.Output{
+		Result:  res,
+		Content: content,
+	}
+
+	if outputOpts.ValidationStrategy != "" {
+		api.Output.ValidationStrategy = outputOpts.ValidationStrategy
+	}
+
+	c.APIs = append(c.APIs, api)
+	return c, nil
+}
+
+// NewDeleteServerCommand constructs a command to make a call to specific runtime version DeleteServer API
+// Input Parameter inputOpts has all input parameters which are required for Runtime DeleteServer API
+// Input Parameter: outputOpts has details about expected output from Runtime DeleteServer API call
+// Return: command to execute or error if any validations fails for DeleteServerInputOptions or DeleteServerOutputOptions
+// This method does validate the input parameters  DeleteServerInputOptions or DeleteServerOutputOptions based on Runtime API Version
+// For more details about supported parameters refer to DeleteServerInputOptions or DeleteServerOutputOptions definition(and ServerOpts struct, which is embedded)
+// nolint: dupl
+func NewDeleteServerCommand(inputOpts *DeleteServerInputOptions, outputOpts *DeleteServerOutputOptions) (*core.Command, error) {
+	// Init the Command object
+	c := &core.Command{}
+
+	// Init the API object
+	api := &core.API{}
+
+	// Set API name
+	api.Name = core.DeleteServerAPIName
+
+	// Validate the input options
+	_, err := inputOpts.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set API version
+	api.Version = inputOpts.RuntimeVersion
+
+	// Construct the server api arguments and output
+	api.Arguments = map[core.APIArgumentType]interface{}{
+		core.ServerName: inputOpts.ServerName,
+	}
+
+	// Construct Output parameters
+	var res = core.Success
+	var content = ""
+
+	if outputOpts != nil && outputOpts.Error != "" {
+		res = core.Failed
+		content = outputOpts.Error
+	}
+
+	api.Output = &core.Output{
+		Result:  res,
+		Content: content,
+	}
+
+	c.APIs = append(c.APIs, api)
+	return c, nil
+}
+
+// NewSetCurrentServerCommand constructs a command to make a call to specific runtime version SetCurrentServer API
+// Input Parameter inputOpts has all input parameters which are required for Runtime SetCurrentServer API
+// Input Parameter: outputOpts has details about expected output from Runtime SetCurrentServer API call
+// Return: command to execute or error if any validations fails for SetCurrentServerInputOptions or SetCurrentServerOutputOptions
+// This method does validate the input parameters  SetCurrentServerInputOptions or SetCurrentServerOutputOptions based on Runtime API Version
+// For more details about supported parameters refer to SetCurrentServerInputOptions or SetCurrentServerOutputOptions definition(and ServerOpts struct, which is embedded)
+func NewSetCurrentServerCommand(inputOpts *SetCurrentServerInputOptions, outputOpts *SetCurrentServerOutputOptions) (*core.Command, error) {
+	// Init the Command object
+	c := &core.Command{}
+
+	// Init the API object
+	api := &core.API{Name: core.SetCurrentServerAPIName}
+
+	// Validate the Input Options
+	_, err := inputOpts.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set API version
+	api.Version = inputOpts.RuntimeVersion
+
+	// Construct the server api arguments and output
+	api.Arguments = map[core.APIArgumentType]interface{}{
+		core.ServerName: inputOpts.ServerName,
+	}
+
+	// Construct Output parameters
+	var res = core.Success
+	var content = ""
+
+	if outputOpts != nil && outputOpts.Error != "" {
+		res = core.Failed
+		content = outputOpts.Error
+	}
+
+	api.Output = &core.Output{
+		Result:  res,
+		Content: content,
+	}
+
+	c.APIs = append(c.APIs, api)
+
+	return c, nil
+}
+
+// NewGetCurrentServerCommand constructs a command to make a call to specific runtime version GetCurrentServer API
+// Input Parameter inputOpts has all input parameters which are required for Runtime GetCurrentServer API
+// Input Parameter: outputOpts has details about expected output from Runtime GetCurrentServer API call
+// Return: command to execute or error if any validations fails for GetCurrentServerInputOptions or GetCurrentServerOutputOptions
+// This method does validate the input parameters  GetCurrentServerInputOptions or GetCurrentServerOutputOptions based on Runtime API Version
+// For more details about supported parameters refer to GetCurrentServerInputOptions or GetCurrentServerOutputOptions definition(and ServerOpts struct, which is embedded)
+func NewGetCurrentServerCommand(inputOpts *GetCurrentServerInputOptions, outputOpts *GetCurrentServerOutputOptions) (*core.Command, error) {
+	// Init the Command object
+	c := &core.Command{}
+	// Init the API object
+	api := &core.API{Name: core.GetCurrentServerAPIName}
+
+	// Validate the Input Options
+	_, err := inputOpts.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set API version
+	api.Version = inputOpts.RuntimeVersion
+
+	// Construct the server api arguments and output
+	api.Arguments = make(map[core.APIArgumentType]interface{})
+
+	// Construct Output parameters
+	var res = core.Success
+	var content = ""
+
+	if outputOpts.ServerOpts != nil {
+		// Validate the Output Options
+		_, err = outputOpts.Validate()
+		if err != nil {
+			return nil, err
+		}
+
+		// Construct get current server output server opts
+		bytes, err := yaml.Marshal(outputOpts.ServerOpts)
+		if err != nil {
+			return nil, err
+		}
+
+		content = string(bytes)
+		res = core.Success
+	} else if outputOpts.Error != "" {
+		res = core.Failed
+		content = outputOpts.Error
+	}
+
+	api.Output = &core.Output{
+		Result:  res,
+		Content: content,
+	}
+
+	if outputOpts.ValidationStrategy != "" {
+		api.Output.ValidationStrategy = outputOpts.ValidationStrategy
+	}
+
+	c.APIs = append(c.APIs, api)
+	return c, nil
+}
+
+// NewRemoveCurrentServerCommand constructs a command to make a call to specific runtime version RemoveCurrentServer API
+// Input Parameter inputOpts has all input parameters which are required for Runtime RemoveCurrentServer API
+// Input Parameter: outputOpts has details about expected output from Runtime RemoveCurrentServer API call
+// Return: command to execute or error if any validations fails for RemoveCurrentServerInputOptions or RemoveCurrentServerOutputOptions
+// This method does validate the input parameters  RemoveCurrentServerInputOptions/ RemoveCurrentServerOutputOptions based on Runtime API Version
+// For more details about supported parameters refer to RemoveCurrentServerInputOptions/ RemoveCurrentServerOutputOptions definition(and ServerOpts struct, which is embedded)
+func NewRemoveCurrentServerCommand(inputOpts *RemoveCurrentServerInputOptions, outputOpts *RemoveCurrentServerOutputOptions) (*core.Command, error) {
+	// Init the Command object
+	c := &core.Command{}
+
+	// Init the API object
+	api := &core.API{Name: core.RemoveCurrentServerAPIName}
+
+	// Validate the Input Options
+	_, err := inputOpts.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set API version
+	api.Version = inputOpts.RuntimeVersion
+
+	// Construct the server api arguments and output
+	api.Arguments = map[core.APIArgumentType]interface{}{
+		core.ServerName: inputOpts.ServerName,
+	}
+
+	// Construct Output parameters
+	var res core.Result
+	var content string
+
+	if outputOpts != nil && outputOpts.Error != "" {
+		res = core.Failed
+		content = outputOpts.Error
+	} else {
+		res = core.Success
+		content = ""
+	}
+	api.Output = &core.Output{
+		Result:  res,
+		Content: content,
+	}
+
+	c.APIs = append(c.APIs, api)
+
+	return c, nil
+}

--- a/test/compatibility/framework/server_commands.go
+++ b/test/compatibility/framework/server_commands.go
@@ -105,24 +105,26 @@ func NewGetServerCommand(inputOpts *GetServerInputOptions, outputOpts *GetServer
 	var res = core.Success
 	var content = ""
 
-	if outputOpts.Error != "" {
-		res = core.Failed
-		content = outputOpts.Error
-	} else if outputOpts.ServerOpts != nil {
-		// Validate the Output Options
-		_, err = outputOpts.Validate()
-		if err != nil {
-			return nil, err
-		}
+	if outputOpts != nil {
+		if outputOpts.ServerOpts != nil {
+			// Validate the Output Options
+			_, err = outputOpts.Validate()
+			if err != nil {
+				return nil, err
+			}
 
-		// Construct get server output server opts
-		bytes, err := yaml.Marshal(outputOpts.ServerOpts)
-		if err != nil {
-			return nil, err
-		}
+			// Construct get server output server opts
+			bytes, err := yaml.Marshal(outputOpts.ServerOpts)
+			if err != nil {
+				return nil, err
+			}
 
-		content = string(bytes)
-		res = core.Success
+			content = string(bytes)
+			res = core.Success
+		} else if outputOpts.Error != "" {
+			res = core.Failed
+			content = outputOpts.Error
+		}
 	}
 
 	api.Output = &core.Output{

--- a/test/compatibility/framework/server_commands_test.go
+++ b/test/compatibility/framework/server_commands_test.go
@@ -1,0 +1,308 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+)
+
+func TestNewSetServerCommand(t *testing.T) {
+	tests := []struct {
+		inputOpts  *SetServerInputOptions
+		outputOpts *SetServerOutputOptions
+		cmd        *core.Command
+		err        string
+	}{
+		{
+			&SetServerInputOptions{
+				RuntimeAPIVersion: &core.RuntimeAPIVersion{
+					RuntimeVersion: core.VersionLatest,
+				},
+				ServerOpts: &ServerOpts{
+					Name: "compatibility-one",
+					Type: ManagementClusterServerType,
+					GlobalOpts: &GlobalServerOpts{
+						Endpoint: "default-compatibility-test-endpoint",
+					},
+				},
+			}, nil,
+			&core.Command{
+				APIs: []*core.API{
+					{
+						Name:    core.SetServerAPIName,
+						Version: core.VersionLatest,
+						Arguments: map[core.APIArgumentType]interface{}{
+							core.Server: `name: compatibility-one
+type: managementcluster
+globalOpts:
+    endpoint: default-compatibility-test-endpoint
+`,
+							"setCurrent": false,
+						},
+						Output: &core.Output{
+							ValidationStrategy: "",
+							Result:             core.Success,
+							Content:            "",
+						},
+					},
+				},
+			}, "",
+		},
+	}
+
+	for _, tt := range tests {
+		cmd, err := NewSetServerCommand(tt.inputOpts, tt.outputOpts)
+		if tt.err != "" {
+			assert.Equal(t, tt.err, err.Error())
+		} else {
+			assert.Equal(t, tt.cmd, cmd)
+		}
+	}
+}
+
+func TestNewGetServerCommand(t *testing.T) {
+	tests := []struct {
+		inputOpts  *GetServerInputOptions
+		outputOpts *GetServerOutputOptions
+		cmd        *core.Command
+		err        string
+	}{
+		{
+			&GetServerInputOptions{
+				RuntimeAPIVersion: &core.RuntimeAPIVersion{
+					RuntimeVersion: core.VersionLatest,
+				},
+				ServerName: "compatibility-one",
+			}, &GetServerOutputOptions{
+				RuntimeAPIVersion: &core.RuntimeAPIVersion{
+					RuntimeVersion: core.Version0280,
+				},
+				ServerOpts: &ServerOpts{
+					Name: "compatibility-one",
+					Type: ManagementClusterServerType,
+					GlobalOpts: &GlobalServerOpts{
+						Endpoint: "default-compatibility-test-endpoint",
+					},
+				},
+			},
+			&core.Command{
+				APIs: []*core.API{
+					{
+						Name:    core.GetServerAPIName,
+						Version: core.VersionLatest,
+						Arguments: map[core.APIArgumentType]interface{}{
+							core.ServerName: "compatibility-one",
+						},
+						Output: &core.Output{
+							ValidationStrategy: "",
+							Result:             core.Success,
+							Content: `name: compatibility-one
+type: managementcluster
+globalOpts:
+    endpoint: default-compatibility-test-endpoint
+`,
+						},
+					},
+				},
+			}, "",
+		},
+	}
+
+	for _, tt := range tests {
+		cmd, err := NewGetServerCommand(tt.inputOpts, tt.outputOpts)
+		if tt.err != "" {
+			assert.Equal(t, tt.err, err.Error())
+		} else {
+			assert.Equal(t, tt.cmd, cmd)
+		}
+	}
+}
+
+func TestNewDeleteServerCommand(t *testing.T) {
+	tests := []struct {
+		inputOpts  *DeleteServerInputOptions
+		outputOpts *DeleteServerOutputOptions
+		cmd        *core.Command
+		err        string
+	}{
+		{
+			&DeleteServerInputOptions{
+				RuntimeAPIVersion: &core.RuntimeAPIVersion{
+					RuntimeVersion: core.VersionLatest,
+				},
+				ServerName: "compatibility-one",
+			}, nil,
+			&core.Command{
+				APIs: []*core.API{
+					{
+						Name:    core.DeleteServerAPIName,
+						Version: core.VersionLatest,
+						Arguments: map[core.APIArgumentType]interface{}{
+							core.ServerName: "compatibility-one",
+						},
+						Output: &core.Output{
+							ValidationStrategy: "",
+							Result:             core.Success,
+							Content:            "",
+						},
+					},
+				},
+			}, "",
+		},
+	}
+
+	for _, tt := range tests {
+		cmd, err := NewDeleteServerCommand(tt.inputOpts, tt.outputOpts)
+		if tt.err != "" {
+			assert.Equal(t, tt.err, err.Error())
+		} else {
+			assert.Equal(t, tt.cmd, cmd)
+		}
+	}
+}
+
+func TestNewSetCurrentServerCommand(t *testing.T) {
+	tests := []struct {
+		inputOpts  *SetCurrentServerInputOptions
+		outputOpts *SetCurrentServerOutputOptions
+		cmd        *core.Command
+		err        string
+	}{
+		{
+			&SetCurrentServerInputOptions{
+				RuntimeAPIVersion: &core.RuntimeAPIVersion{
+					RuntimeVersion: core.VersionLatest,
+				},
+				ServerName: "compatibility-one",
+			}, nil,
+			&core.Command{
+				APIs: []*core.API{
+					{
+						Name:    core.SetCurrentServerAPIName,
+						Version: core.VersionLatest,
+						Arguments: map[core.APIArgumentType]interface{}{
+							core.ServerName: "compatibility-one",
+						},
+						Output: &core.Output{
+							ValidationStrategy: "",
+							Result:             core.Success,
+							Content:            "",
+						},
+					},
+				},
+			}, "",
+		},
+	}
+
+	for _, tt := range tests {
+		cmd, err := NewSetCurrentServerCommand(tt.inputOpts, tt.outputOpts)
+		if tt.err != "" {
+			assert.Equal(t, tt.err, err.Error())
+		} else {
+			assert.Equal(t, tt.cmd, cmd)
+		}
+	}
+}
+
+func TestNewGetCurrentServerCommand(t *testing.T) {
+	tests := []struct {
+		inputOpts  *GetCurrentServerInputOptions
+		outputOpts *GetCurrentServerOutputOptions
+		cmd        *core.Command
+		err        string
+	}{
+		{
+			&GetCurrentServerInputOptions{
+				RuntimeAPIVersion: &core.RuntimeAPIVersion{
+					RuntimeVersion: core.VersionLatest,
+				},
+			}, &GetCurrentServerOutputOptions{
+				RuntimeAPIVersion: &core.RuntimeAPIVersion{
+					RuntimeVersion: core.Version0280,
+				},
+				ServerOpts: &ServerOpts{
+					Name: "compatibility-one",
+					Type: ManagementClusterServerType,
+					GlobalOpts: &GlobalServerOpts{
+						Endpoint: "default-compatibility-test-endpoint",
+					},
+				},
+			},
+			&core.Command{
+				APIs: []*core.API{
+					{
+						Name:      core.GetCurrentServerAPIName,
+						Version:   core.VersionLatest,
+						Arguments: map[core.APIArgumentType]interface{}{},
+						Output: &core.Output{
+							ValidationStrategy: "",
+							Result:             core.Success,
+							Content: `name: compatibility-one
+type: managementcluster
+globalOpts:
+    endpoint: default-compatibility-test-endpoint
+`,
+						},
+					},
+				},
+			}, "",
+		},
+	}
+
+	for _, tt := range tests {
+		cmd, err := NewGetCurrentServerCommand(tt.inputOpts, tt.outputOpts)
+		if tt.err != "" {
+			assert.Equal(t, tt.err, err.Error())
+		} else {
+			assert.Equal(t, tt.cmd, cmd)
+		}
+	}
+}
+
+func TestNewRemoveCurrentServerCommand(t *testing.T) {
+	tests := []struct {
+		inputOpts  *RemoveCurrentServerInputOptions
+		outputOpts *RemoveCurrentServerOutputOptions
+		cmd        *core.Command
+		err        string
+	}{
+		{
+			&RemoveCurrentServerInputOptions{
+				RuntimeAPIVersion: &core.RuntimeAPIVersion{
+					RuntimeVersion: core.VersionLatest,
+				},
+				ServerName: "compatibility-one",
+			}, nil,
+			&core.Command{
+				APIs: []*core.API{
+					{
+						Name:    core.RemoveCurrentServerAPIName,
+						Version: core.VersionLatest,
+						Arguments: map[core.APIArgumentType]interface{}{
+							core.ServerName: "compatibility-one",
+						},
+						Output: &core.Output{
+							ValidationStrategy: "",
+							Result:             core.Success,
+							Content:            "",
+						},
+					},
+				},
+			}, "",
+		},
+	}
+
+	for _, tt := range tests {
+		cmd, err := NewRemoveCurrentServerCommand(tt.inputOpts, tt.outputOpts)
+		if tt.err != "" {
+			assert.Equal(t, tt.err, err.Error())
+		} else {
+			assert.Equal(t, tt.cmd, cmd)
+		}
+	}
+}

--- a/test/compatibility/framework/server_options.go
+++ b/test/compatibility/framework/server_options.go
@@ -1,0 +1,86 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+)
+
+// GetServerInputOptions used to generate GetServer command
+type GetServerInputOptions struct {
+	*core.RuntimeAPIVersion        // required
+	ServerName              string // required
+}
+
+// GetServerOutputOptions used to generate GetServer command
+type GetServerOutputOptions struct {
+	*core.RuntimeAPIVersion                         // required
+	*ServerOpts                                     // For specific version options look into ServerOpts definition
+	ValidationStrategy      core.ValidationStrategy // Type of validation to be performed i.e. exact or partial. default is partial
+	Error                   string                  // expected error message could be the sub string of actual error message
+}
+
+// SetServerInputOptions used to generate SetServer command
+type SetServerInputOptions struct {
+	*core.RuntimeAPIVersion      // required
+	*ServerOpts                  // required
+	SetCurrentServer        bool // required
+}
+
+// SetServerOutputOptions used to generate SetServer command
+type SetServerOutputOptions struct {
+	ValidationStrategy core.ValidationStrategy // Type of validation to be performed i.e. exact or partial. default is partial
+	Error              string                  // expected error message could be the sub string of actual error message
+}
+
+// DeleteServerInputOptions used to generate DeleteServer command
+type DeleteServerInputOptions struct {
+	*core.RuntimeAPIVersion        // required
+	ServerName              string // required
+}
+
+// DeleteServerOutputOptions used to generate DeleteServer command
+type DeleteServerOutputOptions struct {
+	*core.RuntimeAPIVersion                         // required
+	ValidationStrategy      core.ValidationStrategy // Type of validation to be performed i.e. exact or partial. default is partial
+	Error                   string                  // expected error message could be the sub string of actual error message
+}
+
+// SetCurrentServerInputOptions used to generate SetCurrentServer command
+type SetCurrentServerInputOptions struct {
+	*core.RuntimeAPIVersion        // required
+	ServerName              string // required
+}
+
+// SetCurrentServerOutputOptions used to generate SetCurrentServer command
+type SetCurrentServerOutputOptions struct {
+	*core.RuntimeAPIVersion        // required
+	Error                   string // expected error message could be the sub string of actual error message
+}
+
+// GetCurrentServerInputOptions used to generate GetCurrentServer command
+type GetCurrentServerInputOptions struct {
+	*core.RuntimeAPIVersion // required
+}
+
+// GetCurrentServerOutputOptions used to generate GetCurrentServer command
+type GetCurrentServerOutputOptions struct {
+	*core.RuntimeAPIVersion                         // required
+	*ServerOpts                                     // For specific version options look into ServerOpts definition
+	ValidationStrategy      core.ValidationStrategy // Type of validation to be performed i.e. exact or partial. default is partial
+	Error                   string                  // expected error message could be the sub string of actual error message
+}
+
+// RemoveCurrentServerInputOptions used to generate RemoveCurrentServer command
+type RemoveCurrentServerInputOptions struct {
+	*core.RuntimeAPIVersion        // required
+	ServerName              string // required for v1.0.0 - v0.28.0
+}
+
+// RemoveCurrentServerOutputOptions used to generate RemoveCurrentServer command
+type RemoveCurrentServerOutputOptions struct {
+	*core.RuntimeAPIVersion                         // required
+	ValidationStrategy      core.ValidationStrategy // Type of validation to be performed i.e. exact or partial. default is partial
+	Error                   string                  // expected error message could be the sub string of actual error message
+}

--- a/test/compatibility/framework/server_validators.go
+++ b/test/compatibility/framework/server_validators.go
@@ -36,7 +36,7 @@ func (opts *SetServerInputOptions) Validate() (bool, error) {
 	}
 
 	switch opts.RuntimeVersion {
-	case core.VersionLatest, core.Version0280, core.Version0254:
+	case core.VersionLatest, core.Version0280, core.Version0254, core.Version0116:
 		if !opts.ValidName() {
 			return false, fmt.Errorf("invalid 'name' for set server input options for the specified runtime version %v", opts.RuntimeVersion)
 		}

--- a/test/compatibility/framework/server_validators.go
+++ b/test/compatibility/framework/server_validators.go
@@ -1,0 +1,119 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+)
+
+func (opts *ServerOpts) ValidName() bool {
+	return opts.Name != ""
+}
+
+func (opts *ServerOpts) ValidServerType() bool {
+	return opts.Type != "" && (opts.Type == ManagementClusterServerType || opts.Type == GlobalServerType)
+}
+
+func (opts *ServerOpts) ValidGlobalOptsOrManagementClusterOpts() bool {
+	return (opts.GlobalOpts != nil && opts.GlobalOpts.Endpoint != "") || (opts.ManagementClusterOpts != nil && opts.ManagementClusterOpts.Endpoint != "")
+}
+
+func (opts *ServerOpts) ValidDiscoverySources() bool {
+	return opts.DiscoverySources != nil || len(opts.DiscoverySources) == 0
+}
+
+// Validate  the setServerInputOptions as per runtime version i.e. check whether mandatory fields are set and throw error if missing
+func (opts *SetServerInputOptions) Validate() (bool, error) {
+	// Run Core Validators
+	_, err := opts.RuntimeAPIVersion.Validate()
+	if err != nil {
+		return false, err
+	}
+
+	switch opts.RuntimeVersion {
+	case core.VersionLatest, core.Version0280, core.Version0254:
+		if !opts.ValidName() {
+			return false, fmt.Errorf("invalid 'name' for set server input options for the specified runtime version %v", opts.RuntimeVersion)
+		}
+		if !opts.ValidServerType() {
+			return false, fmt.Errorf("invalid 'type' for set server input options for the specified runtime version %v", opts.RuntimeVersion)
+		}
+		if !opts.ValidGlobalOptsOrManagementClusterOpts() {
+			return false, fmt.Errorf("invalid 'global or clusterOpts' for set server input options for the specified runtime version %v", opts.RuntimeVersion)
+		}
+		return true, nil
+	default:
+		return false, errors.New("SetServer API is not supported for the specified runtime version")
+	}
+}
+
+// Validate the opts as per runtime version i.e. check whether the expected fields are supported for the runtime version specified
+func (opts *GetServerInputOptions) Validate() (bool, error) {
+	_, err := opts.RuntimeAPIVersion.Validate()
+	if err != nil {
+		return false, err
+	}
+
+	if opts.ServerName == "" {
+		return false, errors.New("server name is required")
+	}
+	return true, nil
+}
+
+// Validate the opts as per runtime version i.e. check whether the expected fields are supported for the runtime version specified
+func (opts *GetServerOutputOptions) Validate() (bool, error) {
+	_, err := opts.RuntimeAPIVersion.Validate()
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Validate the opts as per runtime version i.e. check whether the expected fields are supported for the runtime version specified
+func (opts *DeleteServerInputOptions) Validate() (bool, error) {
+	_, err := opts.RuntimeAPIVersion.Validate()
+	if err != nil {
+		return false, err
+	}
+	if opts.ServerName == "" {
+		return false, errors.New("server name is required")
+	}
+	return true, nil
+}
+
+// Validate the opts as per runtime version i.e. check whether the expected fields are supported for the runtime version specified
+func (opts *GetCurrentServerInputOptions) Validate() (bool, error) {
+	_, err := opts.RuntimeAPIVersion.Validate()
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Validate the opts as per runtime version i.e. check whether the expected fields are supported for the runtime version specified
+func (opts *SetCurrentServerInputOptions) Validate() (bool, error) {
+	// Run Core Validators
+	_, err := opts.RuntimeAPIVersion.Validate()
+	if err != nil {
+		return false, err
+	}
+	if opts.ServerName == "" {
+		return false, errors.New("server name is required")
+	}
+	return true, nil
+}
+
+// Validate the getServerOutputOptions as per runtime version i.e. check whether the expected fields are supported for the runtime version specified
+func (opts *GetCurrentServerOutputOptions) Validate() (bool, error) {
+	// Run Core Validators
+	_, err := opts.RuntimeAPIVersion.Validate()
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/parser.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/parser.go
@@ -18,3 +18,13 @@ func parseContext(context string) (*configtypes.Context, error) {
 	}
 	return &ctx, nil
 }
+
+// parseServer unmarshalls string to Server struct
+func parseServer(server string) (*configtypes.Server, error) {
+	var s configtypes.Server
+	err := yaml.Unmarshal([]byte(server), &s)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/parser_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/parser_test.go
@@ -51,3 +51,44 @@ globalOpts:
 		})
 	}
 }
+
+func TestParseServer(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverStr      string
+		err            string
+		expectedServer *configtypes.Server
+	}{
+		{
+			name: "Parse valid context str",
+			serverStr: `name: compatibility-test-one
+type: managementcluster
+globalOpts:
+    endpoint: default-compatibility-test-endpoint
+`,
+			expectedServer: &configtypes.Server{
+				Name: "compatibility-test-one",
+				Type: configtypes.ManagementClusterServerType,
+				GlobalOpts: &configtypes.GlobalServer{
+					Endpoint: "default-compatibility-test-endpoint",
+				},
+			},
+		},
+		{
+			name:      "Failed to parse invalid string",
+			serverStr: `name`,
+			err:       "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `name` into types.Server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseServer(tt.serverStr)
+			if tt.err != "" || err != nil {
+				assert.Equal(t, tt.err, err.Error())
+			} else {
+				assert.Equal(t, tt.expectedServer, actual)
+			}
+		})
+	}
+}

--- a/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_apis.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_apis.go
@@ -18,6 +18,15 @@ var apiHandlers = map[core.RuntimeAPIName]func(*core.API) *core.APIResponse{
 	core.SetCurrentContextAPIName:    triggerSetCurrentContextAPI,
 	core.GetCurrentContextAPIName:    triggerGetCurrentContextAPI,
 	core.RemoveCurrentContextAPIName: triggerRemoveCurrentContextAPI,
+	core.SetServerAPIName:            triggerSetServerAPI,
+	core.AddServerAPIName:            triggerSetServerAPI,
+	core.PutServerAPIName:            triggerSetServerAPI,
+	core.GetServerAPIName:            triggerGetServerAPI,
+	core.RemoveServerAPIName:         triggerRemoveServerAPI,
+	core.DeleteServerAPIName:         triggerRemoveServerAPI,
+	core.SetCurrentServerAPIName:     triggerSetCurrentServerAPI,
+	core.GetCurrentServerAPIName:     triggerGetCurrentServerAPI,
+	core.RemoveCurrentServerAPIName:  triggerRemoveCurrentServerAPI,
 }
 
 // triggerAPIs trigger runtime apis and construct logs

--- a/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_context_apis_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_context_apis_test.go
@@ -1,0 +1,348 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+)
+
+func TestTriggerContextAPIs(t *testing.T) {
+	_, cleanup := core.SetupTempCfgFiles()
+	defer func() {
+		cleanup()
+	}()
+	ctx := `name: context-one
+target: kubernetes
+globalOpts:
+  endpoint: test-endpoint
+`
+	var tests = []struct {
+		name         string
+		apiName      core.RuntimeAPIName
+		apis         []core.API
+		expectedLogs map[core.RuntimeAPIName][]core.APILog
+	}{
+		{
+			name:    "Trigger SetContext API",
+			apiName: core.SetContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.SetContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger GetContext API",
+			apiName: core.GetContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.GetContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: ctx,
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.GetContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: &configtypes.Context{
+								Name:   "context-one",
+								Target: "kubernetes",
+								GlobalOpts: &configtypes.GlobalServer{
+									Endpoint: "test-endpoint",
+								},
+							},
+							ResponseType: core.MapResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger RemoveContext API",
+			apiName: core.RemoveContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.RemoveContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.RemoveContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger DeleteContext API",
+			apiName: core.DeleteContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.DeleteContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.DeleteContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger SetCurrentContext API",
+			apiName: core.SetCurrentContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.SetCurrentContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger GetCurrentContext API",
+			apiName: core.GetCurrentContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.GetCurrentContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Target: "kubernetes",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: ctx,
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.GetCurrentContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: &configtypes.Context{
+								Name:   "context-one",
+								Target: "kubernetes",
+								GlobalOpts: &configtypes.GlobalServer{
+									Endpoint: "test-endpoint",
+								},
+							},
+							ResponseType: core.MapResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger RemoveCurrentContext API",
+			apiName: core.RemoveCurrentContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.RemoveCurrentContextAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Target: "kubernetes",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.RemoveCurrentContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualLogs := triggerAPIs(tt.apis)
+			assert.Equal(t, tt.expectedLogs[tt.apiName], actualLogs[tt.apiName])
+		})
+	}
+}

--- a/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_server_apis.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_server_apis.go
@@ -6,8 +6,8 @@ package cmd
 import (
 	"fmt"
 
-	configtypes "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
-	configlib "github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
+	configlib "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
 )
 
@@ -69,10 +69,22 @@ func triggerGetCurrentServerAPI(*core.API) *core.APIResponse {
 	return getCurrentServer()
 }
 
+// triggerRemoveCurrentServerAPI trigger remove server runtime api
+func triggerRemoveCurrentServerAPI(api *core.API) *core.APIResponse {
+	// Parse arguments needed to trigger the runtime api
+	serverName, err := core.ParseStr(api.Arguments[core.ServerName])
+	if err != nil {
+		return &core.APIResponse{
+			ResponseType: core.ErrorResponse,
+			ResponseBody: fmt.Errorf("failed to parse string from argument %v with error %v ", core.Target, err.Error()),
+		}
+	}
+	return removeCurrentServer(serverName)
+}
+
 func getServer(serverName string) *core.APIResponse {
 	// Call runtime GetServer API
 	server, err := configlib.GetServer(serverName)
-
 	if err != nil {
 		return &core.APIResponse{
 			ResponseType: core.ErrorResponse,
@@ -154,5 +166,19 @@ func getCurrentServer() *core.APIResponse {
 	return &core.APIResponse{
 		ResponseType: core.MapResponse,
 		ResponseBody: server,
+	}
+}
+
+func removeCurrentServer(serverName string) *core.APIResponse {
+	err := configlib.RemoveCurrentServer(serverName)
+	if err != nil {
+		return &core.APIResponse{
+			ResponseType: core.ErrorResponse,
+			ResponseBody: err.Error(),
+		}
+	}
+	return &core.APIResponse{
+		ResponseBody: "",
+		ResponseType: core.StringResponse,
 	}
 }

--- a/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_server_apis_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_server_apis_test.go
@@ -8,23 +8,20 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	configapi "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
-
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
 )
 
-func TestTriggerAPIs(t *testing.T) {
+func TestTriggerServerAPIs(t *testing.T) {
 	_, cleanup := core.SetupTempCfgFiles()
 	defer func() {
 		cleanup()
 	}()
-
-	ctx := `name: context-one
-type: k8s
+	server := `name: compatibility-test-one
+type: managementcluster
 globalOpts:
-  endpoint: test-endpoint
+    endpoint: test-endpoint
 `
-
 	var tests = []struct {
 		name         string
 		apiName      core.RuntimeAPIName
@@ -32,14 +29,14 @@ globalOpts:
 		expectedLogs map[core.RuntimeAPIName][]core.APILog
 	}{
 		{
-			name:    "Trigger SetContext API",
-			apiName: core.SetContextAPIName,
+			name:    "Trigger SetServerAPI",
+			apiName: core.SetServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
+					Name:    core.SetServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -50,7 +47,7 @@ globalOpts:
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.SetContextAPIName: {
+				core.SetServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: "",
@@ -62,14 +59,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger GetContext API",
-			apiName: core.GetContextAPIName,
+			name:    "Trigger GetServerAPI",
+			apiName: core.GetServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
+					Name:    core.SetServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -78,26 +75,26 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.GetContextAPIName,
+					Name:    core.GetServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
-						Content: ctx,
+						Content: server,
 					},
 				},
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.GetContextAPIName: {
+				core.GetServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
-							ResponseBody: &configapi.Context{
-								Name: "context-one",
-								Type: "k8s",
-								GlobalOpts: &configapi.GlobalServer{
+							ResponseBody: &configtypes.Server{
+								Name: "compatibility-test-one",
+								Type: configtypes.ManagementClusterServerType,
+								GlobalOpts: &configtypes.GlobalServer{
 									Endpoint: "test-endpoint",
 								},
 							},
@@ -109,14 +106,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger RemoveContext API",
-			apiName: core.RemoveContextAPIName,
+			name:    "Trigger RemoveServerAPI",
+			apiName: core.RemoveServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
+					Name:    core.SetServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -125,10 +122,10 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.RemoveContextAPIName,
+					Name:    core.RemoveServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
@@ -138,7 +135,7 @@ globalOpts:
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.RemoveContextAPIName: {
+				core.RemoveServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: "",
@@ -150,14 +147,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger DeleteContext API",
-			apiName: core.DeleteContextAPIName,
+			name:    "Trigger DeleteServerAPI",
+			apiName: core.DeleteServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
+					Name:    core.SetServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -166,10 +163,10 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.DeleteContextAPIName,
+					Name:    core.DeleteServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
@@ -179,7 +176,7 @@ globalOpts:
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.DeleteContextAPIName: {
+				core.DeleteServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: "",
@@ -191,14 +188,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger SetCurrentContext API",
-			apiName: core.SetCurrentContextAPIName,
+			name:    "Trigger SetCurrentServerAPI",
+			apiName: core.SetCurrentServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
+					Name:    core.SetServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -207,10 +204,10 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.SetCurrentContextAPIName,
+					Name:    core.SetCurrentServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
@@ -220,7 +217,7 @@ globalOpts:
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.SetCurrentContextAPIName: {
+				core.SetCurrentServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: "",
@@ -232,14 +229,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger GetCurrentContext API",
-			apiName: core.GetCurrentContextAPIName,
+			name:    "Trigger GetCurrentServerAPI",
+			apiName: core.GetCurrentServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
+					Name:    core.SetServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -248,10 +245,10 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.SetCurrentContextAPIName,
+					Name:    core.SetCurrentServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
@@ -259,30 +256,82 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.GetCurrentContextAPIName,
+					Name:    core.GetCurrentServerAPIName,
 					Version: core.VersionLatest,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextType: "k8s",
+						core.Target: "kubernetes",
 					},
 					Output: &core.Output{
 						Result:  "success",
-						Content: ctx,
+						Content: server,
 					},
 				},
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.GetCurrentContextAPIName: {
+				core.GetCurrentServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
-							ResponseBody: &configapi.Context{
-								Name: "context-one",
-								Type: "k8s",
-								GlobalOpts: &configapi.GlobalServer{
+							ResponseBody: &configtypes.Server{
+								Name: "compatibility-test-one",
+								Type: configtypes.ManagementClusterServerType,
+								GlobalOpts: &configtypes.GlobalServer{
 									Endpoint: "test-endpoint",
 								},
 							},
 							ResponseType: core.MapResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger RemoveCurrentServerAPI",
+			apiName: core.RemoveCurrentServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentServerAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.RemoveCurrentServerAPIName,
+					Version: core.VersionLatest,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.RemoveCurrentServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
 						},
 					},
 				},

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_11_6/cmd/parser_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_11_6/cmd/parser_test.go
@@ -8,49 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	configtypes "github.com/vmware-tanzu/tanzu-framework/cli/runtime/apis/config/v1alpha1"
+	configtypes "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 )
-
-func TestParseContext(t *testing.T) {
-	tests := []struct {
-		name            string
-		ctxStr          string
-		err             string
-		expectedContext *configtypes.Context
-	}{
-		{
-			name: "Parse valid context str",
-			ctxStr: `name: context-one
-target: kubernetes
-globalOpts:
-  endpoint: test-endpoint
-`,
-			expectedContext: &configtypes.Context{
-				Name:   "context-one",
-				Target: "kubernetes",
-				GlobalOpts: &configtypes.GlobalServer{
-					Endpoint: "test-endpoint",
-				},
-			},
-		},
-		{
-			name:   "Failed to parse invalid string",
-			ctxStr: `name`,
-			err:    "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `name` into v1alpha1.Context",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual, err := parseContext(tt.ctxStr)
-			if tt.err != "" || err != nil {
-				assert.Equal(t, tt.err, err.Error())
-			} else {
-				assert.Equal(t, tt.expectedContext, actual)
-			}
-		})
-	}
-}
 
 func TestParseServer(t *testing.T) {
 	tests := []struct {

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_11_6/cmd/trigger_server_apis_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_11_6/cmd/trigger_server_apis_test.go
@@ -1,0 +1,296 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configtypes "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+)
+
+func TestTriggerServerAPIs(t *testing.T) {
+	_, cleanup := core.SetupTempCfgFiles()
+	defer func() {
+		cleanup()
+	}()
+	server := `name: compatibility-test-one
+type: managementcluster
+globalOpts:
+    endpoint: test-endpoint
+`
+	var tests = []struct {
+		name         string
+		apiName      core.RuntimeAPIName
+		apis         []core.API
+		expectedLogs map[core.RuntimeAPIName][]core.APILog
+	}{
+		{
+			name:    "Trigger SetServerAPI",
+			apiName: core.SetServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.SetServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger GetServerAPI",
+			apiName: core.GetServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.GetServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: server,
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.GetServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: &configtypes.Server{
+								Name: "compatibility-test-one",
+								Type: configtypes.ManagementClusterServerType,
+								GlobalOpts: &configtypes.GlobalServer{
+									Endpoint: "test-endpoint",
+								},
+							},
+							ResponseType: core.MapResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger RemoveServerAPI",
+			apiName: core.RemoveServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.RemoveServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.RemoveServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger DeleteServerAPI",
+			apiName: core.DeleteServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.DeleteServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.DeleteServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger SetCurrentServerAPI",
+			apiName: core.SetCurrentServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.SetCurrentServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger GetCurrentServerAPI",
+			apiName: core.GetCurrentServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.GetCurrentServerAPIName,
+					Version: core.Version0116,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Target: "kubernetes",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: server,
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.GetCurrentServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: &configtypes.Server{
+								Name: "compatibility-test-one",
+								Type: configtypes.ManagementClusterServerType,
+								GlobalOpts: &configtypes.GlobalServer{
+									Endpoint: "test-endpoint",
+								},
+							},
+							ResponseType: core.MapResponse,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualLogs := triggerAPIs(tt.apis)
+			assert.Equal(t, tt.expectedLogs[tt.apiName], actualLogs[tt.apiName])
+		})
+	}
+}

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_11_6/go.mod
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_11_6/go.mod
@@ -12,6 +12,7 @@ replace (
 
 require (
 	github.com/spf13/cobra v1.6.1
+	github.com/stretchr/testify v1.8.1
 	github.com/vmware-tanzu/tanzu-framework v0.11.6
 	github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.1

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/parser.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/parser.go
@@ -18,3 +18,13 @@ func parseContext(context string) (*configapi.Context, error) {
 	}
 	return &ctx, nil
 }
+
+// parseServer unmarshalls string to Server struct
+func parseServer(server string) (*configapi.Server, error) {
+	var s configapi.Server
+	err := yaml.Unmarshal([]byte(server), &s)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/parser_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/parser_test.go
@@ -51,3 +51,44 @@ globalOpts:
 		})
 	}
 }
+
+func TestParseServer(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverStr      string
+		err            string
+		expectedServer *configapi.Server
+	}{
+		{
+			name: "Parse valid context str",
+			serverStr: `name: compatibility-test-one
+type: managementcluster
+globalOpts:
+    endpoint: default-compatibility-test-endpoint
+`,
+			expectedServer: &configapi.Server{
+				Name: "compatibility-test-one",
+				Type: configapi.ManagementClusterServerType,
+				GlobalOpts: &configapi.GlobalServer{
+					Endpoint: "default-compatibility-test-endpoint",
+				},
+			},
+		},
+		{
+			name:      "Failed to parse invalid string",
+			serverStr: `name`,
+			err:       "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `name` into v1alpha1.Server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseServer(tt.serverStr)
+			if tt.err != "" || err != nil {
+				assert.Equal(t, tt.err, err.Error())
+			} else {
+				assert.Equal(t, tt.expectedServer, actual)
+			}
+		})
+	}
+}

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/trigger_apis.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/trigger_apis.go
@@ -18,6 +18,14 @@ var apiHandlers = map[core.RuntimeAPIName]func(*core.API) *core.APIResponse{
 	core.DeleteContextAPIName:     triggerRemoveContextAPI,
 	core.SetCurrentContextAPIName: triggerSetCurrentContextAPI,
 	core.GetCurrentContextAPIName: triggerGetCurrentContextAPI,
+	core.SetServerAPIName:         triggerSetServerAPI,
+	core.AddServerAPIName:         triggerSetServerAPI,
+	core.PutServerAPIName:         triggerSetServerAPI,
+	core.GetServerAPIName:         triggerGetServerAPI,
+	core.RemoveServerAPIName:      triggerRemoveServerAPI,
+	core.DeleteServerAPIName:      triggerRemoveServerAPI,
+	core.SetCurrentServerAPIName:  triggerSetCurrentServerAPI,
+	core.GetCurrentServerAPIName:  triggerGetCurrentServerAPI,
 }
 
 // triggerAPIs trigger runtime apis and construct logs
@@ -49,6 +57,5 @@ func triggerAPIs(apis []core.API) map[core.RuntimeAPIName][]core.APILog {
 		}
 		logs[api.Name] = append(logs[api.Name], log)
 	}
-
 	return logs
 }

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/trigger_context_apis_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/trigger_context_apis_test.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	configapi "github.com/vmware-tanzu/tanzu-framework/cli/runtime/apis/config/v1alpha1"
+	configapi "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
 )
 
@@ -17,11 +18,13 @@ func TestTriggerAPIs(t *testing.T) {
 	defer func() {
 		cleanup()
 	}()
+
 	ctx := `name: context-one
-target: kubernetes
+type: k8s
 globalOpts:
   endpoint: test-endpoint
 `
+
 	var tests = []struct {
 		name         string
 		apiName      core.RuntimeAPIName
@@ -34,7 +37,7 @@ globalOpts:
 			apis: []core.API{
 				{
 					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.Context:    ctx,
 						core.SetCurrent: false,
@@ -64,7 +67,7 @@ globalOpts:
 			apis: []core.API{
 				{
 					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.Context:    ctx,
 						core.SetCurrent: false,
@@ -76,7 +79,7 @@ globalOpts:
 				},
 				{
 					Name:    core.GetContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.ContextName: "context-one",
 					},
@@ -92,8 +95,8 @@ globalOpts:
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: &configapi.Context{
-								Name:   "context-one",
-								Target: "kubernetes",
+								Name: "context-one",
+								Type: "k8s",
 								GlobalOpts: &configapi.GlobalServer{
 									Endpoint: "test-endpoint",
 								},
@@ -111,7 +114,7 @@ globalOpts:
 			apis: []core.API{
 				{
 					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.Context:    ctx,
 						core.SetCurrent: false,
@@ -123,7 +126,7 @@ globalOpts:
 				},
 				{
 					Name:    core.RemoveContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.ContextName: "context-one",
 					},
@@ -152,7 +155,7 @@ globalOpts:
 			apis: []core.API{
 				{
 					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.Context:    ctx,
 						core.SetCurrent: false,
@@ -164,7 +167,7 @@ globalOpts:
 				},
 				{
 					Name:    core.DeleteContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.ContextName: "context-one",
 					},
@@ -193,7 +196,7 @@ globalOpts:
 			apis: []core.API{
 				{
 					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.Context:    ctx,
 						core.SetCurrent: false,
@@ -205,7 +208,7 @@ globalOpts:
 				},
 				{
 					Name:    core.SetCurrentContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.ContextName: "context-one",
 					},
@@ -234,7 +237,7 @@ globalOpts:
 			apis: []core.API{
 				{
 					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.Context:    ctx,
 						core.SetCurrent: false,
@@ -246,7 +249,7 @@ globalOpts:
 				},
 				{
 					Name:    core.SetCurrentContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.ContextName: "context-one",
 					},
@@ -257,9 +260,9 @@ globalOpts:
 				},
 				{
 					Name:    core.GetCurrentContextAPIName,
-					Version: core.VersionLatest,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Target: "kubernetes",
+						core.ContextType: "k8s",
 					},
 					Output: &core.Output{
 						Result:  "success",
@@ -273,65 +276,13 @@ globalOpts:
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: &configapi.Context{
-								Name:   "context-one",
-								Target: "kubernetes",
+								Name: "context-one",
+								Type: "k8s",
 								GlobalOpts: &configapi.GlobalServer{
 									Endpoint: "test-endpoint",
 								},
 							},
 							ResponseType: core.MapResponse,
-						},
-					},
-				},
-			},
-		},
-
-		{
-			name:    "Trigger RemoveCurrentContext API",
-			apiName: core.RemoveCurrentContextAPIName,
-			apis: []core.API{
-				{
-					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
-					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
-						core.SetCurrent: false,
-					},
-					Output: &core.Output{
-						Result:  "success",
-						Content: "",
-					},
-				},
-				{
-					Name:    core.SetCurrentContextAPIName,
-					Version: core.VersionLatest,
-					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
-					},
-					Output: &core.Output{
-						Result:  "success",
-						Content: "",
-					},
-				},
-				{
-					Name:    core.RemoveCurrentContextAPIName,
-					Version: core.VersionLatest,
-					Arguments: map[core.APIArgumentType]interface{}{
-						core.Target: "kubernetes",
-					},
-					Output: &core.Output{
-						Result:  "success",
-						Content: "",
-					},
-				},
-			},
-
-			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.RemoveCurrentContextAPIName: {
-					{
-						APIResponse: &core.APIResponse{
-							ResponseBody: "",
-							ResponseType: core.StringResponse,
 						},
 					},
 				},

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/trigger_server_apis.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/trigger_server_apis.go
@@ -6,7 +6,7 @@ package cmd
 import (
 	"fmt"
 
-	configtypes "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+	configapi "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 	configlib "github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
 )
@@ -69,29 +69,7 @@ func triggerGetCurrentServerAPI(*core.API) *core.APIResponse {
 	return getCurrentServer()
 }
 
-func getServer(serverName string) *core.APIResponse {
-	// Call runtime GetServer API
-	server, err := configlib.GetServer(serverName)
-
-	if err != nil {
-		return &core.APIResponse{
-			ResponseType: core.ErrorResponse,
-			ResponseBody: err.Error(),
-		}
-	}
-	if server == nil {
-		return &core.APIResponse{
-			ResponseType: core.ErrorResponse,
-			ResponseBody: fmt.Errorf("server %v not found", server),
-		}
-	}
-	return &core.APIResponse{
-		ResponseType: core.MapResponse,
-		ResponseBody: server,
-	}
-}
-
-func setServer(server *configtypes.Server, setCurrent bool) *core.APIResponse {
+func setServer(server *configapi.Server, setCurrent bool) *core.APIResponse {
 	// Call runtime SetServer API
 	err := configlib.AddServer(server, setCurrent)
 	if err != nil {
@@ -122,6 +100,26 @@ func removeServer(serverName string) *core.APIResponse {
 	}
 }
 
+func getCurrentServer() *core.APIResponse {
+	server, err := configlib.GetCurrentServer()
+	if err != nil {
+		return &core.APIResponse{
+			ResponseType: core.ErrorResponse,
+			ResponseBody: err.Error(),
+		}
+	}
+	if server == nil {
+		return &core.APIResponse{
+			ResponseType: core.ErrorResponse,
+			ResponseBody: fmt.Errorf("server not found"),
+		}
+	}
+	return &core.APIResponse{
+		ResponseType: core.MapResponse,
+		ResponseBody: server,
+	}
+}
+
 func setCurrentServer(serverName string) *core.APIResponse {
 	// Call runtime SetCurrentServer API
 	err := configlib.SetCurrentServer(serverName)
@@ -137,8 +135,10 @@ func setCurrentServer(serverName string) *core.APIResponse {
 	}
 }
 
-func getCurrentServer() *core.APIResponse {
-	server, err := configlib.GetCurrentServer()
+func getServer(serverName string) *core.APIResponse {
+	// Call runtime GetServer API
+	server, err := configlib.GetServer(serverName)
+
 	if err != nil {
 		return &core.APIResponse{
 			ResponseType: core.ErrorResponse,
@@ -148,7 +148,7 @@ func getCurrentServer() *core.APIResponse {
 	if server == nil {
 		return &core.APIResponse{
 			ResponseType: core.ErrorResponse,
-			ResponseBody: fmt.Errorf("server not found"),
+			ResponseBody: fmt.Errorf("server %v not found", server),
 		}
 	}
 	return &core.APIResponse{

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/trigger_server_apis_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_25_4/cmd/trigger_server_apis_test.go
@@ -8,19 +8,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+	configtypes "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
 )
 
-func TestTriggerAPIs(t *testing.T) {
+func TestTriggerServerAPIs(t *testing.T) {
 	_, cleanup := core.SetupTempCfgFiles()
 	defer func() {
 		cleanup()
 	}()
-	ctx := `name: context-one
-target: kubernetes
+	server := `name: compatibility-test-one
+type: managementcluster
 globalOpts:
-  endpoint: test-endpoint
+    endpoint: test-endpoint
 `
 	var tests = []struct {
 		name         string
@@ -29,14 +29,14 @@ globalOpts:
 		expectedLogs map[core.RuntimeAPIName][]core.APILog
 	}{
 		{
-			name:    "Trigger SetContext API",
-			apiName: core.SetContextAPIName,
+			name:    "Trigger SetServerAPI",
+			apiName: core.SetServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.SetServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -47,7 +47,7 @@ globalOpts:
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.SetContextAPIName: {
+				core.SetServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: "",
@@ -59,14 +59,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger GetContext API",
-			apiName: core.GetContextAPIName,
+			name:    "Trigger GetServerAPI",
+			apiName: core.GetServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.SetServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -75,25 +75,25 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.GetContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.GetServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
-						Content: ctx,
+						Content: server,
 					},
 				},
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.GetContextAPIName: {
+				core.GetServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
-							ResponseBody: &configtypes.Context{
-								Name:   "context-one",
-								Target: "kubernetes",
+							ResponseBody: &configtypes.Server{
+								Name: "compatibility-test-one",
+								Type: configtypes.ManagementClusterServerType,
 								GlobalOpts: &configtypes.GlobalServer{
 									Endpoint: "test-endpoint",
 								},
@@ -106,14 +106,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger RemoveContext API",
-			apiName: core.RemoveContextAPIName,
+			name:    "Trigger RemoveServerAPI",
+			apiName: core.RemoveServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.SetServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -122,10 +122,10 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.RemoveContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.RemoveServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
@@ -135,7 +135,7 @@ globalOpts:
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.RemoveContextAPIName: {
+				core.RemoveServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: "",
@@ -147,14 +147,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger DeleteContext API",
-			apiName: core.DeleteContextAPIName,
+			name:    "Trigger DeleteServerAPI",
+			apiName: core.DeleteServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.SetServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -163,10 +163,10 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.DeleteContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.DeleteServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
@@ -176,7 +176,7 @@ globalOpts:
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.DeleteContextAPIName: {
+				core.DeleteServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: "",
@@ -188,14 +188,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger SetCurrentContext API",
-			apiName: core.SetCurrentContextAPIName,
+			name:    "Trigger SetCurrentServerAPI",
+			apiName: core.SetCurrentServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.SetServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -204,10 +204,10 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.SetCurrentContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.SetCurrentServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
@@ -217,7 +217,7 @@ globalOpts:
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.SetCurrentContextAPIName: {
+				core.SetCurrentServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
 							ResponseBody: "",
@@ -229,14 +229,14 @@ globalOpts:
 		},
 
 		{
-			name:    "Trigger GetCurrentContext API",
-			apiName: core.GetCurrentContextAPIName,
+			name:    "Trigger GetCurrentServerAPI",
+			apiName: core.GetCurrentServerAPIName,
 			apis: []core.API{
 				{
-					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.SetServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
+						core.Server:     server,
 						core.SetCurrent: false,
 					},
 					Output: &core.Output{
@@ -245,10 +245,10 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.SetCurrentContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.SetCurrentServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
+						core.ServerName: "compatibility-test-one",
 					},
 					Output: &core.Output{
 						Result:  "success",
@@ -256,82 +256,30 @@ globalOpts:
 					},
 				},
 				{
-					Name:    core.GetCurrentContextAPIName,
-					Version: core.VersionLatest,
+					Name:    core.GetCurrentServerAPIName,
+					Version: core.Version0254,
 					Arguments: map[core.APIArgumentType]interface{}{
 						core.Target: "kubernetes",
 					},
 					Output: &core.Output{
 						Result:  "success",
-						Content: ctx,
+						Content: server,
 					},
 				},
 			},
 
 			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.GetCurrentContextAPIName: {
+				core.GetCurrentServerAPIName: {
 					{
 						APIResponse: &core.APIResponse{
-							ResponseBody: &configtypes.Context{
-								Name:   "context-one",
-								Target: "kubernetes",
+							ResponseBody: &configtypes.Server{
+								Name: "compatibility-test-one",
+								Type: configtypes.ManagementClusterServerType,
 								GlobalOpts: &configtypes.GlobalServer{
 									Endpoint: "test-endpoint",
 								},
 							},
 							ResponseType: core.MapResponse,
-						},
-					},
-				},
-			},
-		},
-
-		{
-			name:    "Trigger RemoveCurrentContext API",
-			apiName: core.RemoveCurrentContextAPIName,
-			apis: []core.API{
-				{
-					Name:    core.SetContextAPIName,
-					Version: core.VersionLatest,
-					Arguments: map[core.APIArgumentType]interface{}{
-						core.Context:    ctx,
-						core.SetCurrent: false,
-					},
-					Output: &core.Output{
-						Result:  "success",
-						Content: "",
-					},
-				},
-				{
-					Name:    core.SetCurrentContextAPIName,
-					Version: core.VersionLatest,
-					Arguments: map[core.APIArgumentType]interface{}{
-						core.ContextName: "context-one",
-					},
-					Output: &core.Output{
-						Result:  "success",
-						Content: "",
-					},
-				},
-				{
-					Name:    core.RemoveCurrentContextAPIName,
-					Version: core.VersionLatest,
-					Arguments: map[core.APIArgumentType]interface{}{
-						core.Target: "kubernetes",
-					},
-					Output: &core.Output{
-						Result:  "success",
-						Content: "",
-					},
-				},
-			},
-
-			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
-				core.RemoveCurrentContextAPIName: {
-					{
-						APIResponse: &core.APIResponse{
-							ResponseBody: "",
-							ResponseType: core.StringResponse,
 						},
 					},
 				},

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/parser.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/parser.go
@@ -18,3 +18,13 @@ func parseContext(context string) (*configtypes.Context, error) {
 	}
 	return &ctx, nil
 }
+
+// parseServer unmarshalls string to Server struct
+func parseServer(server string) (*configtypes.Server, error) {
+	var s configtypes.Server
+	err := yaml.Unmarshal([]byte(server), &s)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/trigger_apis.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/trigger_apis.go
@@ -18,6 +18,15 @@ var apiHandlers = map[core.RuntimeAPIName]func(*core.API) *core.APIResponse{
 	core.SetCurrentContextAPIName:    triggerSetCurrentContextAPI,
 	core.GetCurrentContextAPIName:    triggerGetCurrentContextAPI,
 	core.RemoveCurrentContextAPIName: triggerRemoveCurrentContextAPI,
+	core.SetServerAPIName:            triggerSetServerAPI,
+	core.AddServerAPIName:            triggerSetServerAPI,
+	core.PutServerAPIName:            triggerSetServerAPI,
+	core.GetServerAPIName:            triggerGetServerAPI,
+	core.RemoveServerAPIName:         triggerRemoveServerAPI,
+	core.DeleteServerAPIName:         triggerRemoveServerAPI,
+	core.SetCurrentServerAPIName:     triggerSetCurrentServerAPI,
+	core.GetCurrentServerAPIName:     triggerGetCurrentServerAPI,
+	core.RemoveCurrentServerAPIName:  triggerRemoveCurrentServerAPI,
 }
 
 // triggerAPIs trigger runtime apis and construct logs

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/trigger_context_apis_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/trigger_context_apis_test.go
@@ -1,0 +1,348 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configapi "github.com/vmware-tanzu/tanzu-framework/cli/runtime/apis/config/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+)
+
+func TestTriggerAPIs(t *testing.T) {
+	_, cleanup := core.SetupTempCfgFiles()
+	defer func() {
+		cleanup()
+	}()
+	ctx := `name: context-one
+target: kubernetes
+globalOpts:
+  endpoint: test-endpoint
+`
+	var tests = []struct {
+		name         string
+		apiName      core.RuntimeAPIName
+		apis         []core.API
+		expectedLogs map[core.RuntimeAPIName][]core.APILog
+	}{
+		{
+			name:    "Trigger SetContext API",
+			apiName: core.SetContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.SetContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger GetContext API",
+			apiName: core.GetContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.GetContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: ctx,
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.GetContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: &configapi.Context{
+								Name:   "context-one",
+								Target: "kubernetes",
+								GlobalOpts: &configapi.GlobalServer{
+									Endpoint: "test-endpoint",
+								},
+							},
+							ResponseType: core.MapResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger RemoveContext API",
+			apiName: core.RemoveContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.RemoveContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.RemoveContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger DeleteContext API",
+			apiName: core.DeleteContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.DeleteContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.DeleteContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger SetCurrentContext API",
+			apiName: core.SetCurrentContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.SetCurrentContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger GetCurrentContext API",
+			apiName: core.GetCurrentContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.GetCurrentContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Target: "kubernetes",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: ctx,
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.GetCurrentContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: &configapi.Context{
+								Name:   "context-one",
+								Target: "kubernetes",
+								GlobalOpts: &configapi.GlobalServer{
+									Endpoint: "test-endpoint",
+								},
+							},
+							ResponseType: core.MapResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger RemoveCurrentContext API",
+			apiName: core.RemoveCurrentContextAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Context:    ctx,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ContextName: "context-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.RemoveCurrentContextAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Target: "kubernetes",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.RemoveCurrentContextAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualLogs := triggerAPIs(tt.apis)
+			assert.Equal(t, tt.expectedLogs[tt.apiName], actualLogs[tt.apiName])
+		})
+	}
+}

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/trigger_server_apis.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/trigger_server_apis.go
@@ -6,8 +6,9 @@ package cmd
 import (
 	"fmt"
 
-	configtypes "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
-	configlib "github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
+	configtypes "github.com/vmware-tanzu/tanzu-framework/cli/runtime/apis/config/v1alpha1"
+	configlib "github.com/vmware-tanzu/tanzu-framework/cli/runtime/config"
+
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
 )
 
@@ -67,6 +68,53 @@ func triggerSetCurrentServerAPI(api *core.API) *core.APIResponse {
 // triggerGetCurrentServerAPI trigger remove context runtime api
 func triggerGetCurrentServerAPI(*core.API) *core.APIResponse {
 	return getCurrentServer()
+}
+
+func getCurrentServer() *core.APIResponse {
+	server, err := configlib.GetCurrentServer()
+	if err != nil {
+		return &core.APIResponse{
+			ResponseType: core.ErrorResponse,
+			ResponseBody: err.Error(),
+		}
+	}
+	if server == nil {
+		return &core.APIResponse{
+			ResponseType: core.ErrorResponse,
+			ResponseBody: fmt.Errorf("server not found"),
+		}
+	}
+	return &core.APIResponse{
+		ResponseType: core.MapResponse,
+		ResponseBody: server,
+	}
+}
+
+// triggerRemoveCurrentServerAPI trigger remove server runtime api
+func triggerRemoveCurrentServerAPI(api *core.API) *core.APIResponse {
+	// Parse arguments needed to trigger the runtime api
+	serverName, err := core.ParseStr(api.Arguments[core.ServerName])
+	if err != nil {
+		return &core.APIResponse{
+			ResponseType: core.ErrorResponse,
+			ResponseBody: fmt.Errorf("failed to parse string from argument %v with error %v ", core.Target, err.Error()),
+		}
+	}
+	return removeCurrentServer(serverName)
+}
+
+func removeCurrentServer(serverName string) *core.APIResponse {
+	err := configlib.RemoveCurrentServer(serverName)
+	if err != nil {
+		return &core.APIResponse{
+			ResponseType: core.ErrorResponse,
+			ResponseBody: err.Error(),
+		}
+	}
+	return &core.APIResponse{
+		ResponseBody: "",
+		ResponseType: core.StringResponse,
+	}
 }
 
 func getServer(serverName string) *core.APIResponse {
@@ -134,25 +182,5 @@ func setCurrentServer(serverName string) *core.APIResponse {
 	return &core.APIResponse{
 		ResponseBody: "",
 		ResponseType: core.StringResponse,
-	}
-}
-
-func getCurrentServer() *core.APIResponse {
-	server, err := configlib.GetCurrentServer()
-	if err != nil {
-		return &core.APIResponse{
-			ResponseType: core.ErrorResponse,
-			ResponseBody: err.Error(),
-		}
-	}
-	if server == nil {
-		return &core.APIResponse{
-			ResponseType: core.ErrorResponse,
-			ResponseBody: fmt.Errorf("server not found"),
-		}
-	}
-	return &core.APIResponse{
-		ResponseType: core.MapResponse,
-		ResponseBody: server,
 	}
 }

--- a/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/trigger_server_apis_test.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-v0_28_0/cmd/trigger_server_apis_test.go
@@ -1,0 +1,348 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configtypes "github.com/vmware-tanzu/tanzu-framework/cli/runtime/apis/config/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/test/compatibility/core"
+)
+
+func TestTriggerServerAPIs(t *testing.T) {
+	_, cleanup := core.SetupTempCfgFiles()
+	defer func() {
+		cleanup()
+	}()
+	server := `name: compatibility-test-one
+type: managementcluster
+globalOpts:
+    endpoint: test-endpoint
+`
+	var tests = []struct {
+		name         string
+		apiName      core.RuntimeAPIName
+		apis         []core.API
+		expectedLogs map[core.RuntimeAPIName][]core.APILog
+	}{
+		{
+			name:    "Trigger SetServerAPI",
+			apiName: core.SetServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.SetServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger GetServerAPI",
+			apiName: core.GetServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.GetServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: server,
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.GetServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: &configtypes.Server{
+								Name: "compatibility-test-one",
+								Type: configtypes.ManagementClusterServerType,
+								GlobalOpts: &configtypes.GlobalServer{
+									Endpoint: "test-endpoint",
+								},
+							},
+							ResponseType: core.MapResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger RemoveServerAPI",
+			apiName: core.RemoveServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.RemoveServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.RemoveServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger DeleteServerAPI",
+			apiName: core.DeleteServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.DeleteServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.DeleteServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger SetCurrentServerAPI",
+			apiName: core.SetCurrentServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.SetCurrentServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger GetCurrentServerAPI",
+			apiName: core.GetCurrentServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.GetCurrentServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Target: "kubernetes",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: server,
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.GetCurrentServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: &configtypes.Server{
+								Name: "compatibility-test-one",
+								Type: configtypes.ManagementClusterServerType,
+								GlobalOpts: &configtypes.GlobalServer{
+									Endpoint: "test-endpoint",
+								},
+							},
+							ResponseType: core.MapResponse,
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "Trigger RemoveCurrentServerAPI",
+			apiName: core.RemoveCurrentServerAPIName,
+			apis: []core.API{
+				{
+					Name:    core.SetServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.Server:     server,
+						core.SetCurrent: false,
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.SetCurrentServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+				{
+					Name:    core.RemoveCurrentServerAPIName,
+					Version: core.Version0280,
+					Arguments: map[core.APIArgumentType]interface{}{
+						core.ServerName: "compatibility-test-one",
+					},
+					Output: &core.Output{
+						Result:  "success",
+						Content: "",
+					},
+				},
+			},
+
+			expectedLogs: map[core.RuntimeAPIName][]core.APILog{
+				core.RemoveCurrentServerAPIName: {
+					{
+						APIResponse: &core.APIResponse{
+							ResponseBody: "",
+							ResponseType: core.StringResponse,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualLogs := triggerAPIs(tt.apis)
+			assert.Equal(t, tt.expectedLogs[tt.apiName], actualLogs[tt.apiName])
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

- Added Server APIs tests on supported Runtime library versions v0.11.6, v0.25.4, v0.28.0, latest.
- Added helper methods to create API Commands, Validators to validate input and outputOptions
- Extended the testplugins implementation to trigger Server APIs.
- Set/Get/ DeleteServer, Set/Get/RemoveCurrentServer API methods are tested for supported Runtime Library versions 1.0.0/latest, 0.28.0, 0.25.4, 0.11.6.
- Added group of tests using single server involving Set/Get/ DeleteServer, Set/Get/RemoveCurrentServer API methods.
- Added group of tests using two servers involving Set/Get/ DeleteServer, Set/Get/RemoveCurrentServer API methods.

Implemented  Helper methods to create commands and input & output options in the framework.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Added Unit testing for the helper functions like Command creations, Trigger Server APIs.

Commands
Build and Run compatibility tests
`make compatibility-tests`

Build all the runtime specific version test plugins. Binaries of all the test plugins needs to be build to run any compatibility test.
`make build-compatibility-test-plugins`

Run all compatibility tests
`make run-compatibility-tests`

What will the tests cover ?
Interactions of different implementations of APIs across various versions of library works as expected.

What will be the test results ?
GitHub CI runner pipeline include Logs with details on test cases from test-case that are executed and succeeded/failed.

For more details on Cross-version API compatibility testing refer to https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/test/compatibility/docs/cross-version-api-compatibility.md

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Added Cross-version Server APIs Compatibility tests
```

