### PR TITLE
Bug fix: Update plugin usage to include target

### DIFF
--- a/plugin/root.go
+++ b/plugin/root.go
@@ -25,6 +25,9 @@ func newRootCmd(descriptor *PluginDescriptor) *cobra.Command {
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
 		},
+		Annotations: map[string]string{
+			"target": string(descriptor.Target),
+		},
 	}
 	cobra.AddTemplateFuncs(TemplateFuncs)
 	cmd.SetUsageTemplate(CmdTemplate)

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -23,8 +23,8 @@ var UsageFunc = func(c *cobra.Command) error {
 
 // CmdTemplate is the template for plugin commands.
 const CmdTemplate = `{{ bold "Usage:" }}{{if .Runnable}}
-  tanzu {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  tanzu {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+  tanzu{{ $target := index .Annotations "target" }}{{ if and (ne $target "global") (ne $target "") }} {{ $target }} {{ else }} {{ end }}{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  tanzu{{ $target := index .Annotations "target" }}{{ if and (ne $target "global") (ne $target "") }} {{ $target }} {{ else }} {{ end }}{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 {{ bold "Aliases:" }}
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
@@ -44,7 +44,7 @@ const CmdTemplate = `{{ bold "Usage:" }}{{if .Runnable}}
 {{ bold "Additional help topics:" }}{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
 
-Use "{{if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{else}}tanzu {{.CommandPath}}{{end}} [command] --help" for more information about a command.{{end}}
+Use "{{if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{else}}tanzu{{ $target := index .Annotations "target" }}{{ if and (ne $target "global") (ne $target "") }} {{ $target }} {{ else }} {{ end }}{{.CommandPath}}{{end}} [command] --help" for more information about a command.{{end}}
 `
 
 // TemplateFuncs are the template usage funcs.


### PR DESCRIPTION
### What this PR does / why we need it
- Update newRootCmd function to add target annotation for plugin root command
-  Update plugin execute function to propagate the target annotation from parent to all children commands
- Update the usage template to include target annotation

Few caveats:
- This fix addresses the plugins built with latest runtime after this fix. Existing plugins using previous runtime will not pick this change and issue still exists.
- Plugins need to be updated to latest runtime to pick this change.

- With kubernetes targeted plugins
Both Commands `tz hello create -h `and `tz k8s hello create -h` will display the help usage with target kubernetes
```
mpanchajanya@mpanchajanF09MK ~> tz hello create -h
Tanzu CLI plugins to create

Usage:
  tanzu kubernetes hello create [flags]
  tanzu kubernetes hello create [command]

Aliases:
  create, tmc

Available Commands:
  try         Try and possibly fail at something
  version     Print the version number of Hugo

Flags:
  -h, --help   help for create

Use "tanzu kubernetes hello create [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~> tz k8s hello create -h
Tanzu CLI plugins to create

Usage:
  tanzu kubernetes hello create [flags]
  tanzu kubernetes hello create [command]

Aliases:
  create, tmc

Available Commands:
  try         Try and possibly fail at something
  version     Print the version number of Hugo

Flags:
  -h, --help   help for create

Use "tanzu kubernetes hello create [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~>

```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- Create a new plugin hello with target kubernetes and few child commands
```
mpanchajanya@mpanchajanF09MK ~> tz
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components

  Build
    accelerator             Manage accelerators in a Kubernetes cluster

  Manage
    hello                   Hello Plugin1.1

  System
    ceip-participation      Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    login                   Login to the platform
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

Not logged in
mpanchajanya@mpanchajanF09MK ~> tz k8s
Tanzu CLI plugins that target a Kubernetes cluster

Usage:
  tanzu kubernetes [command]

Available command groups:

  Build
    accelerator             Manage accelerators in a Kubernetes cluster

  Manage
    hello                   Hello Plugin1.1


Flags:
  -h, --help   help for kubernetes

Use "tanzu kubernetes [command] --help" for more information about a command.

Not logged in
mpanchajanya@mpanchajanF09MK ~> tz k8s hello
Hello Plugin1.1

Usage:
  tanzu kubernetes hello [command]

Aliases:
  hello, hello

Available Commands:
  create        Tanzu CLI plugins to create
  list          Tanzu CLI plugins to list

Flags:
  -h, --help   help for hello

Use "tanzu kubernetes hello [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~> tz k8s hello list -h
Tanzu CLI plugins to list

Usage:
  tanzu kubernetes hello list [flags]
  tanzu kubernetes hello list [command]

Aliases:
  list, k8s

Available Commands:
  try         Try and possibly fail at something
  version     Print the version number of Hugo

Flags:
  -h, --help   help for list

Use "tanzu kubernetes hello list [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~> tz k8s hello list try -h
Try and possibly fail at something

Usage:
  tanzu kubernetes hello list try [flags]

Flags:
  -h, --help   help for try
mpanchajanya@mpanchajanF09MK ~>

```
- Delete the hello plugin
```
mpanchajanya@mpanchajanF09MK ~> tz plugin delete hello
Deleting Plugin 'hello' for target 'kubernetes'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'hello'
mpanchajanya@mpanchajanF09MK ~>
```

- Update the hello plugin with target mission-control and re build

```
mpanchajanya@mpanchajanF09MK ~> tz
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components

  Build
    accelerator             Manage accelerators in a Kubernetes cluster

  System
    ceip-participation      Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    login                   Login to the platform
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

Not logged in
mpanchajanya@mpanchajanF09MK ~> tz tmc
Tanzu CLI plugins that target a Tanzu Mission Control endpoint

Usage:
  tanzu mission-control [command]

Available command groups:

  Manage
    hello                   Hello Plugin1.1


Flags:
  -h, --help   help for mission-control

Use "tanzu mission-control [command] --help" for more information about a command.

Not logged in
mpanchajanya@mpanchajanF09MK ~> tz tmc hello
Hello Plugin1.1

Usage:
  tanzu mission-control hello [command]

Aliases:
  hello, hello

Available Commands:
  create        Tanzu CLI plugins to create
  list          Tanzu CLI plugins to list

Flags:
  -h, --help   help for hello

Use "tanzu mission-control hello [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~> tz tmc hello list -h
Tanzu CLI plugins to list

Usage:
  tanzu mission-control hello list [flags]
  tanzu mission-control hello list [command]

Aliases:
  list, k8s

Available Commands:
  try         Try and possibly fail at something
  version     Print the version number of Hugo

Flags:
  -h, --help   help for list

Use "tanzu mission-control hello list [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~> tz tmc hello list try -h
Try and possibly fail at something

Usage:
  tanzu mission-control hello list try [flags]

Flags:
  -h, --help   help for try
mpanchajanya@mpanchajanF09MK ~>

```

- Delete the hello plugin
```
mpanchajanya@mpanchajanF09MK ~> tz plugin delete hello
Deleting Plugin 'hello' for target 'kubernetes'. Are you sure? [y/N]: y
[ok] successfully deleted plugin 'hello'
mpanchajanya@mpanchajanF09MK ~>
```

- Update the hello plugin target to global
```
mpanchajanya@mpanchajanF09MK ~> tz
Usage:
  tanzu [command]

Available command groups:

  Admin
    builder                 Build Tanzu components

  Build
    accelerator             Manage accelerators in a Kubernetes cluster

  Manage
    hello                   Hello Plugin1.1

  System
    ceip-participation      Manage VMware's Customer Experience Improvement Program (CEIP) Participation (subject to change)
    completion              Output shell completion code
    config                  Configuration for the CLI
    context                 Configure and manage contexts for the Tanzu CLI
    init                    Initialize the CLI
    login                   Login to the platform
    plugin                  Manage CLI plugins
    version                 Version information

  Target
    kubernetes              Tanzu CLI plugins that target a Kubernetes cluster
    mission-control         Tanzu CLI plugins that target a Tanzu Mission Control endpoint


Flags:
  -h, --help   help for tanzu

Use "tanzu [command] --help" for more information about a command.

Not logged in
mpanchajanya@mpanchajanF09MK ~> tz hello
Hello Plugin1.1

Usage:
  tanzu hello [command]

Aliases:
  hello, hello

Available Commands:
  create        Tanzu CLI plugins to create
  list          Tanzu CLI plugins to list

Flags:
  -h, --help   help for hello

Use "tanzu hello [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~> tz hello create -h
Tanzu CLI plugins to create

Usage:
  tanzu hello create [flags]
  tanzu hello create [command]

Aliases:
  create, tmc

Available Commands:
  try         Try and possibly fail at something
  version     Print the version number of Hugo

Flags:
  -h, --help   help for create

Use "tanzu hello create [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~> tz hello create try -h
Try and possibly fail at something

Usage:
  tanzu hello list try [flags]

Flags:
  -h, --help   help for try
mpanchajanya@mpanchajanF09MK ~>

```
<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Target kubernetes/mission-control will be displayed in help usage of plugins built with latest runtime 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
