### PR TITLE
[release-1.0] Expose TANZU_CLI_LOG_LEVEL environment variable to control the log level

### DIFF
--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/tj/assert"
+)
+
+func TestLogger(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		test                  string
+		logLevel              string
+		containStrings        []string
+		doesNotContainStrings []string
+	}{
+		{
+			test:                  "when TANZU_CLI_LOG_LEVEL is not configured",
+			logLevel:              "",
+			containStrings:        []string{"log-default", "log-0", "log-1", "log-3"},
+			doesNotContainStrings: []string{"log-5", "log-8"},
+		},
+		{
+			test:                  "when TANZU_CLI_LOG_LEVEL is set to 3",
+			logLevel:              "",
+			containStrings:        []string{"log-default", "log-0", "log-1", "log-3"},
+			doesNotContainStrings: []string{"log-5", "log-8"},
+		},
+		{
+			test:                  "when TANZU_CLI_LOG_LEVEL is set to 6",
+			logLevel:              "6",
+			containStrings:        []string{"log-default", "log-0", "log-1", "log-3", "log-5"},
+			doesNotContainStrings: []string{"log-8"},
+		},
+		{
+			test:                  "when TANZU_CLI_LOG_LEVEL is set to 9",
+			logLevel:              "9",
+			containStrings:        []string{"log-default", "log-0", "log-1", "log-3", "log-5", "log-8"},
+			doesNotContainStrings: []string{},
+		},
+		{
+			test:                  "when TANZU_CLI_LOG_LEVEL is configured with incorrect value",
+			logLevel:              "a",
+			containStrings:        []string{"log-default", "log-0", "log-1", "log-3"},
+			doesNotContainStrings: []string{"log-5", "log-8"},
+		},
+	}
+
+	for _, spec := range tests {
+		defer os.Setenv(EnvTanzuCLILogLevel, "")
+		os.Setenv(EnvTanzuCLILogLevel, spec.logLevel)
+
+		l = NewLogger()
+		stderr := &bytes.Buffer{}
+		SetStderr(stderr)
+
+		Info("log-default")
+		V(0).Info("log-0")
+		V(1).Info("log-1")
+		V(3).Info("log-3")
+		V(5).Info("log-5")
+		V(8).Info("log-8")
+
+		for _, logStr := range spec.containStrings {
+			assert.Contains(stderr.String(), logStr, spec.test)
+		}
+		for _, logStr := range spec.doesNotContainStrings {
+			assert.NotContains(stderr.String(), logStr, spec.test)
+		}
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

Cherry-pick: https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/83

Tanzu Plugin Runtime exposes a logger functionality and also allows logs to be displayed based on the different log levels.
It also exposes API to control the log level for external plugins.

However, we wanted the log levels to be controlled by the user at the runtime so that we can enable more logs for debugging purposes. This PR provides an environment variable `TANZU_CLI_LOG_LEVEL` to control the log level.

The default value of the Tanzu CLI log level is `3`. So any user wanting to see more debug logs should configure `TANZU_CLI_LOG_LEVEL` with value `>3`. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

* Manually tested the change.
* Added unit tests.
* Sample tests details mentioned under: https://github.com/vmware-tanzu/tanzu-cli/pull/437
<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Expose the `TANZU_CLI_LOG_LEVEL` environment variable to control the log level
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
