### PR TITLE
Introduce additional metadata field to Context

### DIFF
--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -28,4 +28,5 @@ const (
 	KeyTelemetry               = "telemetry"
 	KeyCLIId                   = "cliId"
 	KeySource                  = "source"
+	KeyAdditionalMetadata      = "additionalMetadata"
 )

--- a/config/contexts.go
+++ b/config/contexts.go
@@ -14,33 +14,6 @@ import (
 	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
-// ContextOpts is used to construct options for context apis
-type ContextOpts struct {
-	DeleteAllAdditionalMetadata bool   // To delete the entire additional metadata property of context
-	AdditionalMetadataKey       string // key string to identify the additional metadata property
-}
-
-// ContextOptions are used to pass options for context apis
-type ContextOptions func(c *ContextOpts)
-
-// WithDeleteAllAdditionalMetadata to delete all additional metadata of a context
-func WithDeleteAllAdditionalMetadata() ContextOptions {
-	return func(c *ContextOpts) {
-		c.DeleteAllAdditionalMetadata = true
-	}
-}
-
-// WithAdditionalMetadataKey to specify additional metadata key
-func WithAdditionalMetadataKey(key string) ContextOptions {
-	return func(c *ContextOpts) {
-		c.AdditionalMetadataKey = key
-	}
-}
-
-func NewContextOpts() *ContextOpts {
-	return &ContextOpts{}
-}
-
 // GetContext retrieves the context by name
 func GetContext(name string) (*configtypes.Context, error) {
 	// Retrieve client config node
@@ -273,44 +246,6 @@ func EndpointFromContext(s *configtypes.Context) (endpoint string, err error) {
 	}
 }
 
-// DeleteContextAdditionalMetadata deletes additionalMetadata of a specific context in the Tanzu client configuration.
-// The contextName parameter specifies the name of the context from which additionalMetadata is to be deleted.
-// The options parameter allows providing additional context configuration options.
-func DeleteContextAdditionalMetadata(contextName string, options ...ContextOptions) error {
-	// Create a new contextOptions with default values
-	contextOptions := NewContextOpts()
-
-	// Apply any provided options to the contextOptions
-	for _, opt := range options {
-		opt(contextOptions)
-	}
-
-	// Acquire a lock on the Tanzu client configuration to ensure exclusive access during modifications.
-	AcquireTanzuConfigLock()
-	defer ReleaseTanzuConfigLock()
-
-	// Retrieve the YAML node representing the client configuration.
-	node, err := getClientConfigNodeNoLock()
-	if err != nil {
-		return err
-	}
-
-	// Get the context node for the specified contextName from the client configuration.
-	ctx, err := getContext(node, contextName)
-	if err != nil {
-		return err
-	}
-
-	// Delete the additionalMetadata of the context by key or delete all, based on the provided contextOptions.
-	err = removeContextAdditionalMetadata(node, ctx.Name, contextOptions.AdditionalMetadataKey, contextOptions.DeleteAllAdditionalMetadata)
-	if err != nil {
-		return err
-	}
-
-	// Persist the modified client configuration back to storage.
-	return persistConfig(node)
-}
-
 func getContext(node *yaml.Node, name string) (*configtypes.Context, error) {
 	// check if context name is empty
 	if name == "" {
@@ -361,11 +296,8 @@ func setContext(node *yaml.Node, ctx *configtypes.Context) (persist bool, err er
 		return false, errors.New("context name cannot be empty")
 	}
 
-	// Get Patch Strategies from config metadata
-	patchStrategies, err := GetConfigMetadataPatchStrategy()
-	if err != nil {
-		patchStrategies = make(map[string]string)
-	}
+	// Get Patch Strategies
+	patchStrategies := constructPatchStrategies()
 
 	var persistDiscoverySources bool
 
@@ -423,6 +355,22 @@ func setContext(node *yaml.Node, ctx *configtypes.Context) (persist bool, err er
 	}
 	contextsNode.Content = result
 	return persistDiscoverySources || persist, err
+}
+
+// Get Patch Strategies from config metadata
+// By default;  AdditionalMetadata field will be patched in replace strategy if there are no patch strategies
+func constructPatchStrategies() map[string]string {
+	patchStrategies, err := GetConfigMetadataPatchStrategy()
+	if err != nil {
+		patchStrategies = map[string]string{
+			"contexts.additionalMetadata": "replace",
+		}
+	}
+	// Verify if there are patch strategies defined for `contexts.additionalMetadata` if not set replace by default
+	if patchStrategies != nil && patchStrategies["contexts.additionalMetadata"] != "merge" {
+		patchStrategies["contexts.additionalMetadata"] = "replace"
+	}
+	return patchStrategies
 }
 
 func setCurrentContext(node *yaml.Node, ctx *configtypes.Context) (persist bool, err error) {
@@ -490,62 +438,6 @@ func removeContext(node *yaml.Node, name string) error {
 		}
 		contexts = append(contexts, contextNode)
 	}
-	contextsNode.Content = contexts
-	return nil
-}
-
-// removeContextAdditionalMetadata removes the additionalMetadata property of a specific context in a YAML node.
-// If removeAll is true, it removes the entire additionalMetadata property.
-// If removeAll is false, it removes a specific key from the additionalMetadata property.
-func removeContextAdditionalMetadata(node *yaml.Node, name, key string, removeAll bool) error {
-	// check if context name is empty
-	if name == "" {
-		return errors.New("context name cannot be empty")
-	}
-
-	// check if key is empty when not removing all
-	if !removeAll && key == "" {
-		return errors.New("key cannot be empty")
-	}
-
-	// Find the contexts node in the YAML node
-	keys := []nodeutils.Key{
-		{Name: KeyContexts},
-	}
-	contextsNode := nodeutils.FindNode(node.Content[0], nodeutils.WithKeys(keys))
-	if contextsNode == nil {
-		// If no contexts node is found, there is nothing to remove.
-		return nil
-	}
-
-	// Create a new list to hold modified context nodes
-	var contexts []*yaml.Node
-	for _, contextNode := range contextsNode.Content {
-		if index := nodeutils.GetNodeIndex(contextNode.Content, "name"); index != -1 && contextNode.Content[index].Value == name {
-			if removeAll {
-				// If removeAll is true, remove the entire additionalMetadata property.
-				index := nodeutils.GetNodeIndex(contextNode.Content, KeyAdditionalMetadata)
-				if index != -1 {
-					contextNode.Content = append(contextNode.Content[:index-1], contextNode.Content[index+1:]...)
-				}
-			} else {
-				// If removeAll is false, remove the specified key from additionalMetadata property.
-				additionalMetadataKey := []nodeutils.Key{{Name: KeyAdditionalMetadata}}
-				additionalMetadataNode := nodeutils.FindNode(contextNode, nodeutils.WithKeys(additionalMetadataKey))
-				if additionalMetadataNode != nil && additionalMetadataNode.Content != nil {
-					index := nodeutils.GetNodeIndex(additionalMetadataNode.Content, key)
-					if index != -1 {
-						// Remove the specific key from additionalMetadata.
-						additionalMetadataNode.Content = append(additionalMetadataNode.Content[:index-1], additionalMetadataNode.Content[index+1:]...)
-					}
-				}
-			}
-		}
-		// Add the modified context node to the new list.
-		contexts = append(contexts, contextNode)
-	}
-
-	// Update the contexts node with the modified list of contexts.
 	contextsNode.Content = contexts
 	return nil
 }

--- a/config/contexts_additionalmetadata_test.go
+++ b/config/contexts_additionalmetadata_test.go
@@ -1,0 +1,724 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+func TestDeleteContextAdditionalMetadata(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{cfgNextGen: ``, cfg: ``, cfgMetadata: ``})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	var testcases = []struct {
+		name       string
+		ctx        *configtypes.Context
+		ctxOptions ContextOptions
+		out        map[string]interface{}
+		errStr     string
+	}{
+
+		{
+			name: "should add additional metadata",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuer":  "vmw1",
+					"issuer2": "vmw1",
+					"issuer3": "vmw1",
+				},
+			},
+			ctxOptions: WithAdditionalMetadataKey("issuer4"),
+			out: map[string]interface{}{
+				"issuer":  "vmw1",
+				"issuer2": "vmw1",
+				"issuer3": "vmw1",
+			},
+		},
+
+		{
+			name: "should update additional metadata",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuer": "vmw2",
+				},
+			},
+			ctxOptions: WithAdditionalMetadataKey("issuer"),
+			out: map[string]interface{}{
+				"issuer2": "vmw1",
+				"issuer3": "vmw1",
+			},
+		},
+		{
+			name: "should delete all additional metadata",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuer":  "vmw2",
+					"issuer2": "vmw2",
+					"issuer3": "vmw2",
+					"issuer4": "vmw2",
+				},
+			},
+			ctxOptions: WithDeleteAllAdditionalMetadata(),
+			out:        nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// perform test
+			err := SetContext(tc.ctx, false)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+
+			err = DeleteContextAdditionalMetadata(tc.ctx.Name, tc.ctxOptions)
+			assert.NoError(t, err)
+
+			ctx, err := GetContext(tc.ctx.Name)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.out, ctx.AdditionalMetadata)
+		})
+	}
+}
+
+func TestContextAdditionalMetadataStringToString(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{cfgNextGen: ``, cfg: ``, cfgMetadata: ``})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	var testcases = []struct {
+		name   string
+		ctx    *configtypes.Context
+		out    map[string]interface{}
+		errStr string
+	}{
+
+		{
+			name: "should add additional metadata tags:tag1",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuer": "vmw1",
+				},
+			},
+		},
+		{
+			name: "should update additional metadata tags:tag2",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuer": "vmw2",
+				},
+			},
+		},
+
+		{
+			name: "should clear additional metadata string:string",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuer": "",
+				},
+			},
+		},
+
+		{
+			name: "should update additional metadata tags:tag1",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuer": "vmw1",
+				},
+			},
+		},
+		{
+			name: "should update additional metadata tags:tag2",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuer": "vmw2",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// perform test
+			err := SetContext(tc.ctx, false)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+			ctx, err := GetContext(tc.ctx.Name)
+			assert.NoError(t, err)
+
+			if tc.out != nil {
+				assert.Equal(t, tc.out, ctx.AdditionalMetadata)
+			} else {
+				assert.Equal(t, tc.ctx.AdditionalMetadata, ctx.AdditionalMetadata)
+			}
+		})
+	}
+}
+
+func TestContextAdditionalMetadataStringToInt(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{cfgNextGen: ``, cfg: ``, cfgMetadata: ``})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	var testcases = []struct {
+		name   string
+		ctx    *configtypes.Context
+		out    map[string]interface{}
+		errStr string
+	}{
+
+		// Additional metadata of map[string]int
+
+		{
+			name: "should add additional metadata tags:0",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"contextId": 0,
+				},
+			},
+			out: map[string]interface{}{
+				"contextId": 0,
+			},
+		},
+		{
+			name: "should update additional metadata tags:1",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"contextId": 1,
+				},
+			},
+			out: map[string]interface{}{
+				"contextId": 1,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// perform test
+			err := SetContext(tc.ctx, false)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+			ctx, err := GetContext(tc.ctx.Name)
+			assert.NoError(t, err)
+
+			if tc.out != nil {
+				assert.Equal(t, tc.out, ctx.AdditionalMetadata)
+			} else {
+				assert.Equal(t, tc.ctx.AdditionalMetadata, ctx.AdditionalMetadata)
+			}
+		})
+	}
+}
+
+func TestContextAdditionalMetadataStringToStringArray(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{cfgNextGen: ``, cfg: ``, cfgMetadata: ``})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	var testcases = []struct {
+		name   string
+		ctx    *configtypes.Context
+		out    map[string]interface{}
+		errStr string
+	}{
+
+		{
+			name: "should add additional metadata \"tags\": []string{},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuers": []string{},
+				},
+			},
+			out: map[string]interface{}{
+				"issuers": []interface{}{},
+			},
+		},
+		{
+			name: "should update additional metadata \"tags\": []string{\"tag1\"},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuers": []interface{}{"vmw1"},
+				},
+			},
+		},
+		{
+			name: "should update additional metadata \"tags\": []string{\"tag2\"},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuers": []interface{}{"vmw1", "vmw2"},
+				},
+			},
+		},
+		{
+			name: "should update additional metadata \"tags\": []string{\"tag1\", \"tag2\"},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuers": []interface{}{"vmw1", "vmw2"},
+				},
+			},
+		},
+		{
+			name: "should update additional metadata \"tags\": []string{\"tag3\", \"tag4\"},\n",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuers": []interface{}{"vmw1", "vmw2", "vmw3", "vmw4"},
+				},
+			},
+		},
+		{
+			name: "should update additional metadata \"tags\": []string{\"tag3\", \"tag4\", \"tag1\"},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"issuers": []interface{}{"vmw1", "vmw2", "vmw3", "vmw4"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// perform test
+			err := SetContext(tc.ctx, false)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+			ctx, err := GetContext(tc.ctx.Name)
+			assert.NoError(t, err)
+
+			if tc.out != nil {
+				assert.Equal(t, tc.out, ctx.AdditionalMetadata)
+			} else {
+				assert.Equal(t, tc.ctx.AdditionalMetadata, ctx.AdditionalMetadata)
+			}
+		})
+	}
+}
+
+func TestContextAdditionalMetadataStringToMap(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{cfgNextGen: ``, cfg: ``, cfgMetadata: ``})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	var testcases = []struct {
+		name   string
+		ctx    *configtypes.Context
+		out    map[string]interface{}
+		errStr string
+	}{
+
+		{
+			name: "should add additional metadata \"auth\": map[string]string{\"a1\": \"x\",\n},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"auth": map[string]string{
+						"a1": "x",
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"auth": map[string]interface{}{
+					"a1": "x",
+				},
+			},
+		},
+		{
+			name: "should update additional metadata \"auth\": map[string]string{\n\"a2\": \"y\",\n},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"auth": map[string]string{
+						"a2": "y",
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"auth": map[string]interface{}{
+					"a1": "x",
+					"a2": "y",
+				},
+			},
+		},
+		{
+			name: "should update additional metadata \"auth\": map[string]string{\n\"a1\": \"y\",\n},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"auth": map[string]string{
+						"a1": "y",
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"auth": map[string]interface{}{
+					"a1": "y",
+					"a2": "y",
+				},
+			},
+		},
+		{
+			name: "should update additional metadata \"auth\": map[string]string{\n\"a1\": \"z\",\n\"a3\": \"z\",\n},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"auth": map[string]string{
+						"a1": "z",
+						"a3": "z",
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"auth": map[string]interface{}{
+					"a1": "z",
+					"a3": "z",
+					"a2": "y",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// perform test
+			err := SetContext(tc.ctx, false)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+			ctx, err := GetContext(tc.ctx.Name)
+			assert.NoError(t, err)
+			if tc.out != nil {
+				assert.Equal(t, tc.out, ctx.AdditionalMetadata)
+			} else {
+				assert.Equal(t, tc.ctx.AdditionalMetadata, ctx.AdditionalMetadata)
+			}
+		})
+	}
+}
+
+func TestContextAdditionalMetadataStringToStruct(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{cfgNextGen: ``, cfg: ``, cfgMetadata: ``})
+
+	defer func() {
+		cleanUp()
+	}()
+
+	var testcases = []struct {
+		name   string
+		ctx    *configtypes.Context
+		out    map[string]interface{}
+		errStr string
+	}{
+
+		{
+			name: "should add additional metadata \"globalAuth\": configtypes.GlobalServerAuth{\n\t\t\t\t\t\tAccessToken: \"token1\",\n\t\t\t\t\t},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"globalAuth": configtypes.GlobalServerAuth{
+						AccessToken: "token1",
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"globalAuth": map[string]interface{}{
+					"accessToken": "token1",
+				},
+			},
+		},
+		{
+			name: "should update additional metadata \"globalAuth\": configtypes.GlobalServerAuth{\n\t\t\t\t\t\tAccessToken: \"token1\",\n\t\t\t\t\t\tIDToken:     \"id-1\",\n\t\t\t\t\t},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"globalAuth": configtypes.GlobalServerAuth{
+						AccessToken: "token1",
+						IDToken:     "id-1",
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"globalAuth": map[string]interface{}{
+					"accessToken": "token1",
+					"IDToken":     "id-1",
+				},
+			},
+		},
+		{
+			name: "should update additional metadata \"globalAuth\": configtypes.GlobalServerAuth{\n\t\t\t\t\t\tAccessToken: \"token1\",\n\t\t\t\t\t\tIDToken:     \"id-1\",\n\t\t\t\t\t\tPermissions: []string{\"p1\", \"p2\"},\n\t\t\t\t\t},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"globalAuth": configtypes.GlobalServerAuth{
+						AccessToken: "token1",
+						IDToken:     "id-1",
+						Permissions: []string{"p1", "p2"},
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"globalAuth": map[string]interface{}{
+					"accessToken": "token1",
+					"IDToken":     "id-1",
+					"permissions": []interface{}{"p1", "p2"},
+				},
+			},
+		},
+
+		{
+			name: "should update additional metadata \"globalAuth\": configtypes.GlobalServerAuth{\n\t\t\t\t\t\tAccessToken: \"token1\",\n\t\t\t\t\t\tIDToken:     \"id-1\",\n\t\t\t\t\t\tPermissions: []string{\"p1\", \"p2\"},\n\t\t\t\t\t},\n\t\t\t\t\t\"globalAuth2\": configtypes.GlobalServerAuth{\n\t\t\t\t\t\tAccessToken: \"token1\",\n\t\t\t\t\t\tIDToken:     \"id-1\",\n\t\t\t\t\t\tPermissions: []string{\"p1\", \"p2\"},\n\t\t\t\t\t},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"globalAuth": configtypes.GlobalServerAuth{
+						AccessToken: "token1",
+						IDToken:     "id-1",
+						Permissions: []string{"p1", "p2"},
+					},
+					"globalAuth2": configtypes.GlobalServerAuth{
+						AccessToken: "token1",
+						IDToken:     "id-1",
+						Permissions: []string{"p1", "p2"},
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"globalAuth": map[string]interface{}{
+					"accessToken": "token1",
+					"IDToken":     "id-1",
+					"permissions": []interface{}{"p1", "p2"},
+				},
+				"globalAuth2": map[string]interface{}{
+					"accessToken": "token1",
+					"IDToken":     "id-1",
+					"permissions": []interface{}{"p1", "p2"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// perform test
+			err := SetContext(tc.ctx, false)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+			ctx, err := GetContext(tc.ctx.Name)
+			assert.NoError(t, err)
+
+			if tc.out != nil {
+				assert.Equal(t, tc.out, ctx.AdditionalMetadata)
+			} else {
+				assert.Equal(t, tc.ctx.AdditionalMetadata, ctx.AdditionalMetadata)
+			}
+		})
+	}
+}
+
+func TestContextAdditionalMetadataStringToStructArray(t *testing.T) {
+	// Setup config data
+	_, cleanUp := setupTestConfig(t, &CfgTestData{cfgNextGen: ``, cfg: ``, cfgMetadata: ``})
+
+	defer func() {
+		cleanUp()
+	}()
+	var testcases = []struct {
+		name   string
+		ctx    *configtypes.Context
+		out    map[string]interface{}
+		errStr string
+	}{
+
+		{
+			name: "should add additional metadata \"globalAuth\": configtypes.GlobalServerAuth{\n\t\t\t\t\t\tAccessToken: \"token1\",\n\t\t\t\t\t},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"globalAuth": []*configtypes.GlobalServerAuth{
+						{
+							AccessToken: "token1",
+						},
+
+						{
+							AccessToken: "token2",
+						},
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"globalAuth": []interface{}{
+					map[string]interface{}{
+						"accessToken": "token1",
+					},
+					map[string]interface{}{
+						"accessToken": "token2",
+					},
+				},
+			},
+		},
+
+		{
+			name: "should update additional metadata \"globalAuth\": configtypes.GlobalServerAuth{\n\t\t\t\t\t\tAccessToken: \"token1\",\n\t\t\t\t\t\tIDToken:     \"id-1\",\n\t\t\t\t\t},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"globalAuth": []*configtypes.GlobalServerAuth{
+						{
+							AccessToken: "token1",
+							IDToken:     "id-1",
+						},
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"globalAuth": []interface{}{
+					map[string]interface{}{
+						"accessToken": "token1",
+						"IDToken":     "id-1",
+					},
+					map[string]interface{}{
+						"accessToken": "token2",
+					},
+				},
+			},
+		},
+
+		{
+			name: "should update additional metadata \"globalAuth\": configtypes.GlobalServerAuth{\n\t\t\t\t\t\tAccessToken: \"token1\",\n\t\t\t\t\t\tIDToken:     \"id-1\",\n\t\t\t\t\t\tPermissions: []string{\"p1\", \"p2\"},\n\t\t\t\t\t},\n\t\t\t\t\t\"globalAuth2\": configtypes.GlobalServerAuth{\n\t\t\t\t\t\tAccessToken: \"token1\",\n\t\t\t\t\t\tIDToken:     \"id-1\",\n\t\t\t\t\t\tPermissions: []string{\"p1\", \"p2\"},\n\t\t\t\t\t},",
+			ctx: &configtypes.Context{
+				Name:   "test-mc",
+				Target: configtypes.TargetK8s,
+				AdditionalMetadata: map[string]interface{}{
+					"globalAuth": []*configtypes.GlobalServerAuth{
+						{
+							Permissions: []string{"p1"},
+						},
+					},
+					"globalAuth2": []*configtypes.GlobalServerAuth{
+						{
+							AccessToken: "token2",
+							Permissions: []string{"p2"},
+						},
+					},
+				},
+			},
+			out: map[string]interface{}{
+				"globalAuth": []interface{}{
+					map[string]interface{}{
+						"accessToken": "token1",
+						"IDToken":     "id-1",
+						"permissions": []interface{}{"p1"},
+					},
+					map[string]interface{}{
+						"accessToken": "token2",
+					},
+				},
+				"globalAuth2": []interface{}{
+					map[string]interface{}{
+						"accessToken": "token2",
+						"permissions": []interface{}{"p2"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// perform test
+			err := SetContext(tc.ctx, false)
+			if tc.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.errStr)
+			}
+			ctx, err := GetContext(tc.ctx.Name)
+			assert.NoError(t, err)
+			if tc.out != nil {
+				assert.Equal(t, tc.out, ctx.AdditionalMetadata)
+			} else {
+				assert.Equal(t, tc.ctx.AdditionalMetadata, ctx.AdditionalMetadata)
+			}
+		})
+	}
+}

