### PR TITLE
Add EULA Acceptance support

### DIFF
--- a/config/cli_options_nextgen_test.go
+++ b/config/cli_options_nextgen_test.go
@@ -26,7 +26,7 @@ func TestSetCEIPOptIn(t *testing.T) {
 			value: "true",
 		},
 		{
-			name:  "should update and persist eipOptIn value as false",
+			name:  "should update and persist ceipOptIn value as false",
 			value: "false",
 		},
 		{
@@ -42,6 +42,56 @@ func TestSetCEIPOptIn(t *testing.T) {
 			c, err := GetCEIPOptIn()
 			assert.Equal(t, spec.value, c)
 			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestSetEULAStatus(t *testing.T) {
+	// Setup config test data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	tests := []struct {
+		name        string
+		value       EULAStatus
+		expectError bool
+	}{
+		{
+			name:        "should persist eulaStatus value as accepted when empty client config",
+			value:       EULAStatusAccepted,
+			expectError: false,
+		},
+		{
+			name:        "should update and persist shown eulaStatus value",
+			value:       EULAStatusShown,
+			expectError: false,
+		},
+		{
+			name:        "should update and persist unset eulaStatus value",
+			value:       EULAStatusUnset,
+			expectError: false,
+		},
+		{
+			name:        "should error on invalid eulaStatus value",
+			value:       EULAStatus("invalidinvalid"),
+			expectError: true,
+		},
+	}
+
+	for _, spec := range tests {
+		t.Run(spec.name, func(t *testing.T) {
+			err := SetEULAStatus(spec.value)
+			if spec.expectError {
+				assert.Equal(t, "invalid eula status", err.Error())
+			} else {
+				assert.NoError(t, err)
+				val, err := GetEULAStatus()
+				assert.Equal(t, spec.value, val)
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/config/clientconfig_factory_test.go
+++ b/config/clientconfig_factory_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestClientConfigNodeUpdateInParallel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	addServer := func(mcName string) error {
 		_, err := getClientConfigNode()
 		if err != nil {

--- a/config/clientconfig_test.go
+++ b/config/clientconfig_test.go
@@ -255,6 +255,10 @@ func TestConfigLegacyDirWithoutEnvConfigKey(t *testing.T) {
 }
 
 func TestClientConfigUpdateInParallel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	addServer := func(mcName string) error {
 		_, err := GetClientConfig()
 		if err != nil {

--- a/config/clientconfignextgen_factory_test.go
+++ b/config/clientconfignextgen_factory_test.go
@@ -35,6 +35,10 @@ func TestGetClientConfigNextGenNode(t *testing.T) {
 }
 
 func TestClientConfigNextGenNodeUpdateInParallel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	addContext := func(mcName string) error {
 		_, err := getClientConfigNextGenNode()
 		if err != nil {

--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -23,5 +23,6 @@ const (
 	KeyBomRepo                 = "bomRepo"
 	KeyCompatibilityFilePath   = "compatibilityFilePath"
 	KeyCEIPOptIn               = "ceipOptIn"
+	KeyEULAStatus              = "eulaStatus"
 	KeyCerts                   = "certs"
 )

--- a/config/metadata_factory_test.go
+++ b/config/metadata_factory_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestConfigMetadataNodeUpdateInParallel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	addPatchStrategy := func(key, value string) error {
 		// Get config metadata node
 		_, err := getMetadataNode()

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -286,8 +286,10 @@ type GCPPluginRepository struct {
 // CoreCliOptions are core CLI specific options that are specific to CLI(not for plugins) like ceipOptIn, etc
 // that goes into nextgen configuration file.
 type CoreCliOptions struct {
-	// CEIPOptIn is the users CEIP opt-in/opt-out status.
+	// CEIPOptIn is the user's CEIP opt-in/opt-out status.
 	CEIPOptIn string `json:"ceipOptIn,omitempty" yaml:"ceipOptIn,omitempty"`
+	// EULAStatus is the EULA acceptance status.
+	EULAStatus string `json:"eulaStatus,omitempty" yaml:"eulaStatus,omitempty"`
 	// DiscoverySources determine where to discover plugins
 	DiscoverySources []PluginDiscovery `json:"discoverySources,omitempty" yaml:"discoverySources,omitempty"`
 }


### PR DESCRIPTION
### What this PR does / why we need it

 Implement {Get,Set}EULAStatus
 to read/write user's EULA acceptance status.

`tanzu eula show`
 
Shows agreement text AND prompts for user to accept terms.

Displays short text summarizing general terms, with link to online URL with more details.

`tanzu eula accept`

bypasses the interactive display of the terms, and accepts them immediately. 

This is useful for automation use cases. 

Also:
- small number of unit tests are taking >90% of run time (upwards of 1.5 minutes), configured them so they are skippable with go test -short.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #N/A

### Describe testing done for PR

Ran updated unit tests.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
