### PR TITLE
Update SyncPluginsForTarget API to allow configuring `stdout` and `stderr` externally

### DIFF
--- a/plugin/sync_plugins.go
+++ b/plugin/sync_plugins.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -21,16 +22,62 @@ const (
 	customCommandName string = "_custom_command"
 )
 
-func runCommand(commandPath string, args []string) (bytes.Buffer, bytes.Buffer, error) {
+// cmdOptions specifies the command options
+type cmdOptions struct {
+	outWriter io.Writer
+	errWriter io.Writer
+}
+
+type CommandOptions func(o *cmdOptions)
+
+// WithOutputWriter specifies the CommandOption for configuring Stdout
+func WithOutputWriter(outWriter io.Writer) CommandOptions {
+	return func(o *cmdOptions) {
+		o.outWriter = outWriter
+	}
+}
+
+// WithErrorWriter specifies the CommandOption for configuring Stderr
+func WithErrorWriter(errWriter io.Writer) CommandOptions {
+	return func(o *cmdOptions) {
+		o.errWriter = errWriter
+	}
+}
+
+// WithNoStdout specifies to ignore stdout
+func WithNoStdout() CommandOptions {
+	return func(o *cmdOptions) {
+		o.outWriter = io.Discard
+	}
+}
+
+// WithNoStderr specifies to ignore stderr
+func WithNoStderr() CommandOptions {
+	return func(o *cmdOptions) {
+		o.errWriter = io.Discard
+	}
+}
+
+func runCommand(commandPath string, args []string, opts *cmdOptions) (bytes.Buffer, bytes.Buffer, error) {
+	command := exec.Command(commandPath, args...)
+
 	var stderr bytes.Buffer
 	var stdout bytes.Buffer
 
-	command := exec.Command(commandPath, args...)
-	command.Stdout = &stdout
-	command.Stderr = &stderr
+	wout := io.MultiWriter(&stdout, os.Stdout)
+	werr := io.MultiWriter(&stderr, os.Stderr)
 
-	err := command.Run()
-	return stdout, stderr, err
+	if opts.outWriter != nil {
+		wout = io.MultiWriter(&stdout, opts.outWriter)
+	}
+	if opts.errWriter != nil {
+		werr = io.MultiWriter(&stderr, opts.errWriter)
+	}
+
+	command.Stdout = wout
+	command.Stderr = werr
+
+	return stdout, stderr, command.Run()
 }
 
 // SyncPluginsForTarget will attempt to install plugins required by the active
@@ -43,10 +90,23 @@ func runCommand(commandPath string, args []string) (bytes.Buffer, bytes.Buffer, 
 // implementation are subjected to change/removal if an alternative means to
 // provide equivalent functionality can be introduced.
 //
-// The output of the plugin syncing will be return as a string.
-func SyncPluginsForTarget(target types.Target) (string, error) {
+// By default this API will write to os.Stdout and os.Stderr.
+// To write the logs to different output and error streams as part of the plugin sync
+// command invocation, configure CommandOptions as part of the parameters.
+//
+// Example:
+//
+//	var outBuf bytes.Buffer
+//	var errBuf bytes.Buffer
+//	SyncPluginsForTarget(types.TargetK8s, WithOutputWriter(outBuf), WithErrorWriter(errBuf))
+func SyncPluginsForTarget(target types.Target, opts ...CommandOptions) (string, error) {
 	// For now, the implementation expects env var TANZU_BIN to be set and
 	// pointing to the core CLI binary used to invoke the plugin sync with.
+
+	options := &cmdOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
 
 	cliPath := os.Getenv("TANZU_BIN")
 	if cliPath == "" {
@@ -61,12 +121,12 @@ func SyncPluginsForTarget(target types.Target) (string, error) {
 
 	// Check if there is an alternate means to perform the plugin syncing
 	// operation, if not fall back to `plugin sync`
-	output, _, err := runCommand(cliPath, altCommandArgs)
-	if err == nil && output.String() != "" {
-		args = strings.Fields(output.String())
+	stdoutOutput, _, err := runCommand(cliPath, altCommandArgs, &cmdOptions{outWriter: io.Discard, errWriter: io.Discard})
+	if err == nil && stdoutOutput.String() != "" {
+		args = strings.Fields(stdoutOutput.String())
 	}
 
 	// Runs the actual command
-	stdoutOutput, stderrOutput, err := runCommand(cliPath, args)
+	stdoutOutput, stderrOutput, err := runCommand(cliPath, args, options)
 	return fmt.Sprintf("%s%s", stdoutOutput.String(), stderrOutput.String()), err
 }


### PR DESCRIPTION
### What this PR does / why we need it

The `TanzuPluginSyncForTarget` API is exposed to sync plugins as an experimental API.

* However, when this API is invoked by a plugin, `stdout` and `stderr` are returned as part of the API and are not actively written to the `stdout` or `stderr`. 
* Because of this it makes it feel like the CLI is stuck when installing plugins, especially when there large number of plugin that needs to be installed as part of plugin sync API giving subpar UX to the users.

This change exposes additional `CommandOptions` to configure the `outputWriter` and `errorWriter` using `WithOutputWriter` and `WithErrorWriter` options when invoking the `TanzuPluginSyncForTarget` API, along with writing the output directly to the `os.Stdout` and `os.Stderr` by default.

**Note:** Unlike before, the API will now write the output/error of the plugin sync operation to stderr and stdout by default. Callers who previously manage the output by processing the return values of the API call should consider turning off the default writing to the os.Stdout and os.Stderr by passing WithNoStdout and WithNoStderr options as the additional parameters to the function call in order to avoid duplicate echoing.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
* Added unit tests to capture the stdout and stderr along with verifying return types with different combinations

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the `SyncPluginsForTarget` API to allow configuring the `OutputStream` and `ErrorStream` externally. If not configured it defaults the writes to `os.Stdout` and `os.Stderr`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