--- a/config/contexts_it_test.go
+++ b/config/contexts_it_test.go
@@ -260,6 +260,9 @@ currentContext:
         path: test-path-updated
         context: test-context-updated
         isManagementCluster: true
+      additionalMetadata:
+        metaToken: updated-token1
+        newToken: optional
       discoverySources:
         - gcp:
             name: test
@@ -322,6 +325,9 @@ func TestContextsIntegration(t *testing.T) {
 				},
 			},
 		},
+		AdditionalMetadata: map[string]interface{}{
+			"metaToken": "token1",
+		},
 	}
 	err = SetContext(newCtx, true)
 	assert.NoError(t, err)
@@ -371,6 +377,10 @@ func TestContextsIntegration(t *testing.T) {
 					ManifestPath: "test-manifest-path-updated",
 				},
 			},
+		},
+		AdditionalMetadata: map[string]interface{}{
+			"metaToken": "updated-token1",
+			"newToken":  "optional",
 		},
 	}
 	err = SetContext(updatedCtx, true)

--- a/config/contexts_it_test.go
+++ b/config/contexts_it_test.go
@@ -260,14 +260,14 @@ currentContext:
         path: test-path-updated
         context: test-context-updated
         isManagementCluster: true
-      additionalMetadata:
-        metaToken: updated-token1
-        newToken: optional
       discoverySources:
         - gcp:
             name: test
             bucket: test-bucket-updated
             manifestPath: test-manifest-path-updated
