### PR TITLE
Add Deprecation annotation to the Deprecated APIs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -127,6 +127,28 @@ issues:
         - revive
       text: "it will be inferred from"
 
+    # Ignore the deprecated function use (staticcheck, SA1019) for the below files
+    - path: (.+)_test.go
+      linters:
+        - staticcheck
+      text: "SA1019:"
+    - path: config/cli_repositories.go
+      linters:
+        - staticcheck
+      text: "SA1019:"
+    - path: config/conversion.go
+      linters:
+        - staticcheck
+      text: "SA1019:"
+    - path: config/legacy_clientconfig_factory.go
+      linters:
+        - staticcheck
+      text: "SA1019:"
+    - path: config/servers.go
+      linters:
+        - staticcheck
+      text: "SA1019:"
+
   include:
     - EXC0011 # disable excluding of issues about missing package comments from stylecheck
 

--- a/config/contexts.go
+++ b/config/contexts.go
@@ -80,7 +80,7 @@ func SetContext(c *configtypes.Context, setCurrent bool) error {
 	}
 
 	// Set current server
-	if setCurrent && s.Type == configtypes.ManagementClusterServerType {
+	if setCurrent && s.Type == configtypes.ManagementClusterServerType { // nolint:staticcheck
 		persist, err = setCurrentServer(node, s.Name)
 		if err != nil {
 			return err

--- a/config/discovery_sources_node.go
+++ b/config/discovery_sources_node.go
@@ -135,8 +135,8 @@ func setDiscoverySource(discoverySourcesNode *yaml.Node, discoverySource configt
 }
 
 func getDiscoverySourceTypeAndName(discoverySource configtypes.PluginDiscovery) (string, string) {
-	if discoverySource.GCP != nil && discoverySource.GCP.Name != "" {
-		return DiscoveryTypeGCP, discoverySource.GCP.Name
+	if discoverySource.GCP != nil && discoverySource.GCP.Name != "" { // nolint:staticcheck
+		return DiscoveryTypeGCP, discoverySource.GCP.Name // nolint:staticcheck
 	} else if discoverySource.OCI != nil && discoverySource.OCI.Name != "" {
 		return DiscoveryTypeOCI, discoverySource.OCI.Name
 	} else if discoverySource.Local != nil && discoverySource.Local.Name != "" {

--- a/config/legacy_clientconfig_factory.go
+++ b/config/legacy_clientconfig_factory.go
@@ -112,18 +112,12 @@ func clientConfigSetCLI(cfg *configtypes.ClientConfig, node *yaml.Node) (err err
 		if cfg.ClientOptions.CLI.UnstableVersionSelector != "" {
 			setUnstableVersionSelector(node, string(cfg.ClientOptions.CLI.UnstableVersionSelector))
 		}
-		//nolint:staticcheck
-		// Disable deprecated lint warning
 		if cfg.ClientOptions.CLI.Edition != "" {
 			setEdition(node, string(cfg.ClientOptions.CLI.Edition))
 		}
-		//nolint:staticcheck
-		// Disable deprecated lint warning
 		if cfg.ClientOptions.CLI.BOMRepo != "" {
 			setBomRepo(node, cfg.ClientOptions.CLI.BOMRepo)
 		}
-		//nolint:staticcheck
-		// Disable deprecated lint warning
 		if cfg.ClientOptions.CLI.CompatibilityFilePath != "" {
 			setCompatibilityFilePath(node, cfg.ClientOptions.CLI.CompatibilityFilePath)
 		}

--- a/config/servers.go
+++ b/config/servers.go
@@ -14,6 +14,8 @@ import (
 )
 
 // GetServer retrieves server by name
+//
+// Deprecated: This API is deprecated. Use GetContext instead.
 func GetServer(name string) (*configtypes.Server, error) {
 	// Retrieve client config node
 	node, err := getClientConfigNode()
@@ -24,12 +26,16 @@ func GetServer(name string) (*configtypes.Server, error) {
 }
 
 // ServerExists checks if server by specified name is present in config
+//
+// Deprecated: This API is deprecated. Use ContextExists instead.
 func ServerExists(name string) (bool, error) {
 	exists, _ := GetServer(name)
 	return exists != nil, nil
 }
 
 // GetCurrentServer retrieves the current server
+//
+// Deprecated: This API is deprecated. Use GetCurrentContext instead.
 func GetCurrentServer() (*configtypes.Server, error) {
 	// Retrieve client config node
 	node, err := getClientConfigNode()
@@ -40,6 +46,8 @@ func GetCurrentServer() (*configtypes.Server, error) {
 }
 
 // SetCurrentServer add or update current server
+//
+// Deprecated: This API is deprecated. Use SetCurrentContext instead.
 func SetCurrentServer(name string) error {
 	// Retrieve client config node
 	AcquireTanzuConfigLock()
@@ -78,6 +86,8 @@ func SetCurrentServer(name string) error {
 }
 
 // RemoveCurrentServer removes the current server if server exists by specified name
+//
+// Deprecated: This API is deprecated. Use RemoveCurrentContext instead.
 func RemoveCurrentServer(name string) error {
 	// Retrieve client config node
 	AcquireTanzuConfigLock()
@@ -108,16 +118,22 @@ func RemoveCurrentServer(name string) error {
 }
 
 // PutServer add or update server and currentServer
+//
+// Deprecated: This API is deprecated. Use AddContext or SetContext instead.
 func PutServer(s *configtypes.Server, setCurrent bool) error {
 	return SetServer(s, setCurrent)
 }
 
 // AddServer add or update server and currentServer
+//
+// Deprecated: This API is deprecated. Use AddContext or SetContext instead.
 func AddServer(s *configtypes.Server, setCurrent bool) error {
 	return SetServer(s, setCurrent)
 }
 
 // SetServer add or update server and currentServer
+//
+// Deprecated: This API is deprecated. Use AddContext or SetContext instead.
 func SetServer(s *configtypes.Server, setCurrent bool) error {
 	// Acquire tanzu config lock
 	AcquireTanzuConfigLock()
@@ -186,11 +202,15 @@ func frontFillContexts(s *configtypes.Server, setCurrent bool, node *yaml.Node) 
 }
 
 // DeleteServer deletes the server specified by name
+//
+// Deprecated: This API is deprecated. Use DeleteContext instead.
 func DeleteServer(name string) error {
 	return RemoveServer(name)
 }
 
 // RemoveServer removed the server by name
+//
+// Deprecated: This API is deprecated. Use DeleteContext instead.
 func RemoveServer(name string) error {
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()
@@ -385,6 +405,8 @@ func setServer(node *yaml.Node, s *configtypes.Server) (persist bool, err error)
 }
 
 // EndpointFromServer returns the endpoint from server.
+//
+// Deprecated: This API is deprecated. Use EndpointFromContext instead.
 func EndpointFromServer(s *configtypes.Server) (endpoint string, err error) {
 	switch s.Type {
 	case configtypes.ManagementClusterServerType:

--- a/config/types/clientconfig.go
+++ b/config/types/clientconfig.go
@@ -64,19 +64,22 @@ type EditionSelector string
 type VersionSelectorLevel string
 
 // IsGlobal tells if the server is global.
-// Deprecation targeted for a future version. Use Context.Target instead.
+//
+// Deprecated: This API is deprecated. Use Context.Target instead.
 func (s *Server) IsGlobal() bool {
 	return s.Type == GlobalServerType
 }
 
 // IsManagementCluster tells if the server is a management cluster.
-// Deprecation targeted for a future version. Use Context.Target instead.
+//
+// Deprecated: This API is deprecated. Use context.IsManagementCluster instead.
 func (s *Server) IsManagementCluster() bool {
 	return s.Type == ManagementClusterServerType
 }
 
 // GetCurrentServer returns the current server.
-// Deprecation targeted for a future version. Use GetCurrentContext() instead.
+//
+// Deprecated: This API is deprecated. Use GetCurrentContext() instead.
 func (c *ClientConfig) GetCurrentServer() (*Server, error) {
 	for _, server := range c.KnownServers {
 		if server.Name == c.CurrentServer {
@@ -179,6 +182,8 @@ func (c *Context) IsManagementCluster() bool {
 // alpha: only versions tagged with -alpha
 // experimental: all pre-release versions without +build semver data
 // all: return all unstable versions.
+//
+// Deprecated: This API is deprecated.
 func (c *ClientConfig) SetUnstableVersionSelector(f VersionSelectorLevel) {
 	if c.ClientOptions == nil {
 		c.ClientOptions = &ClientOptions{}
@@ -246,6 +251,8 @@ func (c *ClientConfig) SplitFeaturePath(featurePath string) (string, string, err
 // SetEditionSelector indicates the edition of tanzu to be run
 // EditionStandard is the default, EditionCommunity is also available.
 // These values affect branding and cluster creation
+//
+// Deprecated: This API is deprecated.
 func (c *ClientConfig) SetEditionSelector(edition EditionSelector) {
 	if c.ClientOptions == nil {
 		c.ClientOptions = &ClientOptions{}

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -12,21 +12,25 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // ServerType is the type of server.
-// Deprecation targeted for a future version. Superseded by Target.
+//
+// Deprecated: This API is deprecated. Superseded by Target.
 type ServerType string
 
 const (
 	// ManagementClusterServerType is a management cluster server.
-	// Deprecation targeted for a future version. Superseded by TargetK8s.
+	//
+	// Deprecated: This variable is deprecated. Use TargetK8s instead.
 	ManagementClusterServerType ServerType = "managementcluster"
 
 	// GlobalServerType is a global control plane server.
-	// Deprecation targeted for a future version. Superseded by TargetTMC.
+	//
+	// Deprecated: This variable is deprecated. Use TargetTMC instead.
 	GlobalServerType ServerType = "global"
 )
 
 // Server connection.
-// Deprecation targeted for a future version. Superseded by Context.
+//
+// Deprecated: This struct is deprecated. Use Context instead.
 type Server struct {
 	// Name of the server.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
@@ -67,7 +71,8 @@ type Context struct {
 }
 
 // ManagementClusterServer is the configuration for a management cluster kubeconfig.
-// Deprecation targeted for a future version. Superseded by ClusterServer.
+//
+// Deprecated: This struct is deprecated. Use ClusterServer instead.
 type ManagementClusterServer struct {
 	// Endpoint for the login.
 	Endpoint string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
@@ -147,21 +152,28 @@ type EnvMap map[string]string
 // CLIOptions are options for the CLI.
 type CLIOptions struct {
 	// Repositories are the plugin repositories.
+	//
+	// Deprecated: Repositories has been deprecated and will be removed from future version
 	Repositories []PluginRepository `json:"repositories,omitempty" yaml:"repositories,omitempty"`
 	// DiscoverySources determines from where to discover stand-alone plugins
 	DiscoverySources []PluginDiscovery `json:"discoverySources,omitempty" yaml:"discoverySources,omitempty"`
 	// UnstableVersionSelector determined which version tags are allowed
+	//
+	// Deprecated: UnstableVersionSelector has been deprecated and will be removed from future version
 	UnstableVersionSelector VersionSelectorLevel `json:"unstableVersionSelector,omitempty" yaml:"unstableVersionSelector,omitempty"`
-	// Deprecated: Edition has been deprecated and will be removed from future version
 	// Edition
+	//
+	// Deprecated: Edition has been deprecated and will be removed from future version
 	Edition EditionSelector `json:"edition,omitempty" yaml:"edition,omitempty"`
-	// Deprecated: BOMRepo has been deprecated and will be removed from future version
 	// BOMRepo is the root repository URL used to resolve the compatibiilty file
 	// and bill of materials. An example URL is projects.registry.vmware.com/tkg.
+	//
+	// Deprecated: BOMRepo has been deprecated and will be removed from future version
 	BOMRepo string `json:"bomRepo,omitempty" yaml:"bomRepo,omitempty"`
-	// Deprecated: CompatibilityFilePath has been deprecated and will be removed from future version
 	// CompatibilityFilePath is the path, from the BOM repo, to download and access the compatibility file.
 	// the compatibility file is used for resolving the bill of materials for creating clusters.
+	//
+	// Deprecated: CompatibilityFilePath has been deprecated and will be removed from future version
 	CompatibilityFilePath string `json:"compatibilityFilePath,omitempty" yaml:"compatibilityFilePath,omitempty"`
 }
 
@@ -169,6 +181,8 @@ type CLIOptions struct {
 // configs must be set.
 type PluginDiscovery struct {
 	// GCPStorage is set if the plugins are to be discovered via Google Cloud Storage.
+	//
+	// Deprecated: GCP has been deprecated and will be removed from future version
 	GCP *GCPDiscovery `json:"gcp,omitempty" yaml:"gcp,omitempty"`
 	// OCIDiscovery is set if the plugins are to be discovered via an OCI Image Registry.
 	OCI *OCIDiscovery `json:"oci,omitempty" yaml:"oci,omitempty"`
@@ -182,6 +196,8 @@ type PluginDiscovery struct {
 
 // GCPDiscovery provides a plugin discovery mechanism via a Google Cloud Storage
 // bucket with a manifest.yaml file.
+//
+// Deprecated: GCPDiscovery has been deprecated and will be removed from future version
 type GCPDiscovery struct {
 	// Name is a name of the discovery
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
@@ -244,12 +260,16 @@ type LocalDiscovery struct {
 }
 
 // PluginRepository is a CLI plugin repository
+//
+// Deprecated: PluginRepository has been deprecated and will be removed from future version
 type PluginRepository struct {
 	// GCPPluginRepository is a plugin repository that utilizes GCP cloud storage.
 	GCPPluginRepository *GCPPluginRepository `json:"gcpPluginRepository,omitempty" yaml:"gcpPluginRepository,omitempty"`
 }
 
 // GCPPluginRepository is a plugin repository that utilizes GCP cloud storage.
+//
+// Deprecated: GCPPluginRepository has been deprecated and will be removed from future version
 type GCPPluginRepository struct {
 	// Name of the repository.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
@@ -264,11 +284,13 @@ type GCPPluginRepository struct {
 // ClientConfig is the Schema for the configs API
 type ClientConfig struct {
 	// KnownServers available.
-	// Deprecation targeted for a future version. Superseded by KnownContexts.
+	//
+	// Deprecated: This field is deprecated. Use KnownContexts instead.
 	KnownServers []*Server `json:"servers,omitempty" yaml:"servers,omitempty"`
 
 	// CurrentServer in use.
-	// Deprecation targeted for a future version. Superseded by CurrentContext.
+	//
+	// Deprecated: This field is deprecated. Use CurrentContext instead.
 	CurrentServer string `json:"current,omitempty" yaml:"current,omitempty"`
 
 	// KnownContexts available.


### PR DESCRIPTION
### What this PR does / why we need it

- This PR marks all the server APIs for the configuration file as deprecated and suggests using context APIs instead.
- This PR also marks additional ClientConfig configurations that are deprecated and is not used by the core-cli as Deprecated

- The PR uses the standard deprecation syntax for the APIs as specified in https://go.dev/blog/godoc

> To signal that an identifier should not be used, add a paragraph to its doc comment that begins with "Deprecated:" followed by some information about the deprecation.

- The documentation site [pkg.go.dev](https://pkg.go.dev/) hides the documentation for deprecated identifiers behind a click of a "show" button.

- The [staticcheck](https://staticcheck.io/) tool reports use of deprecated identifiers

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add Deprecation annotation to the Deprecated APIs
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
