### PR TITLE
Add configuration APIs for Certificate configuration

### DIFF
--- a/config/certs.go
+++ b/config/certs.go
@@ -1,0 +1,200 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/nodeutils"
+
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+// GetCerts retrieves all the certs
+func GetCerts() ([]*configtypes.Cert, error) {
+	// Retrieve client config node
+	node, err := getClientConfigNode()
+	if err != nil {
+		return nil, err
+	}
+
+	return getCerts(node)
+}
+
+// GetCert retrieves the cert configuration by hostname
+func GetCert(hostName string) (*configtypes.Cert, error) {
+	if hostName == "" {
+		return nil, errors.New("hostname is empty")
+	}
+	// Retrieve client config node
+	node, err := getClientConfigNode()
+	if err != nil {
+		return nil, err
+	}
+	return getCert(node, hostName)
+}
+
+// SetCert add or update cert configuration
+func SetCert(c *configtypes.Cert) error {
+	if c == nil {
+		return nil
+	}
+	if c.HostName == "" {
+		return errors.New("hostname is empty")
+	}
+	// Retrieve client config node
+	AcquireTanzuConfigLock()
+	defer ReleaseTanzuConfigLock()
+	node, err := getClientConfigNodeNoLock()
+	if err != nil {
+		return err
+	}
+	// Add or update the cert
+	persist, err := setCert(node, c)
+	if err != nil {
+		return err
+	}
+	if persist {
+		err = persistConfig(node)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// DeleteCert delete a cert configuration by hostname
+func DeleteCert(hostName string) error {
+	if hostName == "" {
+		return errors.New("hostname is empty")
+	}
+	// Retrieve client config node
+	AcquireTanzuConfigLock()
+	defer ReleaseTanzuConfigLock()
+	node, err := getClientConfigNodeNoLock()
+	if err != nil {
+		return err
+	}
+	_, err = getCert(node, hostName)
+	if err != nil {
+		return err
+	}
+	err = removeCert(node, hostName)
+	if err != nil {
+		return err
+	}
+	return persistConfig(node)
+}
+
+// CertExists checks if cert config by hostname already exists
+func CertExists(hostName string) (bool, error) {
+	if hostName == "" {
+		return false, errors.New("hostname is empty")
+	}
+	exists, _ := GetCert(hostName)
+	return exists != nil, nil
+}
+
+// Pre-reqs: node != nil
+func getCerts(node *yaml.Node) ([]*configtypes.Cert, error) {
+	cfg, err := convertNodeToClientConfig(node)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Certs != nil {
+		return cfg.Certs, nil
+	}
+	// return empty list if the config doesn't have Certs
+	return make([]*configtypes.Cert, 0), nil
+}
+
+// Pre-reqs: node != nil and hostName != ""
+func getCert(node *yaml.Node, hostName string) (*configtypes.Cert, error) {
+	cfg, err := convertNodeToClientConfig(node)
+	if err != nil {
+		return nil, err
+	}
+	for _, cert := range cfg.Certs {
+		if cert.HostName == hostName {
+			return cert, nil
+		}
+	}
+	return nil, fmt.Errorf("cert configuration for %v not found", hostName)
+}
+
+// Pre-reqs: node != nil and cert != nil
+func setCert(node *yaml.Node, cert *configtypes.Cert) (persist bool, err error) {
+	// Get Patch Strategies from config metadata
+	patchStrategies, err := GetConfigMetadataPatchStrategy()
+	if err != nil {
+		patchStrategies = make(map[string]string)
+	}
+
+	// Convert cert to node
+	newCertNode, err := convertObjectToNode(cert)
+	if err != nil {
+		return persist, err
+	}
+
+	// Find the certs node from the root node
+	keys := []nodeutils.Key{
+		{Name: KeyCerts, Type: yaml.SequenceNode},
+	}
+	certsNode := nodeutils.FindNode(node.Content[0], nodeutils.WithForceCreate(), nodeutils.WithKeys(keys))
+	if certsNode == nil {
+		return persist, err
+	}
+
+	exists := false
+	var result []*yaml.Node
+	// Skip duplicate for cert
+	for _, certNode := range certsNode.Content {
+		if index := nodeutils.GetNodeIndex(certNode.Content, "hostName"); index != -1 &&
+			certNode.Content[index].Value == cert.HostName {
+			exists = true
+			// replace the nodes as per patch strategy
+			_, err = nodeutils.DeleteNodes(newCertNode.Content[0], certNode, nodeutils.WithPatchStrategyKey(KeyCerts), nodeutils.WithPatchStrategies(patchStrategies))
+			if err != nil {
+				return false, err
+			}
+			persist, err = nodeutils.MergeNodes(newCertNode.Content[0], certNode)
+			if err != nil {
+				return false, err
+			}
+			result = append(result, certNode)
+			continue
+		}
+		result = append(result, certNode)
+	}
+	if !exists {
+		result = append(result, newCertNode.Content[0])
+		persist = true
+	}
+	certsNode.Content = result
+	return persist, err
+}
+
+//nolint:dupl
+func removeCert(node *yaml.Node, hostName string) error {
+	// Find the certs node in the yaml node
+	keys := []nodeutils.Key{
+		{Name: KeyCerts},
+	}
+	certsNode := nodeutils.FindNode(node.Content[0], nodeutils.WithKeys(keys))
+	if certsNode == nil {
+		return nil
+	}
+	var certs []*yaml.Node
+	for _, certNode := range certsNode.Content {
+		if index := nodeutils.GetNodeIndex(certNode.Content, "hostName"); index != -1 && certNode.Content[index].Value == hostName {
+			continue
+		}
+		certs = append(certs, certNode)
+	}
+	certsNode.Content = certs
+	return nil
+}

--- a/config/certs_test.go
+++ b/config/certs_test.go
@@ -1,0 +1,256 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+func TestSetGetDeleteCerts(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	cert1 := &configtypes.Cert{
+		HostName:       "test1",
+		CACertData:     "<REDACTED>",
+		SkipCertVerify: "false",
+	}
+
+	cert2 := &configtypes.Cert{
+		HostName:       "test2",
+		CACertData:     "<REDACTED>",
+		SkipCertVerify: "true",
+		Insecure:       "false",
+	}
+
+	ctx, err := GetCert("test1")
+	assert.Equal(t, "cert configuration for test1 not found", err.Error())
+	assert.Nil(t, ctx)
+
+	err = SetCert(cert1)
+	assert.NoError(t, err)
+
+	ctx, err = GetCert("test1")
+	assert.Nil(t, err)
+	assert.Equal(t, cert1, ctx)
+
+	err = SetCert(cert2)
+	assert.NoError(t, err)
+
+	ctx, err = GetCert("test2")
+	assert.Nil(t, err)
+	assert.Equal(t, cert2, ctx)
+
+	_, err = GetCert("")
+	assert.Equal(t, "hostname is empty", err.Error())
+
+	err = DeleteCert("test")
+	assert.Equal(t, "cert configuration for test not found", err.Error())
+
+	err = DeleteCert("")
+	assert.Equal(t, "hostname is empty", err.Error())
+
+	err = DeleteCert("test1")
+	assert.Nil(t, err)
+
+	ctx, err = GetCert("test1")
+	assert.Nil(t, ctx)
+	assert.Equal(t, "cert configuration for test1 not found", err.Error())
+}
+
+func TestSetCert(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	tests := []struct {
+		name   string
+		cert   *configtypes.Cert
+		errStr string
+	}{
+		{
+			name: "should add new cert to empty client config",
+			cert: &configtypes.Cert{
+				HostName:       "test.vmware.com",
+				CACertData:     "testCAData",
+				SkipCertVerify: "true",
+				Insecure:       "true",
+			},
+		},
+		{
+			name: "should update existing cert",
+			cert: &configtypes.Cert{
+				HostName:       "test.vmware.com",
+				CACertData:     "testCADataUpdated",
+				Insecure:       "false",
+				SkipCertVerify: "false",
+			},
+		},
+		{
+			name: "should update existing cert with SkipCertVerify and Insecure field",
+			cert: &configtypes.Cert{
+				HostName:       "test.vmware.com",
+				CACertData:     "testCADataUpdated",
+				SkipCertVerify: "true",
+				Insecure:       "true",
+			},
+		},
+		{
+			name: "should add the new cert to the existing certs",
+			cert: &configtypes.Cert{
+				HostName:       "test.vmware.com:443",
+				CACertData:     "testCAData2",
+				SkipCertVerify: "true",
+				Insecure:       "false",
+			},
+		},
+		{
+			name: "should return error when the hostname is empty",
+			cert: &configtypes.Cert{
+				HostName:       "",
+				CACertData:     "testCAData2",
+				SkipCertVerify: "true",
+				Insecure:       "false",
+			},
+			errStr: "hostname is empty",
+		},
+		{
+			name: "should not return error when the cert is nil",
+			cert: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := SetCert(tc.cert)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+			// if cert is not nil, validate with GetCert
+			if tc.cert != nil {
+				ok, err := CertExists(tc.cert.HostName)
+				if tc.errStr == "" {
+					assert.True(t, ok)
+					assert.NoError(t, err)
+				} else {
+					assert.EqualError(t, err, tc.errStr)
+				}
+
+				gotCert, err := GetCert(tc.cert.HostName)
+				if tc.errStr == "" {
+					assert.NoError(t, err)
+					assert.Equal(t, tc.cert, gotCert)
+				} else {
+					assert.EqualError(t, err, tc.errStr)
+				}
+			}
+		})
+	}
+}
+
+func TestGetCerts(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	tests := []struct {
+		name      string
+		cert      *configtypes.Cert
+		errStr    string
+		wantCerts []*configtypes.Cert
+	}{
+		{
+			name:      "should return empty list when no certs were added",
+			cert:      nil,
+			wantCerts: []*configtypes.Cert{},
+		},
+		{
+			name: "should return the cert added",
+			cert: &configtypes.Cert{
+				HostName:   "test.vmware.com",
+				CACertData: "testCAData",
+				Insecure:   "false",
+			},
+			wantCerts: []*configtypes.Cert{
+				{
+					HostName:   "test.vmware.com",
+					CACertData: "testCAData",
+					Insecure:   "false",
+				},
+			},
+		},
+		{
+			name: "should return the cert updated",
+			cert: &configtypes.Cert{
+				HostName:   "test.vmware.com",
+				CACertData: "testCADataUpdated",
+				Insecure:   "true",
+			},
+			wantCerts: []*configtypes.Cert{
+				{
+					HostName:   "test.vmware.com",
+					CACertData: "testCADataUpdated",
+					Insecure:   "true",
+				},
+			},
+		},
+		{
+			name: "should return both the existing and the new cert added",
+			cert: &configtypes.Cert{
+				HostName:       "test.vmware.com:443",
+				CACertData:     "testCAData2",
+				SkipCertVerify: "true",
+				Insecure:       "false",
+			},
+			wantCerts: []*configtypes.Cert{
+				{
+					HostName:   "test.vmware.com",
+					CACertData: "testCADataUpdated",
+					Insecure:   "true",
+				},
+				{
+					HostName:       "test.vmware.com:443",
+					CACertData:     "testCAData2",
+					SkipCertVerify: "true",
+					Insecure:       "false",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := SetCert(tc.cert)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+
+			gotCerts, err := GetCerts()
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.wantCerts, gotCerts)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+		})
+	}
+}

--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -23,4 +23,5 @@ const (
 	KeyBomRepo                 = "bomRepo"
 	KeyCompatibilityFilePath   = "compatibilityFilePath"
 	KeyCEIPOptIn               = "ceipOptIn"
+	KeyCerts                   = "certs"
 )

--- a/config/conversion.go
+++ b/config/conversion.go
@@ -180,6 +180,7 @@ func convertObjectToNode[
 		*configtypes.Server |
 		*configtypes.PluginRepository |
 		*configtypes.Context |
+		*configtypes.Cert |
 		*configtypes.PluginDiscovery](obj T) (*yaml.Node, error) {
 
 	bytes, err := yaml.Marshal(obj)

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -288,6 +288,18 @@ type CoreCliOptions struct {
 	CEIPOptIn string `json:"ceipOptIn,omitempty" yaml:"ceipOptIn,omitempty"`
 }
 
+// Cert provides a certificate configuration for an endpoint
+type Cert struct {
+	// Host is the host name/ip for which the certificate configuration is applicable
+	HostName string `json:"hostName,omitempty" yaml:"hostName,omitempty"`
+	// CACertData is the CA certificate for the host
+	CACertData string `json:"caCertData,omitempty" yaml:"caCertData,omitempty"`
+	// Insecure is to allow insecure connections with host
+	Insecure string `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	// SkipCertVerify is to skip certificate validation
+	SkipCertVerify string `json:"skipCertVerify,omitempty" yaml:"skipCertVerify,omitempty"`
+}
+
 // ClientConfig is the Schema for the configs API
 type ClientConfig struct {
 	// KnownServers available.
@@ -312,6 +324,9 @@ type ClientConfig struct {
 	// CoreCliOptions are core CLI specific options that are specific to CLI(not for plugins) like ceipOptIn, etc
 	// that goes into nextgen configuration file.
 	CoreCliOptions *CoreCliOptions `json:"cli,omitempty" yaml:"cli,omitempty"`
+
+	// Certs is the collection of hostname, and it's certificate data used to communicate with the host
+	Certs []*Cert `json:"certs,omitempty" yaml:"certs,omitempty"`
 }
 
 // ClientConfigList contains a list of ClientConfig


### PR DESCRIPTION
### What this PR does / why we need it
This PR is to add configuration APIs for custom certificate configuration

The sample configuration is shown below which would be added to the configuration file (config-ng.yaml)

```
certs:
    - hostName: localhost:9876
      skipCertVerify: "true"
      insecure: "true"
      caCertData: <REDACTED>
```
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Unit tests and CI passed
<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add configuration APIs for Certificate configuration
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