+      additionalMetadata:
+        metaToken: updated-token1
+        newToken: optional
 currentContext:
     kubernetes: test-mc2
 `

--- a/config/contexts_test.go
+++ b/config/contexts_test.go
@@ -38,6 +38,9 @@ func TestSetGetDeleteContext(t *testing.T) {
 				},
 			},
 		},
+		AdditionalMetadata: map[string]interface{}{
+			"metaToken": "token1",
+		},
 	}
 
 	ctx2 := &configtypes.Context{
@@ -56,6 +59,9 @@ func TestSetGetDeleteContext(t *testing.T) {
 					ManifestPath: "test-manifest-path",
 				},
 			},
+		},
+		AdditionalMetadata: map[string]interface{}{
+			"metaToken": "token1",
 		},
 	}
 
@@ -105,6 +111,8 @@ contexts:
       ctx-field: new-ctx-field
       optional: true
       target: kubernetes
+      additionalMetadata:
+        metaToken: token1
       clusterOpts:
         isManagementCluster: true
         endpoint: old-test-endpoint
@@ -151,6 +159,9 @@ contexts:
 				},
 			},
 		},
+		AdditionalMetadata: map[string]interface{}{
+			"metaToken": "token1",
+		},
 	}
 
 	err := SetContext(ctx, false)
@@ -162,6 +173,7 @@ contexts:
 	assert.Equal(t, c.ClusterOpts.Endpoint, "old-test-endpoint")
 	assert.Equal(t, c.ClusterOpts.Path, ctx.ClusterOpts.Path)
 	assert.Equal(t, c.ClusterOpts.Context, ctx.ClusterOpts.Context)
+	assert.Equal(t, c.AdditionalMetadata, ctx.AdditionalMetadata)
 }
 
 func TestSetContextWithDiscoverySourceWithNewFields(t *testing.T) {
@@ -576,6 +588,9 @@ func TestSetContext(t *testing.T) {
 					Context:             "test-context",
 					IsManagementCluster: true,
 				},
+				AdditionalMetadata: map[string]interface{}{
+					"metaToken": "token1",
+				},
 			},
 			current: true,
 		},
@@ -590,6 +605,9 @@ func TestSetContext(t *testing.T) {
 					Path:                "test-path",
 					Context:             "test-context",
 					IsManagementCluster: true,
+				},
+				AdditionalMetadata: map[string]interface{}{
+					"metaToken": "token1",
 				},
 			},
 		},
@@ -624,6 +642,9 @@ func TestSetContext(t *testing.T) {
 					Path:                "updated-test-path",
 					Context:             "updated-test-context",
 					IsManagementCluster: true,
+				},
+				AdditionalMetadata: map[string]interface{}{
+					"metaToken": "updated-token1",
 				},
 			},
 		},

--- a/config/legacy_clientconfig_factory_test.go
+++ b/config/legacy_clientconfig_factory_test.go
@@ -151,13 +151,16 @@ current: test-mc
         path: test-context-path
         context: test-context
       discoverySources:
-        - local:
-            name: test
-            path: test-local-path
         - gcp:
             name: test2
             bucket: ctx-test-bucket
             manifestPath: ctx-test-manifest-path
+            annotation: one
+            required: true
+          contextType: tmc
+        - local:
+            name: test
+            path: test-local-path
 currentContext:
     kubernetes: test-mc
 `

