### PR TITLE
 Provide experimental SyncPluginsForTarget API

### DIFF
--- a/plugin/sync_plugins.go
+++ b/plugin/sync_plugins.go
@@ -1,0 +1,44 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+// SyncPluginsForTarget will attempt to install plugins required by the active
+// Context of the provided target. This is most useful for any plugin
+// implementation which creates a new Context or updates an existing one as
+// part of its operation, and prefers that the plugins appropriate for the
+// Context are immediately available for use.
+//
+// Note: This API is considered EXPERIMENTAL. Both the function's signature and
+// implementation are subjected to change/removal if an alternative means to
+// provide equivalent functionality can be introduced.
+//
+// Stdout output of the command is returned as a string on successful
+// execution of the command, otherwise, the Stderr output is returned instead.
+func SyncPluginsForTarget(target types.Target) (string, error) {
+	// For now, the implementation expects env var TANZU_BIN to be set and
+	// pointing to the core CLI binary used to invoke the plugin sync with.
+
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+
+	cliPath := os.Getenv("TANZU_BIN")
+	command := exec.Command(cliPath, "plugin", "sync")
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err := command.Run()
+
+	if err != nil {
+		return stderr.String(), err
+	}
+	return stdout.String(), nil
+}

--- a/plugin/sync_plugins.go
+++ b/plugin/sync_plugins.go
@@ -5,11 +5,33 @@ package plugin
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
+
+const (
+	// customCommandName is the name of the command expected to be implemented
+	// by the CLI should there be a need to discover and alternative invocation
+	// method
+	customCommandName string = "_custom_command"
+)
+
+func runCommand(commandPath string, args []string) (bytes.Buffer, bytes.Buffer, error) {
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+
+	command := exec.Command(commandPath, args...)
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	err := command.Run()
+	return stdout, stderr, err
+}
 
 // SyncPluginsForTarget will attempt to install plugins required by the active
 // Context of the provided target. This is most useful for any plugin
