### PR TITLE
Add validators functionality to prompts

### DIFF
--- a/component/prompt.go
+++ b/component/prompt.go
@@ -4,10 +4,13 @@
 package component
 
 import (
+	"errors"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/AlecAivazis/survey/v2/terminal"
 )
 
@@ -112,6 +115,9 @@ type PromptOptions struct {
 	// Standard in/out/error
 	Stdio terminal.Stdio
 	Icons survey.IconSet
+
+	// Validators on user inputs
+	Validators []survey.Validator
 }
 
 // PromptOpt is an option for prompts
@@ -127,6 +133,11 @@ func translatePromptOpts(options *PromptOptions) (surveyOpts []survey.AskOpt) {
 		icons.SelectFocus = options.Icons.SelectFocus
 	}))
 
+	// Add validators
+	for _, v := range options.Validators {
+		surveyOpts = append(surveyOpts, survey.WithValidator(v))
+	}
+
 	return
 }
 
@@ -139,4 +150,39 @@ func WithStdio(in terminal.FileReader, out terminal.FileWriter, err io.Writer) P
 		options.Stdio.Err = err
 		return nil
 	}
+}
+
+// WithValidator specifies a validator to use while prompting the user
+func WithValidator(v survey.Validator) PromptOpt {
+	return func(options *PromptOptions) error {
+		// add the provided validator to the list
+		options.Validators = append(options.Validators, v)
+
+		// nothing went wrong
+		return nil
+	}
+}
+
+// Custom validators to be used in prompts
+
+// NoUpperCase checks if a given input string contains uppercase characters and returns an error if it does. This function does not panic if the input value is not a string.
+func NoUpperCase(v interface{}) error {
+	s, ok := v.(string)
+
+	if ok && strings.ToLower(s) != s {
+		return errors.New("value contains uppercase characters")
+	}
+
+	return nil
+}
+
+// NoOnlySpaces checks if a given input string contains only empty spaces and returns an error if it does. This function does not panic if the input value is not a string.
+func NoOnlySpaces(v interface{}) error {
+	s, ok := v.(string)
+
+	if ok && strings.TrimSpace(s) == "" {
+		return errors.New("value contains only spaces")
+	}
+
+	return nil
 }

--- a/component/prompt_test.go
+++ b/component/prompt_test.go
@@ -4,9 +4,11 @@
 package component
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,4 +80,97 @@ func Test_PromptOptions(t *testing.T) {
 	assert.Equal("?", options.Icons.Question.Text)
 	assert.Equal("cyan+b", options.Icons.Question.Format)
 	assert.Equal(2, len(opts))
+}
+
+func TestAskPrompt_Validation(t *testing.T) {
+	// Setup mock prompts
+	p := &mockPrompt{
+		answers: []string{"", " ", "t", "very-very-long-name", "ALL_CAPS_NAME", "Test", "test"},
+	}
+
+	var res string
+
+	// Setup PromptOpts validators
+	var promptOpts []PromptOpt
+
+	promptOpts = append(
+		promptOpts,
+		WithValidator(survey.Required),
+		WithValidator(NoOnlySpaces),
+		WithValidator(survey.MinLength(2)),
+		WithValidator(survey.MaxLength(4)),
+		WithValidator(NoUpperCase),
+	)
+
+	// Prepare the surveyOpts
+	var options = &PromptOptions{}
+	for _, opt := range promptOpts {
+		err := opt(options)
+		assert.Nil(t, err)
+	}
+	surveyOpts := translatePromptOpts(options)
+
+	// Trigger the Prompt
+	err := survey.Ask([]*survey.Question{
+		{
+			Prompt: p,
+		},
+	}, &res, surveyOpts...)
+
+	if err != nil {
+		t.Fatalf("Ask() = %v", err)
+	}
+
+	if res != "test" {
+		t.Errorf("answer: %q, want %q", res, "test")
+	}
+	if p.cleanups != 1 {
+		t.Errorf("cleanups: %d, want %d", p.cleanups, 1)
+	}
+
+	if err := p.printedErrors[0].Error(); err != "Value is required" {
+		t.Errorf("printed error 1: %q, want %q", err, "Value is required")
+	}
+	if err := p.printedErrors[1].Error(); err != "value contains only spaces" {
+		t.Errorf("printed error 2: %q, want %q", err, "value contains only spaces")
+	}
+	if err := p.printedErrors[2].Error(); err != "value is too short. Min length is 2" {
+		t.Errorf("printed error 3: %q, want %q", err, "value is too short. Min length is 2")
+	}
+	const maxLen4 = "value is too long. Max length is 4"
+	if err := p.printedErrors[3].Error(); err != maxLen4 {
+		t.Errorf("printed error 2: %q, want %q", err, maxLen4)
+	}
+	if err := p.printedErrors[4].Error(); err != maxLen4 {
+		t.Errorf("printed error 2: %q, want %q", err, maxLen4)
+	}
+	if err := p.printedErrors[5].Error(); err != "value contains uppercase characters" {
+		t.Errorf("printed error 2: %q, want %q", err, "value contains uppercase characters")
+	}
+}
+
+type mockPrompt struct {
+	index         int
+	answers       []string
+	cleanups      int
+	printedErrors []error
+}
+
+func (p *mockPrompt) Prompt(*survey.PromptConfig) (interface{}, error) {
+	if p.index >= len(p.answers) {
+		return nil, errors.New("no valid answers provided")
+	}
+	val := p.answers[p.index]
+	p.index++
+	return val, nil
+}
+
+func (p *mockPrompt) Cleanup(*survey.PromptConfig, interface{}) error {
+	p.cleanups++
+	return nil
+}
+
+func (p *mockPrompt) Error(_ *survey.PromptConfig, err error) error {
+	p.printedErrors = append(p.printedErrors, err)
+	return nil
 }


### PR DESCRIPTION
### What this PR does / why we need it

- Enable validations on prompts 
- Implemented WithValidator() to set validator functions
- Added couple of custom validators NoUpperCase(), NoOnlySpaces()

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- Added unit test to verify the changes including built in validators and custom validators
- Verified importing the tzr changes into tzc locally and tested tanzu context and tanzu login command with new validators required and NoOnlySpaces


Below testing show Required and no only spaces validators in action

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix-do-not-allow-empty-context-names)> tanzu context create
? Select context creation type Control plane endpoint
X Sorry, your reply was invalid: value contains only spaces
? Enter control plane endpoint test
X Sorry, your reply was invalid: value contains only spaces
? Give the context a name test
[i] Failed to test for vSphere supervisor: Get "test/wcp/loginbanner": unsupported protocol scheme ""
[x] : error creating kubeconfig with tanzu pinniped-auth login plugin: Get "test/wcp/loginbanner": unsupported protocol scheme ""
[x] : error creating kubeconfig with tanzu pinniped-auth login plugin: Get "test/wcp/loginbanner": unsupported protocol scheme ""
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix-do-not-allow-empty-context-names) [1]> tanzu context create
? Select context creation type Local kubeconfig
X Sorry, your reply was invalid: Value is required
? Enter path to kubeconfig (if any) test
X Sorry, your reply was invalid: Value is required
? Enter kube context to use test
X Sorry, your reply was invalid: Value is required
? Give the context a name test


```

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
prompt config accepts Validator functions to be performed on prompt answers
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
