### PR TITLE
Bug Fix:  Add empty checks for config APIs

### DIFF
--- a/config/certs.go
+++ b/config/certs.go
@@ -178,7 +178,6 @@ func setCert(node *yaml.Node, cert *configtypes.Cert) (persist bool, err error) 
 	return persist, err
 }
 
-//nolint:dupl
 func removeCert(node *yaml.Node, host string) error {
 	// Find the certs node in the yaml node
 	keys := []nodeutils.Key{

--- a/config/cli_discovery_sources.go
+++ b/config/cli_discovery_sources.go
@@ -118,13 +118,21 @@ func getCLIDiscoverySources(node *yaml.Node) ([]configtypes.PluginDiscovery, err
 }
 
 func getCLIDiscoverySource(node *yaml.Node, name string) (*configtypes.PluginDiscovery, error) {
+	// check if context name is empty
+	if name == "" {
+		return nil, errors.New("discovery source name cannot be empty")
+	}
+
 	cfg, err := convertNodeToClientConfig(node)
 	if err != nil {
 		return nil, err
 	}
 	if cfg.CoreCliOptions != nil && cfg.CoreCliOptions.DiscoverySources != nil {
 		for _, discoverySource := range cfg.CoreCliOptions.DiscoverySources {
-			_, discoverySourceName := getDiscoverySourceTypeAndName(discoverySource)
+			_, discoverySourceName, err := getDiscoverySourceTypeAndName(discoverySource)
+			if err != nil {
+				return nil, err
+			}
 			if discoverySourceName == name {
 				return &discoverySource, nil
 			}
@@ -172,7 +180,12 @@ func deleteCLIDiscoverySource(node *yaml.Node, name string) error {
 	if err != nil {
 		return err
 	}
-	discoverySourceType, discoverySourceName := getDiscoverySourceTypeAndName(*discoverySource)
+
+	discoverySourceType, discoverySourceName, err := getDiscoverySourceTypeAndName(*discoverySource)
+	if err != nil {
+		return err
+	}
+
 	var result []*yaml.Node
 	for _, discoverySourceNode := range cliDiscoverySourcesNode.Content {
 		// Find discovery source matched by discoverySourceType

--- a/config/cli_options.go
+++ b/config/cli_options.go
@@ -22,6 +22,10 @@ func GetEdition() (string, error) {
 
 // SetEdition adds or updates edition value
 func SetEdition(val string) (err error) {
+	// Check if val is empty
+	if val == "" {
+		return errors.New("value cannot be empty")
+	}
 	// Retrieve client config node
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()

--- a/config/cli_repositories.go
+++ b/config/cli_repositories.go
@@ -159,7 +159,9 @@ func deleteCLIRepository(node *yaml.Node, name string) error {
 	}
 
 	repositoryType, repositoryName := getRepositoryTypeAndName(*repository)
-
+	if repositoryType == "" || repositoryName == "" {
+		return errors.New("not found")
+	}
 	var result []*yaml.Node
 	for _, repositoryNode := range cliRepositoriesNode.Content {
 		if repositoryIndex := nodeutils.GetNodeIndex(repositoryNode.Content, repositoryType); repositoryIndex != -1 {

--- a/config/contexts.go
+++ b/config/contexts.go
@@ -6,6 +6,7 @@ package config
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/nodeutils"
@@ -246,6 +247,11 @@ func EndpointFromContext(s *configtypes.Context) (endpoint string, err error) {
 }
 
 func getContext(node *yaml.Node, name string) (*configtypes.Context, error) {
+	// check if context name is empty
+	if name == "" {
+		return nil, errors.New("context name cannot be empty")
+	}
+
 	cfg, err := convertNodeToClientConfig(node)
 	if err != nil {
 		return nil, err
@@ -285,6 +291,11 @@ func setContexts(node *yaml.Node, contexts []*configtypes.Context) (err error) {
 }
 
 func setContext(node *yaml.Node, ctx *configtypes.Context) (persist bool, err error) {
+	// Check if ctx.Name is empty
+	if ctx.Name == "" {
+		return false, errors.New("context name cannot be empty")
+	}
+
 	// Get Patch Strategies from config metadata
 	patchStrategies, err := GetConfigMetadataPatchStrategy()
 	if err != nil {
@@ -394,6 +405,11 @@ func removeCurrentContext(node *yaml.Node, ctx *configtypes.Context) error {
 
 //nolint:dupl
 func removeContext(node *yaml.Node, name string) error {
+	// check if context name is empty
+	if name == "" {
+		return errors.New("context name cannot be empty")
+	}
+
 	// Find the contexts node in the yaml node
 	keys := []nodeutils.Key{
 		{Name: KeyContexts},

--- a/config/contexts_it_test.go
+++ b/config/contexts_it_test.go
@@ -41,6 +41,34 @@ servers:
           manifestPath: updated-test-manifest-path
           annotation: one
           required: true
+  - type: managementcluster
+    managementClusterOpts:
+      endpoint: updated-test-endpoint
+      path: updated-test-path
+      context: updated-test-context
+      annotation: one
+      required: true
+    discoverySources:
+      - gcp:
+          name: test
+          bucket: updated-test-bucket
+          manifestPath: updated-test-manifest-path
+          annotation: one
+          required: true
+  - type: managementcluster
+    managementClusterOpts:
+      endpoint: updated-test-endpoint
+      path: updated-test-path
+      context: updated-test-context
+      annotation: one
+      required: true
+    discoverySources:
+      - gcp:
+          name: test
+          bucket: updated-test-bucket
+          manifestPath: updated-test-manifest-path
+          annotation: one
+          required: true
 current: test-mc
 `
 	expectedCfg := `clientOptions:
@@ -58,6 +86,34 @@ current: test-mc
 servers:
     - name: test-mc
       type: managementcluster
+      managementClusterOpts:
+        endpoint: updated-test-endpoint
+        path: updated-test-path
+        context: updated-test-context
+        annotation: one
+        required: true
+      discoverySources:
+        - gcp:
+            name: test
+            bucket: updated-test-bucket
+            manifestPath: updated-test-manifest-path
+            annotation: one
+            required: true
+    - type: managementcluster
+      managementClusterOpts:
+        endpoint: updated-test-endpoint
+        path: updated-test-path
+        context: updated-test-context
+        annotation: one
+        required: true
+      discoverySources:
+        - gcp:
+            name: test
+            bucket: updated-test-bucket
+            manifestPath: updated-test-manifest-path
+            annotation: one
+            required: true
+    - type: managementcluster
       managementClusterOpts:
         endpoint: updated-test-endpoint
         path: updated-test-path
@@ -103,12 +159,84 @@ current: test-mc2
           manifestPath: test-manifest-path
           annotation: one
           required: true
+  - target: kubernetes
+    group: one
+    clusterOpts:
+      isManagementCluster: true
+      annotation: one
+      required: true
+      annotationStruct:
+        one: one
+      endpoint: test-endpoint
+      path: test-path
+      context: test-context
+    discoverySources:
+      - gcp:
+          name: test
+          bucket: test-bucket
+          manifestPath: test-manifest-path
+          annotation: one
+          required: true
+  - target: kubernetes
+    group: one
+    clusterOpts:
+      isManagementCluster: true
+      annotation: one
+      required: true
+      annotationStruct:
+        one: one
+      endpoint: test-endpoint
+      path: test-path
+      context: test-context
+    discoverySources:
+      - gcp:
+          name: test
+          bucket: test-bucket
+          manifestPath: test-manifest-path
+          annotation: one
+          required: true
 currentContext:
   kubernetes: test-mc
 `
 	expectedCfg2 := `contexts:
     - name: test-mc
       target: kubernetes
+      group: one
+      clusterOpts:
+        isManagementCluster: true
+        annotation: one
+        required: true
+        annotationStruct:
+            one: one
+        endpoint: test-endpoint
+        path: test-path
+        context: test-context
+      discoverySources:
+        - gcp:
+            name: test
+            bucket: test-bucket
+            manifestPath: test-manifest-path
+            annotation: one
+            required: true
+    - target: kubernetes
+      group: one
+      clusterOpts:
+        isManagementCluster: true
+        annotation: one
+        required: true
+        annotationStruct:
+            one: one
+        endpoint: test-endpoint
+        path: test-path
+        context: test-context
+      discoverySources:
+        - gcp:
+            name: test
+            bucket: test-bucket
+            manifestPath: test-manifest-path
+            annotation: one
+            required: true
+    - target: kubernetes
       group: one
       clusterOpts:
         isManagementCluster: true
@@ -175,6 +303,7 @@ func TestContextsIntegration(t *testing.T) {
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, context)
+
 	// Add new Context
 	newCtx := &configtypes.Context{
 		Name:   "test-mc2",
@@ -199,6 +328,32 @@ func TestContextsIntegration(t *testing.T) {
 	ctx, err := GetContext("test-mc2")
 	assert.Nil(t, err)
 	assert.Equal(t, newCtx, ctx)
+
+	// Try to add context with empty name
+	contextWithEmptyName := &configtypes.Context{
+		Name:   "",
+		Target: configtypes.TargetK8s,
+		ClusterOpts: &configtypes.ClusterServer{
+			Path:                "test-path",
+			Context:             "test-context",
+			IsManagementCluster: true,
+		},
+		DiscoverySources: []configtypes.PluginDiscovery{
+			{
+				GCP: &configtypes.GCPDiscovery{
+					Name:         "test",
+					Bucket:       "test-bucket",
+					ManifestPath: "test-manifest-path",
+				},
+			},
+		},
+	}
+	err = SetContext(contextWithEmptyName, true)
+	assert.Equal(t, "context name cannot be empty", err.Error())
+	ctx, err = GetContext("")
+	assert.Equal(t, "context name cannot be empty", err.Error())
+	assert.Nil(t, ctx)
+
 	// Update existing Context
 	updatedCtx := &configtypes.Context{
 		Name:   "test-mc2",
@@ -224,6 +379,7 @@ func TestContextsIntegration(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, updatedCtx, ctx)
 
+	//Read config files
 	file, err := os.ReadFile(cfgTestFiles[0].Name())
 	assert.NoError(t, err)
 	assert.Equal(t, expectedCfg, string(file))

--- a/config/contexts_test.go
+++ b/config/contexts_test.go
@@ -1136,3 +1136,59 @@ func TestSetContextWithUniquePermissions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 7, len(s.GlobalOpts.Auth.Permissions))
 }
+
+func TestSetContextWithEmptyName(t *testing.T) {
+	// setup
+	func() {
+		LocalDirName = TestLocalDirName
+	}()
+	defer func() {
+		cleanupDir(LocalDirName)
+	}()
+	tcs := []struct {
+		name    string
+		ctx     *configtypes.Context
+		current bool
+		errStr  string
+	}{
+		{
+			name: "success  current",
+			ctx: &configtypes.Context{
+				Name:   "",
+				Target: configtypes.TargetK8s,
+				ClusterOpts: &configtypes.ClusterServer{
+					Endpoint:            "test-endpoint",
+					Path:                "test-path",
+					Context:             "test-context",
+					IsManagementCluster: true,
+				},
+			},
+			errStr: "context name cannot be empty",
+		},
+		{
+			name: "success re empty current",
+			ctx: &configtypes.Context{
+				Name:   "",
+				Target: configtypes.TargetK8s,
+				ClusterOpts: &configtypes.ClusterServer{
+					Endpoint:            "test-endpoint",
+					Path:                "test-path",
+					Context:             "test-context",
+					IsManagementCluster: true,
+				},
+			},
+			errStr: "context name cannot be empty",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := SetContext(tc.ctx, tc.current)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+		})
+	}
+}

--- a/config/envs.go
+++ b/config/envs.go
@@ -42,11 +42,16 @@ func GetEnv(key string) (string, error) {
 }
 
 func getEnv(node *yaml.Node, key string) (string, error) {
+	// check if key is empty
+	if key == "" {
+		return "", errors.New("key cannot be empty")
+	}
+
 	cfg, err := convertNodeToClientConfig(node)
 	if err != nil {
 		return "", err
 	}
-	if cfg.ClientOptions == nil && cfg.ClientOptions.Env == nil {
+	if cfg.ClientOptions == nil || cfg.ClientOptions.Env == nil {
 		return "", errors.New("not found")
 	}
 	if val, ok := cfg.ClientOptions.Env[key]; ok {
@@ -72,6 +77,11 @@ func DeleteEnv(key string) error {
 }
 
 func deleteEnv(node *yaml.Node, key string) (err error) {
+	// check if key is empty
+	if key == "" {
+		return errors.New("key cannot be empty")
+	}
+
 	// find env node
 	keys := []nodeutils.Key{
 		{Name: KeyClientOptions},
@@ -123,6 +133,16 @@ func SetEnv(key, value string) (err error) {
 
 //nolint:dupl
 func setEnv(node *yaml.Node, key, value string) (persist bool, err error) {
+	// check if key is empty
+	if key == "" {
+		return false, errors.New("key cannot be empty")
+	}
+
+	// check if value is empty
+	if value == "" {
+		return false, errors.New("value cannot be empty")
+	}
+
 	// find env node
 	keys := []nodeutils.Key{
 		{Name: KeyClientOptions, Type: yaml.MappingNode},

--- a/config/features.go
+++ b/config/features.go
@@ -31,6 +31,16 @@ func IsFeatureEnabled(plugin, key string) (bool, error) {
 }
 
 func getFeature(node *yaml.Node, plugin, key string) (string, error) {
+	// check if plugin is empty
+	if plugin == "" {
+		return "", errors.New("plugin cannot be empty")
+	}
+
+	// check if key is empty
+	if key == "" {
+		return "", errors.New("key cannot be empty")
+	}
+
 	cfg, err := convertNodeToClientConfig(node)
 	if err != nil {
 		return "", err
@@ -61,6 +71,15 @@ func DeleteFeature(plugin, key string) error {
 }
 
 func deleteFeature(node *yaml.Node, plugin, key string) error {
+	// check if plugin is empty
+	if plugin == "" {
+		return errors.New("plugin cannot be empty")
+	}
+
+	// check if key is empty
+	if key == "" {
+		return errors.New("key cannot be empty")
+	}
 	// Find plugin node
 	keys := []nodeutils.Key{
 		{Name: KeyClientOptions},
@@ -105,6 +124,21 @@ func SetFeature(plugin, key, value string) (err error) {
 }
 
 func setFeature(node *yaml.Node, plugin, key, value string) (persist bool, err error) {
+	// check if plugin is empty
+	if plugin == "" {
+		return false, errors.New("plugin cannot be empty")
+	}
+
+	// check if key is empty
+	if key == "" {
+		return false, errors.New("key cannot be empty")
+	}
+
+	// check if value is empty
+	if value == "" {
+		return false, errors.New("value cannot be empty")
+	}
+
 	// find plugin node
 	keys := []nodeutils.Key{
 		{Name: KeyClientOptions, Type: yaml.MappingNode},

--- a/config/metadata_api.go
+++ b/config/metadata_api.go
@@ -125,6 +125,11 @@ func setConfigMetadataPatchStrategies(node *yaml.Node, patchStrategies map[strin
 }
 
 func setConfigMetadataPatchStrategy(node *yaml.Node, key, value string) error {
+	// check if key is empty
+	if key == "" {
+		return errors.New("key cannot be empty")
+	}
+
 	if !strings.EqualFold(value, "replace") && !strings.EqualFold(value, "merge") {
 		return errors.New("allowed values are replace or merge")
 	}

--- a/config/metadata_settings_api.go
+++ b/config/metadata_settings_api.go
@@ -105,6 +105,11 @@ func getSettings(node *yaml.Node) (map[string]string, error) {
 }
 
 func getSetting(node *yaml.Node, key string) (string, error) {
+	// check if key is empty
+	if key == "" {
+		return "", errors.New("key cannot be empty")
+	}
+
 	cfgMetadata, err := convertNodeToMetadata(node)
 	if err != nil {
 		return "", err
@@ -122,6 +127,11 @@ func getSetting(node *yaml.Node, key string) (string, error) {
 }
 
 func deleteSetting(node *yaml.Node, key string) (err error) {
+	// check if key is empty
+	if key == "" {
+		return errors.New("key cannot be empty")
+	}
+
 	// find settings node
 	keys := []nodeutils.Key{
 		{Name: KeyConfigMetadata, Type: yaml.MappingNode},
@@ -152,6 +162,15 @@ func deleteSetting(node *yaml.Node, key string) (err error) {
 
 //nolint:dupl
 func setSetting(node *yaml.Node, key, value string) (persist bool, err error) {
+	// check if key is empty
+	if key == "" {
+		return false, errors.New("key cannot be empty")
+	}
+	// check if value is empty
+	if value == "" {
+		return false, errors.New("value cannot be empty")
+	}
+
 	// find settings node
 	keys := []nodeutils.Key{
 		{Name: KeyConfigMetadata, Type: yaml.MappingNode},

--- a/config/servers.go
+++ b/config/servers.go
@@ -272,6 +272,11 @@ func setCurrentServer(node *yaml.Node, name string) (persist bool, err error) {
 }
 
 func getServer(node *yaml.Node, name string) (*configtypes.Server, error) {
+	// check if name is empty
+	if name == "" {
+		return nil, errors.New("name cannot be empty")
+	}
+
 	cfg, err := convertNodeToClientConfig(node)
 	if err != nil {
 		return nil, err
@@ -298,6 +303,11 @@ func getCurrentServer(node *yaml.Node) (s *configtypes.Server, err error) {
 }
 
 func removeCurrentServer(node *yaml.Node, name string) error {
+	// check if name is empty
+	if name == "" {
+		return errors.New("name cannot be empty")
+	}
+
 	// find current server node
 	keys := []nodeutils.Key{
 		{Name: KeyCurrentServer},
@@ -314,6 +324,11 @@ func removeCurrentServer(node *yaml.Node, name string) error {
 
 //nolint:dupl
 func removeServer(node *yaml.Node, name string) error {
+	// check if name is empty
+	if name == "" {
+		return errors.New("name cannot be empty")
+	}
+
 	// find servers node
 	keys := []nodeutils.Key{
 		{Name: KeyServers},
@@ -344,6 +359,11 @@ func setServers(node *yaml.Node, servers []*configtypes.Server) error {
 }
 
 func setServer(node *yaml.Node, s *configtypes.Server) (persist bool, err error) {
+	// check if name is empty
+	if s.Name == "" {
+		return false, errors.New("server name cannot be empty")
+	}
+
 	// Get Patch Strategies
 	patchStrategies, err := GetConfigMetadataPatchStrategy()
 	if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it
-  Without these empty checks the config items like contexts, servers etc duplicate in config files when name is empty
- Added empty value checks for config APIs to return error when encounter an empty value.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Added Unit tests
Updated the Integration tests
Cross-version compatibility tests passed

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
added empty checks for config apis. Config APIs now doesn't allow bad data to persist in the config yaml files
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