@@ -21,24 +43,30 @@ import (
 // implementation are subjected to change/removal if an alternative means to
 // provide equivalent functionality can be introduced.
 //
-// Stdout output of the command is returned as a string on successful
-// execution of the command, otherwise, the Stderr output is returned instead.
+// The output of the plugin syncing will be return as a string.
 func SyncPluginsForTarget(target types.Target) (string, error) {
 	// For now, the implementation expects env var TANZU_BIN to be set and
 	// pointing to the core CLI binary used to invoke the plugin sync with.
 
-	var stderr bytes.Buffer
-	var stdout bytes.Buffer
-
 	cliPath := os.Getenv("TANZU_BIN")
-	command := exec.Command(cliPath, "plugin", "sync")
-	command.Stdout = &stdout
-	command.Stderr = &stderr
-
-	err := command.Run()
-
-	if err != nil {
-		return stderr.String(), err
+	if cliPath == "" {
+		return "", errors.New("the environment variable TANZU_BIN is not set")
 	}
-	return stdout.String(), nil
+
+	altCommandArgs := []string{customCommandName}
+	args := []string{"plugin", "sync"}
+
+	altCommandArgs = append(altCommandArgs, args...)
+	altCommandArgs = append(altCommandArgs, "--target", string(target))
+
+	// Check if there is an alternate means to perform the plugin syncing
+	// operation, if not fall back to `plugin sync`
+	output, _, err := runCommand(cliPath, altCommandArgs)
+	if err == nil && output.String() != "" {
+		args = strings.Fields(output.String())
+	}
+
+	// Runs the actual command
+	stdoutOutput, stderrOutput, err := runCommand(cliPath, args)
+	return fmt.Sprintf("%s%s", stdoutOutput.String(), stderrOutput.String()), err
 }

--- a/plugin/sync_plugins_test.go
+++ b/plugin/sync_plugins_test.go
@@ -1,0 +1,123 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+const (
+	fakePluginScriptFmtString string = `#!/bin/bash
+# Fake tanzu core binary
+
+# fake alternate command that simply echos args provided
+bad() { echo "bad command failed"; exit 1; }
+plugin() {
+	# error to stderr
+	>&2 echo "$@ failed"
+
+	# regular output to stdout
+	echo "$@ succeeded"
+
+	exit %s
+}
+
+newcommand() {
+	# error to stderr
+	>&2 echo "$@ failed"
+
+	# regular output to stdout
+	echo "$@ succeeded"
+
+	exit %s
+}
+
+case "$1" in
+    _custom_command) "newcommand $@";;
+    newcommand)   $1 "$@";;
+    plugin)   $1 "$@";;
+    bad)   $1 "$@";;
+    *) cat << EOF
+Tanzu Core CLI mock
+
+Usage:
+  tanzu [command]
+
+Available Commands:
+  newcommand  fake new command
+  _custom_command provide alternate command to invoke, if available
+  bad     (non-working)
+EOF
+       exit 0
+       ;;
+esac
+`
+)
+
+func setupFakeCLI(dir string, exitStatus string, newCommandExitStatus string) (string, error) {
+	filePath := filepath.Join(dir, "tanzu")
+
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, fakePluginScriptFmtString, exitStatus, newCommandExitStatus)
+
+	return filePath, nil
+}
+
+func TestSyncPlugins(t *testing.T) {
+	tests := []struct {
+		test            string
+		exitStatus      string
+		expectedOutput  string
+		expectedFailure bool
+	}{
+		{
+			test:            "with no alternate command, sync successfully",
+			exitStatus:      "0",
+			expectedOutput:  "plugin sync succeeded\n",
+			expectedFailure: false,
+		},
+		{
+			test:            "with no alternate command, sync unsuccessfully",
+			exitStatus:      "1",
+			expectedOutput:  "plugin sync failed\n",
+			expectedFailure: true,
+		},
+	}
+
+	for _, spec := range tests {
+		dir, err := os.MkdirTemp("", "tanzu-cli-sync-api")
+		assert.Nil(t, err)
+		defer os.RemoveAll(dir)
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			cliPath, err := setupFakeCLI(dir, spec.exitStatus, spec.exitStatus)
+			assert.Nil(err)
+			os.Setenv("TANZU_BIN", cliPath)
+
+			output, err := SyncPluginsForTarget(types.TargetK8s)
+
+			if spec.expectedFailure {
+				assert.NotNil(err)
+			} else {
+				assert.Nil(err)
+			}
+			assert.Equal(spec.expectedOutput, output)
+
+			os.Unsetenv("TANZU_BIN")
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

   
    SyncPluginsForTarget will attempt to install plugins required by the active
    Context of the provided target. This is most useful for any plugin
    implementation which creates a new Context or updates an existing one as
    part of its operation, and prefers that the plugins appropriate for the
    Context are immediately available for use.

    Note: This API is considered EXPERIMENTAL. Both the function's signature and
    implementation are subjected to change/removal if an alternative means to
    provide equivalent functionality can be introduced.

---

In addition: 

    Check for alternative command invocation

    Invoke what would be a hidden '_custom_command' command to obtain an
    alternate means to perform, in this case, the plugin syncing operation.
    This command is expected to fail at the moment, and the behavior in
    this situation would be to fall back to the original command.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #75

### Describe testing done for PR

- `make test`  (which is updated with test cases to simulate invoking plugin sync or the hypothetical alternate command being discovered and in turn invoked).
- built a plugin linking to this runtime implementation and verified that a plugin command calling SyncPluginsForTarget will result in `tanzu plugin sync` being performed. 
```
tanzu myplugin fakecreate foo
Fake create cluster foo
Sync-ing plugins...
SYNC OK: output=
[i] Checking for required plugins...
[i] Installing plugin 'cluster:v0.28.0' with target 'kubernetes'
[i] Installing plugin 'feature:v0.28.0' with target 'kubernetes'
[i] Installing plugin 'kubernetes-release:v0.28.0' with target 'kubernetes'
[i] Successfully installed all required plugins
[ok] Done
```


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
 Provide experimental SyncPluginsForTarget API
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
