### PR TITLE
Use generics to convert objects to config nodes

### DIFF
--- a/config/cli_repositories.go
+++ b/config/cli_repositories.go
@@ -175,7 +175,7 @@ func deleteCLIRepository(node *yaml.Node, name string) error {
 }
 
 func setRepository(repositoriesNode *yaml.Node, repository configtypes.PluginRepository, patchStrategyOpts ...nodeutils.PatchStrategyOpts) (persist bool, err error) {
-	newNode, err := convertPluginRepositoryToNode(&repository)
+	newNode, err := convertObjectToNode(&repository)
 	if err != nil {
 		return persist, err
 	}

--- a/config/clientconfig_factory.go
+++ b/config/clientconfig_factory.go
@@ -78,7 +78,7 @@ func getClientConfigNoLock() (*yaml.Node, error) {
 // newClientConfigNode create and return new client config node
 func newClientConfigNode() (*yaml.Node, error) {
 	c := &configtypes.ClientConfig{}
-	node, err := convertClientConfigToNode(c)
+	node, err := convertObjectToNode(c)
 	node.Content[0].Style = 0
 	if err != nil {
 		return nil, err

--- a/config/clientconfignextgen_factory_test.go
+++ b/config/clientconfignextgen_factory_test.go
@@ -28,7 +28,7 @@ func TestGetClientConfigNextGenNode(t *testing.T) {
 	//Assertions
 	assert.NoError(t, err)
 	c := &configtypes.ClientConfig{}
-	expectedNode, err := convertClientConfigToNode(c)
+	expectedNode, err := convertObjectToNode(c)
 	expectedNode.Content[0].Style = 0
 	assert.NoError(t, err)
 	assert.Equal(t, expectedNode, node)

--- a/config/contexts.go
+++ b/config/contexts.go
@@ -294,7 +294,7 @@ func setContext(node *yaml.Node, ctx *configtypes.Context) (persist bool, err er
 	var persistDiscoverySources bool
 
 	// Convert context to node
-	newContextNode, err := convertContextToNode(ctx)
+	newContextNode, err := convertObjectToNode(ctx)
 	if err != nil {
 		return persist, err
 	}

--- a/config/conversion.go
+++ b/config/conversion.go
@@ -173,78 +173,15 @@ func convertNodeToMetadata(node *yaml.Node) (obj *configtypes.Metadata, err erro
 	return obj, err
 }
 
-// convertClientConfigToNode converts client config type to yaml node
-func convertClientConfigToNode(obj *configtypes.ClientConfig) (*yaml.Node, error) {
-	bytes, err := yaml.Marshal(obj)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert obj to node")
-	}
-	var node yaml.Node
-	err = yaml.Unmarshal(bytes, &node)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal bytes to node")
-	}
-	return &node, nil
-}
+// convertObjectToNode converts a typed object to yaml node
+func convertObjectToNode[
+	T *configtypes.ClientConfig |
+		*configtypes.Metadata |
+		*configtypes.Server |
+		*configtypes.PluginRepository |
+		*configtypes.Context |
+		*configtypes.PluginDiscovery](obj T) (*yaml.Node, error) {
 
-// convertMetadataToNode converts client config type to yaml node
-func convertMetadataToNode(metadata *configtypes.Metadata) (*yaml.Node, error) {
-	bytes, err := yaml.Marshal(metadata)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert metadata obj to node")
-	}
-	var node yaml.Node
-	err = yaml.Unmarshal(bytes, &node)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal bytes to node")
-	}
-	return &node, nil
-}
-
-// convertServerToNode converts server to yaml node
-func convertServerToNode(obj *configtypes.Server) (*yaml.Node, error) {
-	bytes, err := yaml.Marshal(obj)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert obj to node")
-	}
-	var node yaml.Node
-	err = yaml.Unmarshal(bytes, &node)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal bytes to node")
-	}
-	return &node, nil
-}
-
-// convertPluginRepositoryToNode converts PluginRepository to yaml node
-func convertPluginRepositoryToNode(obj *configtypes.PluginRepository) (*yaml.Node, error) {
-	bytes, err := yaml.Marshal(obj)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert obj to node")
-	}
-	var node yaml.Node
-	err = yaml.Unmarshal(bytes, &node)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal bytes to node")
-	}
-	return &node, nil
-}
-
-// convertContextToNode converts context to yaml node
-func convertContextToNode(obj *configtypes.Context) (*yaml.Node, error) {
-	bytes, err := yaml.Marshal(obj)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert obj to node")
-	}
-	var node yaml.Node
-	err = yaml.Unmarshal(bytes, &node)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal bytes to node")
-	}
-	return &node, nil
-}
-
-// convertPluginDiscoveryToNode converts PluginDiscovery to yaml node
-func convertPluginDiscoveryToNode(obj *configtypes.PluginDiscovery) (*yaml.Node, error) {
 	bytes, err := yaml.Marshal(obj)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to convert obj to node")

--- a/config/discovery_sources_node.go
+++ b/config/discovery_sources_node.go
@@ -55,7 +55,7 @@ func setDiscoverySources(node *yaml.Node, discoverySources []configtypes.PluginD
 //nolint:gocyclo
 func setDiscoverySource(discoverySourcesNode *yaml.Node, discoverySource configtypes.PluginDiscovery, patchStrategyOpts ...nodeutils.PatchStrategyOpts) (persist bool, err error) {
 	// Convert discoverySource change obj to yaml node
-	newNode, err := convertPluginDiscoveryToNode(&discoverySource)
+	newNode, err := convertObjectToNode(&discoverySource)
 	if err != nil {
 		return persist, err
 	}

--- a/config/metadata_factory.go
+++ b/config/metadata_factory.go
@@ -51,7 +51,7 @@ func getMetadataNodeNoLock() (*yaml.Node, error) {
 
 func newMetadataNode() (*yaml.Node, error) {
 	c := &configtypes.Metadata{}
-	node, err := convertMetadataToNode(c)
+	node, err := convertObjectToNode(c)
 	node.Content[0].Style = 0
 	if err != nil {
 		return nil, err

--- a/config/servers.go
+++ b/config/servers.go
@@ -352,7 +352,7 @@ func setServer(node *yaml.Node, s *configtypes.Server) (persist bool, err error)
 	var persistDiscoverySources bool
 
 	// convert server to node
-	newServerNode, err := convertServerToNode(s)
+	newServerNode, err := convertObjectToNode(s)
 	if err != nil {
 		return persist, err
 	}


### PR DESCRIPTION
### What this PR does / why we need it

This does some code cleanup to take advantage of generics to avoid code duplication.
It replaces the 6 different `convert*ToNode(..)` functions to using a single one with generics: `convertObjectToNode[T](..)`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Built the CLI using this change and did a `tz config get` after creating contexts.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