--- a/config/nodeutils/helpers.go
+++ b/config/nodeutils/helpers.go
@@ -13,9 +13,11 @@ func UniqNodes(nodes []*yaml.Node) []*yaml.Node {
 	mapper := make(map[string]bool)
 
 	for _, node := range nodes {
-		if _, ok := mapper[node.Value]; !ok {
-			mapper[node.Value] = true
-			uniq = append(uniq, node)
+		if node.Value != "" {
+			if _, ok := mapper[node.Value]; !ok {
+				mapper[node.Value] = true
+				uniq = append(uniq, node)
+			}
 		}
 	}
 

--- a/config/nodeutils/helpers_test.go
+++ b/config/nodeutils/helpers_test.go
@@ -28,6 +28,24 @@ func TestUniqNode(t *testing.T) {
 				},
 				{
 					Kind:  yaml.ScalarNode,
+					Value: "test2",
+					Style: 0,
+					Tag:   "!!str",
+				},
+			},
+		},
+		{
+			name:  "success 1 uniq nodes",
+			count: 1,
+			nodes: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "test",
+					Style: 0,
+					Tag:   "!!str",
+				},
+				{
+					Kind:  yaml.ScalarNode,
 					Value: "",
 					Style: 0,
 					Tag:   "!!str",

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -65,6 +65,9 @@ type Context struct {
 	// ClusterOpts if the context is a kubernetes cluster.
 	ClusterOpts *ClusterServer `json:"clusterOpts,omitempty" yaml:"clusterOpts,omitempty"`
 
+	// AdditionalMetadata to provide any additional data that is respective to each context
+	AdditionalMetadata map[string]interface{} `json:"additionalMetadata,omitempty" yaml:"additionalMetadata,omitempty"`
+
 	// DiscoverySources determines from where to discover plugins
 	// associated with this context.
 	// Deprecated: This field is deprecated.  It is currently no used.


### PR DESCRIPTION
### What this PR does / why we need it
 - At the moment, Tanzu Plugin Runtime - Context configuration does not provide a means to add any additional metadata.
This proposal introduces a new AdditionalMetadata map field to Context to be able to provide additional data for each context. This way we don't have to release a new version of runtime every time we add a new property to the context object.
Example: TMC will need to store a few additional properties for each context and the fields could change in future. In TMC Self-Managed with VCD's login flow, it requires "VCD org" and "VCD OIDC client ID" to be persisted in context, so that TMC Plugins can auto-refresh or re-trigger the token flow if needed when a TMC plugin command is called.

Example usage:
- Add two new properties to context

```
ctx := &Context {
 Name: tanzu-ctx,
 AdditionalMetadata : map[string]interface{
  “token” : “test-token”
  “issuer” : “test-issuer”
 }
}
SetContext(ctx)  // ctx will  now have both token and issuer metadata

```

- Update the existing additional metadata of a context

```
# To merge the additional metadata

ctx := GetContext()
ctx.AdditionalMetadata[“token”]=”updated-token”
SetContext(ctx)  // ctx will now have both issuer and token metadata


# To replace the additional metadata

ctx := GetContext()
ctx.AdditionalMetadata := map[string]interface{}{
 “token”=”only-token”,
}
SetContext(ctx) // Ctx will only have token metadata

# To delete the entire additional metadata

ctx := GetContext()
ctx.AdditionalMetadata := map[string]interface{}{}
SetContext(ctx) // Ctx will not have any additional metadata

```


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Added unit tests and integrated tests

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
 Introduce new additionalMetadata field in Context
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
