### PR TITLE
Disable autogenerated footer in generated docs

### DIFF
--- a/plugin/root.go
+++ b/plugin/root.go
@@ -33,5 +33,8 @@ func newRootCmd(descriptor *PluginDescriptor) *cobra.Command {
 		newInfoCmd(descriptor),
 	)
 
+	// Disable footers in docs generated
+	cmd.DisableAutoGenTag = true
+
 	return cmd
 }


### PR DESCRIPTION
### What this PR does / why we need it
Small change to disable the autogenerate footer at the end of output from `generate-docs`

Related to the changes made in https://github.com/vmware-tanzu/tanzu-cli/pull/135 so generated docs are more consistent across plugins and core commands and are not subjected to date stamp diffs.

### Which issue(s) this PR fixes
Fixes #N/A

### Describe testing done for PR

Built plugins with this change. Verified that <plugin-binary> `generate-docs` produces markdown in docs/cli/commands that does not contain above-mentioned footer.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Markdown generated by `generate-docs` command no long contains `Autogenerated...` footer
```

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
