### PR TITLE
Move the DiscoverySources config section

### DIFF
--- a/config/cli_discovery_sources.go
+++ b/config/cli_discovery_sources.go
@@ -111,8 +111,8 @@ func getCLIDiscoverySources(node *yaml.Node) ([]configtypes.PluginDiscovery, err
 	if err != nil {
 		return nil, err
 	}
-	if cfg.ClientOptions != nil && cfg.ClientOptions.CLI != nil && cfg.ClientOptions.CLI.DiscoverySources != nil {
-		return cfg.ClientOptions.CLI.DiscoverySources, nil
+	if cfg.CoreCliOptions != nil && cfg.CoreCliOptions.DiscoverySources != nil {
+		return cfg.CoreCliOptions.DiscoverySources, nil
 	}
 	return nil, errors.New("cli discovery sources not found")
 }
@@ -122,8 +122,8 @@ func getCLIDiscoverySource(node *yaml.Node, name string) (*configtypes.PluginDis
 	if err != nil {
 		return nil, err
 	}
-	if cfg.ClientOptions != nil && cfg.ClientOptions.CLI != nil && cfg.ClientOptions.CLI.DiscoverySources != nil {
-		for _, discoverySource := range cfg.ClientOptions.CLI.DiscoverySources {
+	if cfg.CoreCliOptions != nil && cfg.CoreCliOptions.DiscoverySources != nil {
+		for _, discoverySource := range cfg.CoreCliOptions.DiscoverySources {
 			_, discoverySourceName := getDiscoverySourceTypeAndName(discoverySource)
 			if discoverySourceName == name {
 				return &discoverySource, nil
@@ -131,17 +131,6 @@ func getCLIDiscoverySource(node *yaml.Node, name string) (*configtypes.PluginDis
 		}
 	}
 	return nil, errors.New("cli discovery source not found")
-}
-
-// setCLIDiscoverySources Add/Update array of cli discovery sources to the yaml node
-func setCLIDiscoverySources(node *yaml.Node, discoverySources []configtypes.PluginDiscovery) (err error) {
-	for _, discoverySource := range discoverySources {
-		_, err = setCLIDiscoverySource(node, discoverySource)
-		if err != nil {
-			return err
-		}
-	}
-	return err
 }
 
 // setCLIDiscoverySource Add/Update cli discovery source in the yaml node
@@ -154,7 +143,6 @@ func setCLIDiscoverySource(node *yaml.Node, discoverySource configtypes.PluginDi
 
 	// Find the cli discovery sources node
 	keys := []nodeutils.Key{
-		{Name: KeyClientOptions, Type: yaml.MappingNode},
 		{Name: KeyCLI, Type: yaml.MappingNode},
 		{Name: KeyDiscoverySources, Type: yaml.SequenceNode},
 	}
@@ -164,14 +152,13 @@ func setCLIDiscoverySource(node *yaml.Node, discoverySource configtypes.PluginDi
 	}
 
 	// Add or Update cli discovery source to discovery sources node based on patch strategy
-	key := fmt.Sprintf("%v.%v.%v", KeyClientOptions, KeyCLI, KeyDiscoverySources)
+	key := fmt.Sprintf("%v.%v", KeyCLI, KeyDiscoverySources)
 	return setDiscoverySource(discoverySourcesNode, discoverySource, nodeutils.WithPatchStrategyKey(key), nodeutils.WithPatchStrategies(patchStrategies))
 }
 
 func deleteCLIDiscoverySource(node *yaml.Node, name string) error {
 	// Find cli discovery sources node in the yaml node
 	keys := []nodeutils.Key{
-		{Name: KeyClientOptions},
 		{Name: KeyCLI},
 		{Name: KeyDiscoverySources},
 	}

--- a/config/config_factory_test.go
+++ b/config/config_factory_test.go
@@ -193,6 +193,7 @@ contexts:
 currentContext:
     kubernetes: test-mc
 `
+	//nolint:goconst
 	expectedCfgNextGen := `contexts:
     - name: test-mc
       target: kubernetes

--- a/config/legacy_clientconfig_factory.go
+++ b/config/legacy_clientconfig_factory.go
@@ -105,10 +105,6 @@ func clientConfigSetCLI(cfg *configtypes.ClientConfig, node *yaml.Node) (err err
 		if err != nil {
 			return err
 		}
-		err = clientConfigSetCLIDiscoverySources(cfg, node)
-		if err != nil {
-			return err
-		}
 		if cfg.ClientOptions.CLI.UnstableVersionSelector != "" {
 			setUnstableVersionSelector(node, string(cfg.ClientOptions.CLI.UnstableVersionSelector))
 		}
@@ -120,16 +116,6 @@ func clientConfigSetCLI(cfg *configtypes.ClientConfig, node *yaml.Node) (err err
 		}
 		if cfg.ClientOptions.CLI.CompatibilityFilePath != "" {
 			setCompatibilityFilePath(node, cfg.ClientOptions.CLI.CompatibilityFilePath)
-		}
-	}
-	return nil
-}
-
-func clientConfigSetCLIDiscoverySources(cfg *configtypes.ClientConfig, node *yaml.Node) error {
-	if cfg.ClientOptions.CLI.DiscoverySources != nil && len(cfg.ClientOptions.CLI.DiscoverySources) != 0 {
-		err := setCLIDiscoverySources(node, cfg.ClientOptions.CLI.DiscoverySources)
-		if err != nil {
-			return err
 		}
 	}
 	return nil

--- a/config/legacy_clientconfig_factory_test.go
+++ b/config/legacy_clientconfig_factory_test.go
@@ -108,10 +108,6 @@ currentContext:
             - local:
                 name: admin-local
                 path: admin
-            - gcp:
-                name: test
-                bucket: ctx-test-bucket
-                manifestPath: ctx-test-manifest-path
         repositories:
             - gcpPluginRepository:
                 name: test

--- a/config/patchstrategy_it_test.go
+++ b/config/patchstrategy_it_test.go
@@ -13,28 +13,7 @@ import (
 )
 
 func setupConfigData() (string, string, string, string) {
-	cfg := `clientOptions:
-  cli:
-    discoverySources:
-      - gcp:
-          name: test
-          bucket: test-bucket
-          manifestPath: test-manifest-path
-          annotation: one
-          required: true
-      - gcp:
-          name: test2
-          bucket: test-bucket2
-          manifestPath: test-manifest-path2
-          annotation: one
-          required: true
-      - local:
-          name: test-local
-          bucket: test-bucket2
-          manifestPath: test-manifest-path2
-          annotation: one
-          required: true
-servers:
+	cfg := `servers:
   - name: test-mc
     type: managementcluster
     managementClusterOpts:
@@ -60,24 +39,7 @@ contexts:
 currentContext:
   kubernetes: test-mc
 `
-	expectedCfg := `clientOptions:
-    cli:
-        discoverySources:
-            - gcp:
-                name: test
-                bucket: updated-test-bucket
-                manifestPath: updated-test-manifest-path
-                annotation: one
-            - gcp:
-                name: test2
-                bucket: test-bucket2
-                manifestPath: test-manifest-path2
-                annotation: one
-                required: true
-            - oci:
-                name: test-local
-                image: test-local-image-path
-servers:
+	expectedCfg := `servers:
     - name: test-mc
       type: managementcluster
       managementClusterOpts:
@@ -89,7 +51,25 @@ servers:
 current: test-mc
 `
 
-	cfg2 := `contexts:
+	cfg2 := `cli:
+  discoverySources:
+    - oci:
+        name: test
+        image: image
+        annotation: one
+        required: true
+    - oci:
+        name: test2
+        image: image2
+        annotation: one
+        required: true
+    - local:
+        name: test-local
+        bucket: test-bucket2
+        manifestPath: test-manifest-path2
+        annotation: one
+        required: true
+contexts:
   - name: test-mc
     target: kubernetes
     group: one
@@ -105,7 +85,21 @@ current: test-mc
 currentContext:
     kubernetes: test-mc
 `
-	expectedCfg2 := `contexts:
+	expectedCfg2 := `cli:
+    discoverySources:
+        - oci:
+            name: test
+            image: image
+            annotation: one
+        - oci:
+            name: test2
+            image: image2
+            annotation: one
+            required: true
+        - oci:
+            name: test-local
+            image: test-local-image-path
+contexts:
     - name: test-mc
       target: kubernetes
       group: one
@@ -130,7 +124,7 @@ func setupConfigMetadata() string {
     contexts.group: replace
     contexts.clusterOpts.endpoint: replace
     contexts.clusterOpts.annotation: replace
-    clientOptions.cli.discoverySources.gcp.required: replace
+    cli.discoverySources.oci.required: replace
 `
 	return metadata
 }
@@ -149,17 +143,15 @@ func TestIntegrationWithReplacePatchStrategy(t *testing.T) {
 	// Get CLI discovery sources
 	expectedSources := []configtypes.PluginDiscovery{
 		{
-			GCP: &configtypes.GCPDiscovery{
-				Name:         "test",
-				Bucket:       "test-bucket",
-				ManifestPath: "test-manifest-path",
+			OCI: &configtypes.OCIDiscovery{
+				Name:  "test",
+				Image: "image",
 			},
 		},
 		{
-			GCP: &configtypes.GCPDiscovery{
-				Name:         "test2",
-				Bucket:       "test-bucket2",
-				ManifestPath: "test-manifest-path2",
+			OCI: &configtypes.OCIDiscovery{
+				Name:  "test2",
+				Image: "image2",
 			},
 		},
 		{
@@ -175,10 +167,9 @@ func TestIntegrationWithReplacePatchStrategy(t *testing.T) {
 
 	// Get CLI Discovery Source
 	expectedSource := &configtypes.PluginDiscovery{
-		GCP: &configtypes.GCPDiscovery{
-			Name:         "test",
-			Bucket:       "test-bucket",
-			ManifestPath: "test-manifest-path",
+		OCI: &configtypes.OCIDiscovery{
+			Name:  "test",
+			Image: "image",
 		},
 	}
 
@@ -189,10 +180,9 @@ func TestIntegrationWithReplacePatchStrategy(t *testing.T) {
 	// Update CLI discovery sources
 	updatedSources := []configtypes.PluginDiscovery{
 		{
-			GCP: &configtypes.GCPDiscovery{
-				Name:         "test",
-				Bucket:       "updated-test-bucket",
-				ManifestPath: "updated-test-manifest-path",
+			OCI: &configtypes.OCIDiscovery{
+				Name:  "test",
+				Image: "image",
 			},
 		},
 		{

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -67,6 +67,7 @@ type Context struct {
 
 	// DiscoverySources determines from where to discover plugins
 	// associated with this context.
+	// Deprecated: This field is deprecated.  It is currently no used.
 	DiscoverySources []PluginDiscovery `json:"discoverySources,omitempty" yaml:"discoverySources,omitempty"`
 }
 
@@ -156,6 +157,7 @@ type CLIOptions struct {
 	// Deprecated: Repositories has been deprecated and will be removed from future version
 	Repositories []PluginRepository `json:"repositories,omitempty" yaml:"repositories,omitempty"`
 	// DiscoverySources determines from where to discover stand-alone plugins
+	// Deprecated: DiscoverySources has been deprecated and will be removed in a future version
 	DiscoverySources []PluginDiscovery `json:"discoverySources,omitempty" yaml:"discoverySources,omitempty"`
 	// UnstableVersionSelector determined which version tags are allowed
 	//
@@ -286,6 +288,8 @@ type GCPPluginRepository struct {
 type CoreCliOptions struct {
 	// CEIPOptIn is the users CEIP opt-in/opt-out status.
 	CEIPOptIn string `json:"ceipOptIn,omitempty" yaml:"ceipOptIn,omitempty"`
+	// DiscoverySources determine where to discover plugins
+	DiscoverySources []PluginDiscovery `json:"discoverySources,omitempty" yaml:"discoverySources,omitempty"`
 }
 
 // ClientConfig is the Schema for the configs API


### PR DESCRIPTION
### What this PR does / why we need it

This PR moves the DiscoverySources configuration section from "clientOptions.cli.discoverySources" to "cli.discoverySources". The actual handling of discovery sources is kept the same; it is just the section of the configuration file in which they are stored that is moved.

This change is necessary as plugins built with the previous version of the runtime library would set a "default" discovery source which the new independent CLI should not use; by moving the discovery sources section in the config file, the new CLI can ignore the old section and trust that the new section only contains valid sources, even when older plugins are used.

Note that we don't yet modify the CLI to make use of this change but simply start by making sure the `tz plugin source` commands properly work with the new section of discoverySources of the config file.  For this to work though PR https://github.com/vmware-tanzu/tanzu-cli/pull/225 must be used for the CLI. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Using PR https://github.com/vmware-tanzu/tanzu-cli/pull/225, I built the CLI and then verified that the `tanzu plugin source` commands work with the new discoverySources section.

```
# Initialize the config file
$ rm ~/.config/tanzu/config*
$ tz ceip-participation set true
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"

# Add a plugin source in the new section and verify the config
$ tz plugin source add --name central --type local --uri /Users/kmarc/tanzu/plugins/central:large
[ok] successfully added discovery source central
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"
    discoverySources:
        - local:
            name: central
            path: /Users/kmarc/tanzu/plugins/central:large

$ tz plugin source list
  NAME     TYPE   SCOPE
  central  local  Standalone

# Add a second source and verify the config
$ tz plugin source add --name default -u projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest -t oci
[ok] successfully added discovery source default
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"
    discoverySources:
        - local:
            name: central
            path: /Users/kmarc/tanzu/plugins/central:large
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

$ tz plugin source list
  NAME     TYPE   SCOPE
  central  local  Standalone
  default  oci    Standalone

# Delete a plugin source
$ tz plugin source delete central
[ok] deleted discovery source central
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

# Update a plugin source
$ tz plugin source update default -u localhost:9876/bad -t oci
[ok] updated discovery source default
$ tz config get
clientOptions:
    cli:
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        global:
            context-target-v2: "true"
cli:
    ceipOptIn: "true"
    discoverySources:
        - oci:
            name: default
            image: localhost:9876/bad

# Execute an old plugin to populate the old discoverySources section and check the config
$ tz cluster
Kubernetes cluster operations
[...]

# Notice the old and new discoverySources sections not conflicting with each other
$ tz config get
clientOptions:
    cli:
        discoverySources:
            - local:
                name: default
                path: standalone
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        cluster:
            allow-legacy-cluster: "false"
        global:
            context-aware-cli-for-plugins: "true"
            context-target-v2: "true"
        management-cluster:
            package-based-cc: "true"
cli:
    ceipOptIn: "true"
    discoverySources:
        - oci:
            name: default
            image: localhost:9876/bad

# One plugin source is considered.  It is the new one, but since I named them the same, let check further below...
$ tz plugin source list
  NAME     TYPE  SCOPE
  default  oci   Standalone

# Add a different named source
$ tz plugin source add --name default2 -u projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest -t oci
[ok] successfully added discovery source default2

# Delete the new one named "default"
$ tz plugin source delete default
[ok] deleted discovery source default

# Notice a plugin source named "default" in the old section (which will be ignored)
# and one named "default2" in the new section
$ tz config get
clientOptions:
    cli:
        discoverySources:
            - local:
                name: default
                path: standalone
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        cluster:
            allow-legacy-cluster: "false"
        global:
            context-aware-cli-for-plugins: "true"
            context-target-v2: "true"
        management-cluster:
            package-based-cc: "true"
cli:
    ceipOptIn: "true"
    discoverySources:
        - oci:
            name: default2
            image: projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest

# Notice that only the new section is considered
$ tz plugin source list
  NAME      TYPE  SCOPE
  default2  oci   Standalone

# Verify config init
$ tz config init
[ok] successfully initialized the config
$ tz config get
clientOptions:
    cli:
        discoverySources:
            - local:
                name: default
                path: standalone
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
    features:
        cluster:
            allow-legacy-cluster: "false"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
            dual-stack-ipv6-primary: "false"
        global:
            context-aware-cli-for-plugins: "true"
            context-target-v2: "true"
            tkr-version-v1alpha3-beta: "false"
        management-cluster:
            aws-instance-types-exclude-arm: "true"
            custom-nameservers: "false"
            deploy-in-cluster-ipam-provider: "true"
            dual-stack-ipv4-primary: "false"
            dual-stack-ipv6-primary: "false"
            export-from-confirm: "true"
            import: "false"
            package-based-cc: "true"
            standalone-cluster-mode: "false"
        package:
            kctrl-command-tree: "true"
cli:
    ceipOptIn: "true"
    discoverySources:
        - oci:
            name: default2
            image: projects.registry.vmware.com/tanzu_cli_stage/plugins/plugin-inventory:latest
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The configuration entries for Discovery Sources have been moved to a new section under the top-level "cli" tag.  The old "clientOptions.cli.discoverySources" section is no longer used and any content will be ignored. 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
