### PR TITLE
Deprecate legacy config APIs

### DIFF
--- a/config/cli_options.go
+++ b/config/cli_options.go
@@ -11,6 +11,8 @@ import (
 )
 
 // GetEdition retrieves ClientOptions Edition
+//
+// Deprecated: This API is deprecated
 func GetEdition() (string, error) {
 	// Retrieve client config node
 	node, err := getClientConfigNode()
@@ -21,6 +23,8 @@ func GetEdition() (string, error) {
 }
 
 // SetEdition adds or updates edition value
+//
+// Deprecated: This API is deprecated
 func SetEdition(val string) (err error) {
 	// Check if val is empty
 	if val == "" {
@@ -44,6 +48,7 @@ func SetEdition(val string) (err error) {
 	return err
 }
 
+// Deprecated: This method is deprecated
 func setEdition(node *yaml.Node, val string) (persist bool) {
 	editionNode := getCLIOptionsChildNode(KeyEdition, node)
 	if editionNode != nil && editionNode.Value != val {
@@ -53,18 +58,19 @@ func setEdition(node *yaml.Node, val string) (persist bool) {
 	return persist
 }
 
+// Deprecated: This method is deprecated
 func getEdition(node *yaml.Node) (string, error) {
 	cfg, err := convertNodeToClientConfig(node)
 	if err != nil {
 		return "", err
 	}
 	if cfg != nil && cfg.ClientOptions != nil && cfg.ClientOptions.CLI != nil {
-		//nolint:staticcheck
 		return string(cfg.ClientOptions.CLI.Edition), nil
 	}
 	return "", errors.New("edition not found")
 }
 
+// Deprecated: This method is deprecated
 func setUnstableVersionSelector(node *yaml.Node, name string) (persist bool) {
 	unstableVersionSelectorNode := getCLIOptionsChildNode(KeyUnstableVersionSelector, node)
 	if unstableVersionSelectorNode != nil && unstableVersionSelectorNode.Value != name {
@@ -74,6 +80,7 @@ func setUnstableVersionSelector(node *yaml.Node, name string) (persist bool) {
 	return persist
 }
 
+// Deprecated: This method is deprecated
 func setBomRepo(node *yaml.Node, repo string) (persist bool) {
 	bomRepoNode := getCLIOptionsChildNode(KeyBomRepo, node)
 	if bomRepoNode != nil && bomRepoNode.Value != repo {
@@ -83,6 +90,7 @@ func setBomRepo(node *yaml.Node, repo string) (persist bool) {
 	return persist
 }
 
+// Deprecated: This method is deprecated
 func setCompatibilityFilePath(node *yaml.Node, filepath string) (persist bool) {
 	compatibilityFilePathNode := getCLIOptionsChildNode(KeyCompatibilityFilePath, node)
 	if compatibilityFilePathNode.Value != filepath {
@@ -93,6 +101,8 @@ func setCompatibilityFilePath(node *yaml.Node, filepath string) (persist bool) {
 }
 
 // getCLIOptionsChildNode parses the yaml node and returns the matched node based on configOptions
+//
+// Deprecated: This method is deprecated
 func getCLIOptionsChildNode(key string, node *yaml.Node) *yaml.Node {
 	configOptions := func(c *nodeutils.CfgNode) {
 		c.ForceCreate = true

--- a/config/cli_repositories.go
+++ b/config/cli_repositories.go
@@ -14,6 +14,8 @@ import (
 )
 
 // GetCLIRepositories retrieves cli repositories
+//
+// Deprecated: This API is deprecated
 func GetCLIRepositories() ([]configtypes.PluginRepository, error) {
 	// Retrieve client config node
 	node, err := getClientConfigNode()
@@ -25,6 +27,8 @@ func GetCLIRepositories() ([]configtypes.PluginRepository, error) {
 }
 
 // GetCLIRepository retrieves cli repository by name
+//
+// Deprecated: This API is deprecated
 func GetCLIRepository(name string) (*configtypes.PluginRepository, error) {
 	// Retrieve client config node
 	node, err := getClientConfigNode()
@@ -36,6 +40,8 @@ func GetCLIRepository(name string) (*configtypes.PluginRepository, error) {
 }
 
 // SetCLIRepository add or update a repository
+//
+// Deprecated: This API is deprecated
 func SetCLIRepository(repository configtypes.PluginRepository) (err error) {
 	// Retrieve client config node
 	AcquireTanzuConfigLock()
@@ -63,6 +69,8 @@ func SetCLIRepository(repository configtypes.PluginRepository) (err error) {
 }
 
 // DeleteCLIRepository delete a cli repository by name
+//
+// Deprecated: This API is deprecated
 func DeleteCLIRepository(name string) error {
 	// Retrieve client config node
 	AcquireTanzuConfigLock()
@@ -82,6 +90,7 @@ func DeleteCLIRepository(name string) error {
 	return persistConfig(node)
 }
 
+// Deprecated: This method is deprecated
 func getCLIRepositories(node *yaml.Node) ([]configtypes.PluginRepository, error) {
 	cfg, err := convertNodeToClientConfig(node)
 	if err != nil {
@@ -93,6 +102,7 @@ func getCLIRepositories(node *yaml.Node) ([]configtypes.PluginRepository, error)
 	return nil, errors.New("cli repositories not found")
 }
 
+// Deprecated: This method is deprecated
 func getCLIRepository(node *yaml.Node, name string) (*configtypes.PluginRepository, error) {
 	cfg, err := convertNodeToClientConfig(node)
 	if err != nil {
@@ -109,6 +119,7 @@ func getCLIRepository(node *yaml.Node, name string) (*configtypes.PluginReposito
 	return nil, errors.New("cli repository not found")
 }
 
+// Deprecated: This method is deprecated
 func setCLIRepositories(node *yaml.Node, repos []configtypes.PluginRepository) (err error) {
 	for _, repository := range repos {
 		_, err = setCLIRepository(node, repository)
@@ -119,6 +130,7 @@ func setCLIRepositories(node *yaml.Node, repos []configtypes.PluginRepository) (
 	return err
 }
 
+// Deprecated: This method is deprecated
 func setCLIRepository(node *yaml.Node, repository configtypes.PluginRepository) (persist bool, err error) {
 	// Retrieve the patch strategies from config metadata
 	patchStrategies, err := GetConfigMetadataPatchStrategy()
@@ -141,6 +153,7 @@ func setCLIRepository(node *yaml.Node, repository configtypes.PluginRepository) 
 	return setRepository(cliRepositoriesNode, repository, nodeutils.WithPatchStrategies(patchStrategies), nodeutils.WithPatchStrategyKey(fmt.Sprintf("%v.%v.%v", KeyClientOptions, KeyCLI, KeyRepositories)))
 }
 
+// Deprecated: This method is deprecated
 func deleteCLIRepository(node *yaml.Node, name string) error {
 	// Find the cli repositories node in the yaml node
 	keys := []nodeutils.Key{
@@ -176,6 +189,7 @@ func deleteCLIRepository(node *yaml.Node, name string) error {
 	return nil
 }
 
+// Deprecated: This method is deprecated
 func setRepository(repositoriesNode *yaml.Node, repository configtypes.PluginRepository, patchStrategyOpts ...nodeutils.PatchStrategyOpts) (persist bool, err error) {
 	newNode, err := convertObjectToNode(&repository)
 	if err != nil {
@@ -223,6 +237,7 @@ func setRepository(repositoriesNode *yaml.Node, repository configtypes.PluginRep
 	return persist, err
 }
 
+// Deprecated: This method is deprecated
 func getRepositoryTypeAndName(repository configtypes.PluginRepository) (string, string) {
 	if repository.GCPPluginRepository != nil && repository.GCPPluginRepository.Name != "" {
 		return "gcpPluginRepository", repository.GCPPluginRepository.Name

--- a/config/legacy_clientconfig.go
+++ b/config/legacy_clientconfig.go
@@ -14,6 +14,7 @@ import (
 
 // CopyLegacyConfigDir copies configuration files from legacy config dir to the new location. This is a no-op if the legacy dir
 // does not exist or if the new config dir already exists.
+// Deprecated: This API is deprecated use config next gen APIs
 func CopyLegacyConfigDir() error {
 	legacyPath, err := legacyLocalDir()
 	if err != nil {
@@ -42,6 +43,8 @@ func CopyLegacyConfigDir() error {
 }
 
 // storeConfigToLegacyDir stores configuration to legacy dir and logs warning in case of errors.
+//
+// Deprecated: This method is deprecated
 func storeConfigToLegacyDir(data []byte) {
 	var (
 		err                      error
@@ -74,6 +77,8 @@ func storeConfigToLegacyDir(data []byte) {
 }
 
 // persistLegacyClientConfig write to config.yaml
+//
+// Deprecated: This method is deprecated
 func persistLegacyClientConfig(node *yaml.Node) error {
 	data, err := yaml.Marshal(node)
 	if err != nil {

--- a/config/legacy_clientconfig_factory.go
+++ b/config/legacy_clientconfig_factory.go
@@ -99,6 +99,7 @@ func clientConfigSetClientOptions(cfg *configtypes.ClientConfig, node *yaml.Node
 	return nil
 }
 
+// Deprecated: This method is deprecated
 func clientConfigSetCLI(cfg *configtypes.ClientConfig, node *yaml.Node) (err error) {
 	if cfg.ClientOptions.CLI != nil {
 		err = clientConfigSetCLIRepositories(cfg, node)
@@ -121,6 +122,7 @@ func clientConfigSetCLI(cfg *configtypes.ClientConfig, node *yaml.Node) (err err
 	return nil
 }
 
+// Deprecated: This method is deprecated
 func clientConfigSetCLIRepositories(cfg *configtypes.ClientConfig, node *yaml.Node) error {
 	if cfg.ClientOptions.CLI.Repositories != nil && len(cfg.ClientOptions.CLI.Repositories) != 0 {
 		err := setCLIRepositories(node, cfg.ClientOptions.CLI.Repositories)

--- a/config/types/clientconfig.go
+++ b/config/types/clientconfig.go
@@ -38,29 +38,47 @@ var (
 
 const (
 	// AllUnstableVersions allows all plugin versions
+	//
+	// Deprecated: This API constant is deprecated
 	AllUnstableVersions VersionSelectorLevel = "all"
 	// AlphaUnstableVersions allows all alpha tagged versions
+	//
+	// Deprecated: This API constant is deprecated
 	AlphaUnstableVersions VersionSelectorLevel = "alpha"
 	// ExperimentalUnstableVersions includes all pre-releases, minus +build tags
+	//
+	// Deprecated: This API constant is deprecated
 	ExperimentalUnstableVersions VersionSelectorLevel = "experimental"
 	// NoUnstableVersions allows no unstable plugin versions, format major.minor.patch only
+	//
+	// Deprecated: This API constant is deprecated
 	NoUnstableVersions VersionSelectorLevel = "none"
 )
 
 const (
 	// FeatureCli allows a feature to be set at the CLI level (globally) rather than for a single plugin
+	//
+	// Deprecated: This API constant is deprecated
 	FeatureCli string = "cli"
 	// EditionStandard refers to the standard edition
 	// Edition value (in config) affects branding and cluster creation
+	//
+	// Deprecated: This API constant is deprecated
 	EditionStandard = "tkg"
 	// EditionCommunity refers to the community edition
+	//
+	// Deprecated: This API constant is deprecated
 	EditionCommunity = "tce"
 )
 
 // EditionSelector allows selecting edition versions based on config file
+//
+// Deprecated: This type is deprecated
 type EditionSelector string
 
 // VersionSelectorLevel allows selecting plugin versions based on semver properties
+//
+// Deprecated: This API type is deprecated
 type VersionSelectorLevel string
 
 // IsGlobal tells if the server is global.
@@ -90,6 +108,8 @@ func (c *ClientConfig) GetCurrentServer() (*Server, error) {
 }
 
 // HasServer tells whether the Server by the given name exists.
+//
+// Deprecated: This API is deprecated. Use HasContext instead.
 func (c *ClientConfig) HasServer(name string) bool {
 	for _, s := range c.KnownServers {
 		if s.Name == name {

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -139,6 +139,8 @@ type GlobalServerAuth struct {
 // ClientOptions are the client specific options.
 type ClientOptions struct {
 	// CLI options specific to the CLI.
+	//
+	// Deprecated: CLI has been deprecated and will be removed from future version. use CoreCliOptions
 	CLI      *CLIOptions           `json:"cli,omitempty" yaml:"cli,omitempty"`
 	Features map[string]FeatureMap `json:"features,omitempty" yaml:"features,omitempty"`
 	Env      map[string]string     `json:"env,omitempty" yaml:"env,omitempty"`
@@ -151,13 +153,16 @@ type FeatureMap map[string]string
 type EnvMap map[string]string
 
 // CLIOptions are options for the CLI.
+//
+// Deprecated: CLIOptions has been deprecated and will be removed from future version
 type CLIOptions struct {
 	// Repositories are the plugin repositories.
 	//
 	// Deprecated: Repositories has been deprecated and will be removed from future version
 	Repositories []PluginRepository `json:"repositories,omitempty" yaml:"repositories,omitempty"`
 	// DiscoverySources determines from where to discover stand-alone plugins
-	// Deprecated: DiscoverySources has been deprecated and will be removed in a future version
+	//
+	// Deprecated: DiscoverySources has been deprecated and will be removed in a future version. use CoreCliOptions.DiscoverySources
 	DiscoverySources []PluginDiscovery `json:"discoverySources,omitempty" yaml:"discoverySources,omitempty"`
 	// UnstableVersionSelector determined which version tags are allowed
 	//
@@ -336,6 +341,8 @@ type ClientConfig struct {
 }
 
 // ClientConfigList contains a list of ClientConfig
+//
+// Deprecated: ClientConfigList struct is deprecated. Use ClientConfig instead.
 type ClientConfigList struct {
 	Items []ClientConfig `json:"items"`
 }


### PR DESCRIPTION
### What this PR does / why we need it
- Deprecate legacy config apis to encourage use of new config next gen apis.
APIs related to CLIOptions are deprecated to use CoreCLIOptions
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
make lint to verify no staticcheck issues

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
legacy config apis are marked for deprecation . use new config next gen apis
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
