### PR TITLE
Update help text template to fix target usage

### DIFF
--- a/plugin/root.go
+++ b/plugin/root.go
@@ -30,7 +30,7 @@ func newRootCmd(descriptor *PluginDescriptor) *cobra.Command {
 		},
 	}
 	cobra.AddTemplateFuncs(TemplateFuncs)
-	cmd.SetUsageTemplate(CmdTemplate)
+	cmd.SetUsageTemplate(cmdTemplate)
 
 	cmd.AddCommand(
 		newDescribeCmd(descriptor.Description),

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -26,112 +26,132 @@ var UsageFunc = func(c *cobra.Command) error {
 // CmdTemplate is the template for plugin commands.
 const CmdTemplate = `{{ printHelp . }}`
 
-//nolint:all
-func printHelp(cmd cobra.Command) string {
-	var output string
-	target := types.StringToTarget(cmd.Annotations["target"])
+// Constants for help text labels
+const (
+	usageStr                = "Usage:"
+	aliasesStr              = "Aliases:"
+	examplesStr             = "Examples:"
+	availableCommandsStr    = "Available Commands:"
+	flagsStr                = "Flags:"
+	globalFlagsStr          = "Global Flags:"
+	additionalHelpTopicsStr = "Additional help topics:"
+)
 
-	output += component.Bold("Usage:") + "\n"
+// Helper to format the usage help section.
+func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
+	var output strings.Builder
 
-	// Display usage for commands that are runnable
+	base := "  tanzu "
+
 	if cmd.Runnable() {
 		// For kubernetes, k8s, global, or no target display tanzu command path without target
 		if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
-			output += "  tanzu " + cmd.UseLine() + "\n"
+			output.WriteString(base + cmd.UseLine() + "\n")
 		}
 
-		// For non global, or no target display tanzu command path with target
+		// For non global, or no target ;display tanzu command path with target
 		if target != types.TargetGlobal && target != types.TargetUnknown {
-			output += "  tanzu " + string(target) + " " + cmd.UseLine() + "\n"
+			output.WriteString(base + string(target) + " " + cmd.UseLine() + "\n")
 		}
 	}
 
-	// Display usage for commands that have sub-commands
 	if cmd.HasAvailableSubCommands() {
 		if cmd.Runnable() {
 			// If the command is both Runnable and has sub-commands, let's insert an empty
 			// line between the usage for the Runnable and the one for the sub-commands
-			output += "\n"
+			output.WriteString("\n")
 		}
 		// For kubernetes, k8s, global, or no target display tanzu command path without target
 		if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
-			output += "  tanzu " + cmd.CommandPath() + " [command]\n"
+			output.WriteString(base + cmd.CommandPath() + " [command]\n")
 		}
 
 		// For non global, or no target display tanzu command path with target
 		if target != types.TargetGlobal && target != types.TargetUnknown {
-			output += "  tanzu " + string(target) + " " + cmd.CommandPath() + " [command]\n"
+			output.WriteString(base + string(target) + " " + cmd.CommandPath() + " [command]\n")
 		}
 	}
+	return output.String()
+}
 
-	// Display Aliases for the plugin if specified
+// Helper to format the help footer.
+func formatHelpFooter(cmd *cobra.Command, target types.Target) string {
+	var footer strings.Builder
+	if !cmd.HasAvailableSubCommands() {
+		return ""
+	}
+
+	footer.WriteString("\n")
+
+	// For kubernetes, k8s, global, or no target display tanzu command path without target
+	if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
+		footer.WriteString(`Use "`)
+		if !strings.HasSuffix(cmd.CommandPath(), "tanzu ") {
+			footer.WriteString("tanzu ")
+		}
+		footer.WriteString(cmd.CommandPath() + ` [command] --help" for more information about a command.` + "\n")
+	}
+
+	// For non global, or no target display tanzu command path with target
+	if target != types.TargetGlobal && target != types.TargetUnknown {
+		footer.WriteString(`Use "`)
+		if !strings.HasSuffix(cmd.CommandPath(), "tanzu ") {
+			footer.WriteString("tanzu ")
+		}
+		footer.WriteString(string(target) + " " + cmd.CommandPath() + ` [command] --help" for more information about a command.` + "\n")
+	}
+
+	return footer.String()
+}
+
+func printHelp(cmd *cobra.Command) string {
+	var output strings.Builder
+	target := types.StringToTarget(cmd.Annotations["target"])
+
+	output.WriteString(component.Bold(usageStr) + "\n")
+	output.WriteString(formatUsageHelpSection(cmd, target))
+
 	if len(cmd.Aliases) > 0 {
-		output += "\n" + component.Bold("Aliases:") + "\n"
-		output += "  " + cmd.NameAndAliases() + "\n"
+		output.WriteString("\n" + component.Bold(aliasesStr) + "\n")
+		output.WriteString("  " + cmd.NameAndAliases() + "\n")
 	}
 
-	// Display Examples for the plugin if specified
 	if cmd.HasExample() {
-		output += "\n" + component.Bold("Examples:") + "\n"
-		output += cmd.Example + "\n"
+		output.WriteString("\n" + component.Bold(examplesStr) + "\n")
+		output.WriteString(cmd.Example + "\n")
 	}
 
-	// Display Available Commands for the plugin
 	if cmd.HasAvailableSubCommands() {
-		output += "\n" + component.Bold("Available Commands:") + "\n"
+		output.WriteString("\n" + component.Bold(availableCommandsStr) + "\n")
 		for _, c := range cmd.Commands() {
 			if c.IsAvailableCommand() {
-				output += "  " + component.Rpad(c.Name(), c.NamePadding()) + " " + c.Short + "\n"
+				output.WriteString("  " + component.Rpad(c.Name(), c.NamePadding()) + " " + c.Short + "\n")
 			}
 		}
 	}
 
-	// Display Flags of the plugin
 	if cmd.HasAvailableLocalFlags() {
-		output += "\n" + component.Bold("Flags:") + "\n"
-		output += strings.TrimRight(cmd.LocalFlags().FlagUsages(), " ")
+		output.WriteString("\n" + component.Bold(flagsStr) + "\n")
+		output.WriteString(strings.TrimRight(cmd.LocalFlags().FlagUsages(), " "))
 	}
 
-	// Display Global Flags of the plugin
 	if cmd.HasAvailableInheritedFlags() {
-		output += "\n" + component.Bold("Global Flags:") + "\n"
-		output += strings.TrimRight(cmd.InheritedFlags().FlagUsages(), " ")
+		output.WriteString("\n" + component.Bold(globalFlagsStr) + "\n")
+		output.WriteString(strings.TrimRight(cmd.InheritedFlags().FlagUsages(), " "))
 	}
 
-	// Display Additional help topics of the plugin
 	if cmd.HasHelpSubCommands() {
-		output += "\n" + component.Bold("Additional help topics:") + "\n"
+		output.WriteString("\n" + component.Bold(additionalHelpTopicsStr) + "\n")
 		for _, c := range cmd.Commands() {
 			if c.IsAdditionalHelpTopicCommand() {
-				output += "  " + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n"
+				output.WriteString("  " + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
 			}
 		}
 	}
 
-	// Display a note at the very bottom to indicate how to get more help
-	if cmd.HasAvailableSubCommands() {
-		output += "\n"
+	output.WriteString(formatHelpFooter(cmd, target))
 
-		// For kubernetes, k8s, global, or no target display tanzu command path without target
-		if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
-			output += `Use "` //nolint:goconst
-			if !strings.HasSuffix(cmd.CommandPath(), "tanzu ") {
-				output += "tanzu " //nolint:goconst
-			}
-			output += cmd.CommandPath() + ` [command] --help" for more information about a command.` + "\n"
-		}
-
-		// For non global, or no target display tanzu command path with target
-		if target != types.TargetGlobal && target != types.TargetUnknown {
-			output += `Use "`
-			if !strings.HasSuffix(cmd.CommandPath(), "tanzu ") {
-				output += "tanzu "
-			}
-			output += string(target) + " " + cmd.CommandPath() + ` [command] --help" for more information about a command.` + "\n"
-		}
-	}
-
-	return output
+	return output.String()
 }
 
 // TemplateFuncs are the template usage funcs.

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -22,28 +22,92 @@ var UsageFunc = func(c *cobra.Command) error {
 }
 
 // CmdTemplate is the template for plugin commands.
-const CmdTemplate = `{{ bold "Usage:" }}
-  {{if .Runnable}}{{ $target := index .Annotations "target" }}{{ if or (eq $target "kubernetes") (eq $target "k8s") }}tanzu {{.UseLine}}{{ end }}{{ if and (ne $target "global") (ne $target "") }}tanzu {{ $target }} {{ else }} {{ end }}{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}{{ $target := index .Annotations "target" }}{{ if or (eq $target "kubernetes") (eq $target "k8s") }}tanzu {{.CommandPath}} [command]{{end}}{{ if and (ne $target "global") (ne $target "") }}tanzu {{ $target }} {{ else }} {{ end }}{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+const CmdTemplate = `
+{{- bold "Usage:" -}}
 
+{{- if .Runnable -}}
+{{- $target := index .Annotations "target" -}}
+{{- /* For kubernetes, k8s, global, or no target display tanzu command path without target*/ -}}
+{{- if or (eq $target "kubernetes") (eq $target "k8s") (eq $target "global") (eq $target "") }}
+ tanzu {{.UseLine}}
+{{- end -}}
+{{- /* For non global, or no target display tanzu command path with target*/ -}}
+{{- if and (ne $target "global") (ne $target "") }}
+ tanzu {{ $target }} {{.UseLine}}
+{{- end -}}
+{{- print "\n" -}}
+{{- end -}}
+
+{{- if .HasAvailableSubCommands -}}
+{{- $target := index .Annotations "target" -}}
+{{- /* For kubernetes, k8s, global, or no target display tanzu command path without target*/ -}}
+{{- if or (eq $target "kubernetes") (eq $target "k8s") (eq $target "global") (eq $target "") }}
+ tanzu {{.CommandPath}} [command]
+{{- end -}}
+{{- /* For non global, or no target display tanzu command path with target*/ -}}
+{{- if and (ne $target "global") (ne $target "") }}
+ tanzu {{ $target }} {{.CommandPath}} [command]
+{{- end -}}
+{{- print "\n" -}}
+{{- end -}}
+
+{{- /* Display Aliases for the plugin if specified*/ -}}
+{{ if gt (len .Aliases) 0 }}
 {{ bold "Aliases:" }}
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+  {{.NameAndAliases}}
+{{- print "\n" -}}
+{{- end -}}
 
+{{- /* Display Examples for the plugin if specified*/ -}}
+{{ if .HasExample }}
 {{ bold "Examples:" }}
-  {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.Example}}
+{{- print "\n" -}}
+{{- end -}}
 
-{{ bold "Available Commands:" }}{{range .Commands}}{{if .IsAvailableCommand }}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+{{- /* Display Available Commands for the plugin*/ -}}
+{{ if .HasAvailableSubCommands }}
+{{ bold "Available Commands:" }}{{range .Commands}}
+{{- if .IsAvailableCommand }}
+  {{rpad .Name .NamePadding }} {{.Short}}
+{{- end -}}
+{{- end -}}
+{{- print "\n" -}}
+{{- end -}}
 
+{{- /* Display Flags of the plugin*/ -}}
+{{ if .HasAvailableLocalFlags}}
 {{ bold "Flags:" }}
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+{{- print "\n" -}}
+{{- end -}}
 
+{{- /* Display Global Flags of the plugin*/ -}}
+{{ if .HasAvailableInheritedFlags}}
 {{ bold "Global Flags:" }}
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
+{{- print "\n" -}}
+{{- end -}}
 
-{{ bold "Additional help topics:" }}{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+{{- /* Display Additional help topics of the plugin*/ -}}
+{{ if .HasHelpSubCommands}}
+{{ bold "Additional help topics:" }}{{range .Commands}}
+{{- if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}
+{{- end -}}
+{{- end -}}
+{{- print "\n" -}}
+{{- end -}}
 
-{{ $target := index .Annotations "target" }}{{ if or (eq $target "kubernetes") (eq $target "k8s") }}Use "{{if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{else}}tanzu {{.CommandPath}}{{end}} [command] --help" for more information about a command.{{end}}Use "{{if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{else}}tanzu{{ $target := index .Annotations "target" }}{{ if and (ne $target "global") (ne $target "") }} {{ $target }} {{ else }} {{ end }}{{.CommandPath}}{{end}} [command] --help" for more information about a command.{{end}}
+{{ if .HasAvailableSubCommands}}
+{{- $target := index .Annotations "target" }}
+{{- if or (eq $target "kubernetes") (eq $target "k8s") (eq $target "global") (eq $target "") }}
+Use "{{- if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{- else}}tanzu {{.CommandPath}}{{- end}} [command] --help" for more information about a command.
+{{- end -}}
+{{- if and (ne $target "global") (ne $target "") }}
+Use "{{- if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{- else}}tanzu {{ $target }} {{.CommandPath}}{{- end}} [command] --help" for more information about a command.
+{{- end -}}
+{{- end }}
 `
 
 // TemplateFuncs are the template usage funcs.

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -26,6 +26,7 @@ var UsageFunc = func(c *cobra.Command) error {
 // CmdTemplate is the template for plugin commands.
 const CmdTemplate = `{{ printHelp . }}`
 
+//nolint:all
 func printHelp(cmd cobra.Command) string {
 	var output string
 	target := types.StringToTarget(cmd.Annotations["target"])
@@ -113,9 +114,9 @@ func printHelp(cmd cobra.Command) string {
 
 		// For kubernetes, k8s, global, or no target display tanzu command path without target
 		if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
-			output += `Use "`
+			output += `Use "` //nolint:goconst
 			if !strings.HasSuffix(cmd.CommandPath(), "tanzu ") {
-				output += "tanzu "
+				output += "tanzu " //nolint:goconst
 			}
 			output += cmd.CommandPath() + ` [command] --help" for more information about a command.` + "\n"
 		}

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -76,33 +76,6 @@ func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
 	return output.String()
 }
 
-// Helper to format additional help topics
-func formatAdditionalHelpTopicsSection(cmd *cobra.Command, target types.Target) string {
-	var output strings.Builder
-	if !cmd.HasHelpSubCommands() {
-		return ""
-	}
-
-	output.WriteString("\n" + component.Bold(additionalHelpTopicsStr) + "\n")
-	base := indentStr + "tanzu "
-
-	for _, c := range cmd.Commands() {
-		if c.IsAdditionalHelpTopicCommand() {
-			// For kubernetes, k8s, global, or no target display tanzu command path without target
-			if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
-				output.WriteString(base + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
-			}
-
-			// For non global, or no target ;display tanzu command path with target
-			if target != types.TargetGlobal && target != types.TargetUnknown {
-				output.WriteString(base + string(target) + " " + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
-			}
-		}
-	}
-
-	return output.String()
-}
-
 // Helper to format the help footer.
 func formatHelpFooter(cmd *cobra.Command, target types.Target) string {
 	var footer strings.Builder
@@ -168,8 +141,14 @@ func printHelp(cmd *cobra.Command) string {
 		output.WriteString(strings.TrimRight(cmd.InheritedFlags().FlagUsages(), " "))
 	}
 
-	output.WriteString(formatAdditionalHelpTopicsSection(cmd, target))
-
+	if cmd.HasHelpSubCommands() {
+		output.WriteString("\n" + component.Bold(additionalHelpTopicsStr) + "\n")
+		for _, c := range cmd.Commands() {
+			if c.IsAdditionalHelpTopicCommand() {
+				output.WriteString(indentStr + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
+			}
+		}
+	}
 	output.WriteString(formatHelpFooter(cmd, target))
 
 	return output.String()

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -42,6 +42,7 @@ const (
 func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
 	var output strings.Builder
 
+	output.WriteString(component.Bold(usageStr) + "\n")
 	base := indentStr + "tanzu "
 
 	if cmd.Runnable() {
@@ -72,6 +73,33 @@ func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
 			output.WriteString(base + string(target) + " " + cmd.CommandPath() + " [command]\n")
 		}
 	}
+	return output.String()
+}
+
+// Helper to format additional help topics
+func formatAdditionalHelpTopicsSection(cmd *cobra.Command, target types.Target) string {
+	var output strings.Builder
+	if !cmd.HasHelpSubCommands() {
+		return ""
+	}
+
+	output.WriteString("\n" + component.Bold(additionalHelpTopicsStr) + "\n")
+	base := indentStr + "tanzu "
+
+	for _, c := range cmd.Commands() {
+		if c.IsAdditionalHelpTopicCommand() {
+			// For kubernetes, k8s, global, or no target display tanzu command path without target
+			if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
+				output.WriteString(base + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
+			}
+
+			// For non global, or no target ;display tanzu command path with target
+			if target != types.TargetGlobal && target != types.TargetUnknown {
+				output.WriteString(base + string(target) + " " + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
+			}
+		}
+	}
+
 	return output.String()
 }
 
@@ -109,7 +137,6 @@ func printHelp(cmd *cobra.Command) string {
 	var output strings.Builder
 	target := types.StringToTarget(cmd.Annotations["target"])
 
-	output.WriteString(component.Bold(usageStr) + "\n")
 	output.WriteString(formatUsageHelpSection(cmd, target))
 
 	if len(cmd.Aliases) > 0 {
@@ -141,14 +168,7 @@ func printHelp(cmd *cobra.Command) string {
 		output.WriteString(strings.TrimRight(cmd.InheritedFlags().FlagUsages(), " "))
 	}
 
-	if cmd.HasHelpSubCommands() {
-		output.WriteString("\n" + component.Bold(additionalHelpTopicsStr) + "\n")
-		for _, c := range cmd.Commands() {
-			if c.IsAdditionalHelpTopicCommand() {
-				output.WriteString(indentStr + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
-			}
-		}
-	}
+	output.WriteString(formatAdditionalHelpTopicsSection(cmd, target))
 
 	output.WriteString(formatHelpFooter(cmd, target))
 

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -16,7 +16,7 @@ import (
 
 // UsageFunc is the usage func for a plugin.
 var UsageFunc = func(c *cobra.Command) error {
-	t, err := template.New("usage").Funcs(TemplateFuncs).Parse(CmdTemplate)
+	t, err := template.New("usage").Funcs(TemplateFuncs).Parse(cmdTemplate)
 	if err != nil {
 		return err
 	}
@@ -24,7 +24,33 @@ var UsageFunc = func(c *cobra.Command) error {
 }
 
 // CmdTemplate is the template for plugin commands.
-const CmdTemplate = `{{ printHelp . }}`
+// Deprecated: This variable is deprecated.
+const CmdTemplate = `{{ bold "Usage:" }}
+  {{if .Runnable}}{{ $target := index .Annotations "target" }}{{ if or (eq $target "kubernetes") (eq $target "k8s") }}tanzu {{.UseLine}}{{ end }}{{ if and (ne $target "global") (ne $target "") }}tanzu {{ $target }} {{ else }} {{ end }}{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}{{ $target := index .Annotations "target" }}{{ if or (eq $target "kubernetes") (eq $target "k8s") }}tanzu {{.CommandPath}} [command]{{end}}{{ if and (ne $target "global") (ne $target "") }}tanzu {{ $target }} {{ else }} {{ end }}{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+{{ bold "Aliases:" }}
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+{{ bold "Examples:" }}
+  {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+{{ bold "Available Commands:" }}{{range .Commands}}{{if .IsAvailableCommand }}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+{{ bold "Flags:" }}
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+{{ bold "Global Flags:" }}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+{{ bold "Additional help topics:" }}{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+{{ $target := index .Annotations "target" }}{{ if or (eq $target "kubernetes") (eq $target "k8s") }}Use "{{if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{else}}tanzu {{.CommandPath}}{{end}} [command] --help" for more information about a command.{{end}}Use "{{if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{else}}tanzu{{ $target := index .Annotations "target" }}{{ if and (ne $target "global") (ne $target "") }} {{ $target }} {{ else }} {{ end }}{{.CommandPath}}{{end}} [command] --help" for more information about a command.{{end}}
+`
+
+// cmdTemplate is the template for plugin commands.
+const cmdTemplate = `{{ printHelp . }}`
 
 // Constants for help text labels
 const (

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -145,7 +145,7 @@ func printHelp(cmd *cobra.Command) string {
 
 	if cmd.HasExample() {
 		output.WriteString("\n" + component.Bold(examplesStr) + "\n")
-		output.WriteString(cmd.Example + "\n")
+		output.WriteString(indentStr + cmd.Example + "\n")
 	}
 
 	if cmd.HasAvailableSubCommands() {

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -87,7 +87,7 @@ func formatHelpFooter(cmd *cobra.Command, target types.Target) string {
 	// For kubernetes, k8s, global, or no target display tanzu command path without target
 	if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
 		footer.WriteString(`Use "`)
-		if !strings.HasSuffix(cmd.CommandPath(), "tanzu ") {
+		if !strings.HasPrefix(cmd.CommandPath(), "tanzu ") {
 			footer.WriteString("tanzu ")
 		}
 		footer.WriteString(cmd.CommandPath() + ` [command] --help" for more information about a command.` + "\n")
@@ -96,7 +96,7 @@ func formatHelpFooter(cmd *cobra.Command, target types.Target) string {
 	// For non global, or no target display tanzu command path with target
 	if target != types.TargetGlobal && target != types.TargetUnknown {
 		footer.WriteString(`Use "`)
-		if !strings.HasSuffix(cmd.CommandPath(), "tanzu ") {
+		if !strings.HasPrefix(cmd.CommandPath(), "tanzu ") {
 			footer.WriteString("tanzu ")
 		}
 		footer.WriteString(string(target) + " " + cmd.CommandPath() + ` [command] --help" for more information about a command.` + "\n")

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -35,13 +35,14 @@ const (
 	flagsStr                = "Flags:"
 	globalFlagsStr          = "Global Flags:"
 	additionalHelpTopicsStr = "Additional help topics:"
+	indentStr               = "  "
 )
 
 // Helper to format the usage help section.
 func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
 	var output strings.Builder
 
-	base := "  tanzu "
+	base := indentStr + "tanzu "
 
 	if cmd.Runnable() {
 		// For kubernetes, k8s, global, or no target display tanzu command path without target
@@ -113,7 +114,7 @@ func printHelp(cmd *cobra.Command) string {
 
 	if len(cmd.Aliases) > 0 {
 		output.WriteString("\n" + component.Bold(aliasesStr) + "\n")
-		output.WriteString("  " + cmd.NameAndAliases() + "\n")
+		output.WriteString(indentStr + cmd.NameAndAliases() + "\n")
 	}
 
 	if cmd.HasExample() {
@@ -125,7 +126,7 @@ func printHelp(cmd *cobra.Command) string {
 		output.WriteString("\n" + component.Bold(availableCommandsStr) + "\n")
 		for _, c := range cmd.Commands() {
 			if c.IsAvailableCommand() {
-				output.WriteString("  " + component.Rpad(c.Name(), c.NamePadding()) + " " + c.Short + "\n")
+				output.WriteString(indentStr + component.Rpad(c.Name(), c.NamePadding()) + " " + c.Short + "\n")
 			}
 		}
 	}
@@ -144,7 +145,7 @@ func printHelp(cmd *cobra.Command) string {
 		output.WriteString("\n" + component.Bold(additionalHelpTopicsStr) + "\n")
 		for _, c := range cmd.Commands() {
 			if c.IsAdditionalHelpTopicCommand() {
-				output.WriteString("  " + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
+				output.WriteString(indentStr + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
 			}
 		}
 	}

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -29,11 +29,11 @@ const CmdTemplate = `
 {{- $target := index .Annotations "target" -}}
 {{- /* For kubernetes, k8s, global, or no target display tanzu command path without target*/ -}}
 {{- if or (eq $target "kubernetes") (eq $target "k8s") (eq $target "global") (eq $target "") }}
- tanzu {{.UseLine}}
+  tanzu {{.UseLine}}
 {{- end -}}
 {{- /* For non global, or no target display tanzu command path with target*/ -}}
 {{- if and (ne $target "global") (ne $target "") }}
- tanzu {{ $target }} {{.UseLine}}
+  tanzu {{ $target }} {{.UseLine}}
 {{- end -}}
 {{- print "\n" -}}
 {{- end -}}
@@ -42,11 +42,11 @@ const CmdTemplate = `
 {{- $target := index .Annotations "target" -}}
 {{- /* For kubernetes, k8s, global, or no target display tanzu command path without target*/ -}}
 {{- if or (eq $target "kubernetes") (eq $target "k8s") (eq $target "global") (eq $target "") }}
- tanzu {{.CommandPath}} [command]
+  tanzu {{.CommandPath}} [command]
 {{- end -}}
 {{- /* For non global, or no target display tanzu command path with target*/ -}}
 {{- if and (ne $target "global") (ne $target "") }}
- tanzu {{ $target }} {{.CommandPath}} [command]
+  tanzu {{ $target }} {{.CommandPath}} [command]
 {{- end -}}
 {{- print "\n" -}}
 {{- end -}}

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -14,20 +14,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
-const expectedFetchCommandHelpText = `Fetch the plugin tests
-
-Usage:
-  tanzu test fetch [flags]
-
-Flags:
-  -h, --help           help for fetch
-  -l, --local string   path to local repository
-  -u, --url string     url to remote repository
-
-Global Flags:
-  -e, --env string   env to test
-`
-
 func TestUsageFunc(t *testing.T) {
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -60,7 +46,7 @@ func TestUsageFunc(t *testing.T) {
 	assert.Contains(t, string(got), "Usage:")
 }
 
-func SampleTestCommand(t *testing.T, target types.Target) *cobra.Command {
+func SampleTestPlugin(t *testing.T, target types.Target) *Plugin {
 	var pluginsCmd = &cobra.Command{
 		Use:   "plugin",
 		Short: "Plugin tests",
@@ -115,7 +101,7 @@ func SampleTestCommand(t *testing.T, target types.Target) *cobra.Command {
 		pluginsCmd,
 	)
 
-	return p.Cmd
+	return p
 }
 
 func TestGlobalTestPluginCommandHelpText(t *testing.T) {
@@ -137,13 +123,13 @@ func TestGlobalTestPluginCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Global target
-	cmd := SampleTestCommand(t, types.TargetGlobal)
+	p := SampleTestPlugin(t, types.TargetGlobal)
 
 	// Set the arguments as if the user typed them in the command line
-	cmd.SetArgs([]string{"--help"})
+	p.Cmd.SetArgs([]string{"--help"})
 
 	// Execute the command which will trigger the help
-	err = cmd.Execute()
+	err = p.Execute()
 	assert.Nil(t, err)
 
 	err = w.Close()
@@ -194,13 +180,13 @@ func TestKubernetesTestPluginCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Kubernetes target
-	cmd := SampleTestCommand(t, types.TargetK8s)
+	p := SampleTestPlugin(t, types.TargetK8s)
 
 	// Set the arguments as if the user typed them in the command line
-	cmd.SetArgs([]string{"--help"})
+	p.Cmd.SetArgs([]string{"--help"})
 
 	// Execute the command which will trigger the help
-	err = cmd.Execute()
+	err = p.Execute()
 	assert.Nil(t, err)
 
 	err = w.Close()
@@ -253,13 +239,13 @@ func TestMissionControlTestPluginCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with MissionControl target
-	rootCmd := SampleTestCommand(t, types.TargetTMC)
+	p := SampleTestPlugin(t, types.TargetTMC)
 
 	// Set the arguments as if the user typed them in the command line
-	rootCmd.SetArgs([]string{"--help"})
+	p.Cmd.SetArgs([]string{"--help"})
 
 	// Execute the command which will trigger the help
-	err = rootCmd.Execute()
+	err = p.Execute()
 	assert.Nil(t, err)
 
 	err = w.Close()
@@ -310,21 +296,33 @@ func TestGlobalTestPluginFetchCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Global target
-	cmd := SampleTestCommand(t, types.TargetGlobal)
+	p := SampleTestPlugin(t, types.TargetGlobal)
 
 	// Set the arguments as if the user typed them in the command line
-	cmd.SetArgs([]string{"fetch", "--help"})
+	p.Cmd.SetArgs([]string{"fetch", "--help"})
 
 	// Execute the command which will trigger the help
-	err = cmd.Execute()
+	err = p.Execute()
 	assert.Nil(t, err)
 
 	err = w.Close()
 	assert.Nil(t, err)
 
 	got := string(<-c)
+	expected := `Fetch the plugin tests
 
-	assert.Equal(t, expectedFetchCommandHelpText, got)
+Usage:
+  tanzu test fetch [flags]
+
+Flags:
+  -h, --help           help for fetch
+  -l, --local string   path to local repository
+  -u, --url string     url to remote repository
+
+Global Flags:
+  -e, --env string   env to test
+`
+	assert.Equal(t, expected, got)
 }
 
 func TestKubernetesTestPluginFetchCommandHelpText(t *testing.T) {
@@ -346,13 +344,13 @@ func TestKubernetesTestPluginFetchCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Kubernetes target
-	cmd := SampleTestCommand(t, types.TargetK8s)
+	p := SampleTestPlugin(t, types.TargetK8s)
 
 	// Set the arguments as if the user typed them in the command line
-	cmd.SetArgs([]string{"fetch", "--help"})
+	p.Cmd.SetArgs([]string{"fetch", "--help"})
 
 	// Execute the command which will trigger the help
-	err = cmd.Execute()
+	err = p.Execute()
 	assert.Nil(t, err)
 
 	err = w.Close()
@@ -360,7 +358,21 @@ func TestKubernetesTestPluginFetchCommandHelpText(t *testing.T) {
 
 	got := string(<-c)
 
-	assert.Equal(t, expectedFetchCommandHelpText, got)
+	expected := `Fetch the plugin tests
+
+Usage:
+  tanzu test fetch [flags]
+  tanzu kubernetes test fetch [flags]
+
+Flags:
+  -h, --help           help for fetch
+  -l, --local string   path to local repository
+  -u, --url string     url to remote repository
+
+Global Flags:
+  -e, --env string   env to test
+`
+	assert.Equal(t, expected, got)
 }
 
 func TestMissionControlTestPluginFetchCommandHelpText(t *testing.T) {
@@ -382,13 +394,13 @@ func TestMissionControlTestPluginFetchCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with MissionControl target
-	cmd := SampleTestCommand(t, types.TargetTMC)
+	p := SampleTestPlugin(t, types.TargetTMC)
 
 	// Set the arguments as if the user typed them in the command line
-	cmd.SetArgs([]string{"fetch", "--help"})
+	p.Cmd.SetArgs([]string{"fetch", "--help"})
 
 	// Execute the command which will trigger the help
-	err = cmd.Execute()
+	err = p.Execute()
 	assert.Nil(t, err)
 
 	err = w.Close()
@@ -396,5 +408,18 @@ func TestMissionControlTestPluginFetchCommandHelpText(t *testing.T) {
 
 	got := string(<-c)
 
-	assert.Equal(t, expectedFetchCommandHelpText, got)
+	expected := `Fetch the plugin tests
+
+Usage:
+  tanzu mission-control test fetch [flags]
+
+Flags:
+  -h, --help           help for fetch
+  -l, --local string   path to local repository
+  -u, --url string     url to remote repository
+
+Global Flags:
+  -e, --env string   env to test
+`
+	assert.Equal(t, expected, got)
 }

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -89,12 +89,15 @@ func SampleTestPlugin(t *testing.T, target types.Target) *Plugin {
 	fetchCmd.PersistentFlags().StringVarP(&url, "url", "u", "", "url to remote repository")
 	_ = fetchCmd.MarkFlagRequired("url")
 
+	fetchCmd.Example = "sample example usage of the fetch command"
+
 	p, err := NewPlugin(&descriptor)
 	assert.Nil(t, err)
 
 	var env string
 	p.Cmd.PersistentFlags().StringVarP(&env, "env", "e", "", "env to test")
 
+	p.Cmd.Example = "sample example usage of the test command"
 	p.AddCommands(
 		fetchCmd,
 		pushCmd,
@@ -144,6 +147,9 @@ Usage:
 
 Aliases:
   test, t
+
+Examples:
+  sample example usage of the test command
 
 Available Commands:
   fetch         Fetch the plugin tests
@@ -203,6 +209,9 @@ Usage:
 Aliases:
   test, t
 
+Examples:
+  sample example usage of the test command
+
 Available Commands:
   fetch         Fetch the plugin tests
   push          Push the plugin tests
@@ -261,6 +270,9 @@ Usage:
 Aliases:
   test, t
 
+Examples:
+  sample example usage of the test command
+
 Available Commands:
   fetch         Fetch the plugin tests
   push          Push the plugin tests
@@ -314,6 +326,9 @@ func TestGlobalTestPluginFetchCommandHelpText(t *testing.T) {
 Usage:
   tanzu test fetch [flags]
 
+Examples:
+  sample example usage of the fetch command
+
 Flags:
   -h, --help           help for fetch
   -l, --local string   path to local repository
@@ -364,6 +379,9 @@ Usage:
   tanzu test fetch [flags]
   tanzu kubernetes test fetch [flags]
 
+Examples:
+  sample example usage of the fetch command
+
 Flags:
   -h, --help           help for fetch
   -l, --local string   path to local repository
@@ -412,6 +430,9 @@ func TestMissionControlTestPluginFetchCommandHelpText(t *testing.T) {
 
 Usage:
   tanzu mission-control test fetch [flags]
+
+Examples:
+  sample example usage of the fetch command
 
 Flags:
   -h, --help           help for fetch

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -9,62 +9,10 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
-
-func SampleTestCommand(t *testing.T, target types.Target) *cobra.Command {
-	var pluginsCmd = &cobra.Command{
-		Use:   "plugin",
-		Short: "Plugin tests",
-	}
-
-	var fetchCmd = &cobra.Command{
-		Use:   "fetch",
-		Short: "Fetch the plugin tests",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("fetch")
-			return nil
-		},
-	}
-
-	var pushCmd = &cobra.Command{
-		Use:   "push",
-		Short: "Push the plugin tests",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("push")
-			return nil
-		},
-	}
-
-	var descriptor = PluginDescriptor{
-		Name:        "test",
-		Target:      target,
-		Aliases:     []string{"tt", "ttt"},
-		Description: "Test the CLI",
-		Group:       AdminCmdGroup,
-		Version:     "v1.1.0",
-		BuildSHA:    "1234567",
-	}
-
-	var local string
-
-	fetchCmd.Flags().StringVarP(&local, "local", "l", "", "path to local repository")
-	_ = fetchCmd.MarkFlagRequired("local")
-
-	p, err := NewPlugin(&descriptor)
-	assert.Nil(t, err)
-
-	p.AddCommands(
-		fetchCmd,
-		pushCmd,
-		pluginsCmd,
-	)
-
-	return p.Cmd
-}
 
 func TestUsageFunc(t *testing.T) {
 	r, w, err := os.Pipe()
@@ -98,46 +46,58 @@ func TestUsageFunc(t *testing.T) {
 	assert.Contains(t, string(got), "Usage:")
 }
 
-func TestUsageFuncWithKubernetesTargetPlugin(t *testing.T) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Error(err)
+func SampleTestCommand(t *testing.T, target types.Target) *cobra.Command {
+	var pluginsCmd = &cobra.Command{
+		Use:   "plugin",
+		Short: "Plugin tests",
 	}
-	c := make(chan []byte)
-	go readOutput(t, r, c)
 
-	// Set up for our test
-	stdout := os.Stdout
-	stderr := os.Stderr
-	defer func() {
-		os.Stdout = stdout
-		os.Stderr = stderr
-	}()
-	os.Stdout = w
-	os.Stderr = w
+	var fetchCmd = &cobra.Command{
+		Use:   "fetch",
+		Short: "Fetch the plugin tests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("fetch")
+			return nil
+		},
+	}
 
-	cmd := SampleTestCommand(t, types.TargetK8s)
-	err = UsageFunc(cmd)
+	var pushCmd = &cobra.Command{
+		Use:   "push",
+		Short: "Push the plugin tests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("push")
+			return nil
+		},
+	}
+
+	var descriptor = PluginDescriptor{
+		Name:        "test",
+		Target:      target,
+		Aliases:     []string{"t"},
+		Description: "Test the CLI",
+		Group:       AdminCmdGroup,
+		Version:     "v1.1.0",
+		BuildSHA:    "1234567",
+	}
+
+	var local string
+
+	fetchCmd.Flags().StringVarP(&local, "local", "l", "", "path to local repository")
+	_ = fetchCmd.MarkFlagRequired("local")
+
+	p, err := NewPlugin(&descriptor)
 	assert.Nil(t, err)
-	err = w.Close()
-	assert.Nil(t, err)
 
-	got := string(<-c)
+	p.AddCommands(
+		fetchCmd,
+		pushCmd,
+		pluginsCmd,
+	)
 
-	// Check for various segments in the output
-	assert.Contains(t, got, "Usage:")
-	assert.Contains(t, got, "tanzu test [command]")
-	assert.Contains(t, got, "tanzu kubernetes test [command]")
-	assert.Contains(t, got, "Available Commands:")
-	assert.Contains(t, got, "fetch         Fetch the plugin tests")
-	assert.Contains(t, got, "push          Push the plugin tests")
-	assert.Contains(t, got, "Additional help topics:")
-	assert.Contains(t, got, "test plugin        Plugin tests")
-	assert.Contains(t, got, `Use "tanzu test [command] --help" for more information about a command.`)
-	assert.Contains(t, got, `Use "tanzu kubernetes test [command] --help" for more information about a command.`)
+	return p.Cmd
 }
 
-func TestUsageFuncWithGlobalTargetPlugin(t *testing.T) {
+func TestGlobalTestPluginCommandHelpText(t *testing.T) {
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Error(err)
@@ -156,7 +116,9 @@ func TestUsageFuncWithGlobalTargetPlugin(t *testing.T) {
 	os.Stderr = w
 
 	cmd := SampleTestCommand(t, types.TargetGlobal)
-	err = UsageFunc(cmd)
+	cmd.SetArgs([]string{"-h"})
+
+	err = cmd.Execute()
 	assert.Nil(t, err)
 
 	err = w.Close()
@@ -164,18 +126,30 @@ func TestUsageFuncWithGlobalTargetPlugin(t *testing.T) {
 
 	got := string(<-c)
 
-	// Check for various segments in the output
-	assert.Contains(t, got, "Usage:")
-	assert.Contains(t, got, "tanzu test [command]")
-	assert.Contains(t, got, "Available Commands:")
-	assert.Contains(t, got, "fetch         Fetch the plugin tests")
-	assert.Contains(t, got, "push          Push the plugin tests")
-	assert.Contains(t, got, "Additional help topics:")
-	assert.Contains(t, got, "test plugin        Plugin tests")
-	assert.Contains(t, got, `Use "tanzu test [command] --help" for more information about a command.`)
+	expected := `Test the CLI
+
+Usage:
+  tanzu test [command]
+
+Aliases:
+  test, t
+
+Available Commands:
+  fetch         Fetch the plugin tests
+  push          Push the plugin tests
+
+Flags:
+  -h, --help   help for test
+
+Additional help topics:
+  test plugin        Plugin tests
+
+Use "tanzu test [command] --help" for more information about a command.
+`
+	assert.Equal(t, expected, got)
 }
 
-func TestUsageFuncWithTMCTargetPlugin(t *testing.T) {
+func TestKubernetesTestPluginCommandHelpText(t *testing.T) {
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Error(err)
@@ -193,8 +167,10 @@ func TestUsageFuncWithTMCTargetPlugin(t *testing.T) {
 	os.Stdout = w
 	os.Stderr = w
 
-	cmd := SampleTestCommand(t, types.TargetTMC)
-	err = UsageFunc(cmd)
+	cmd := SampleTestCommand(t, types.TargetK8s)
+	cmd.SetArgs([]string{"-h"})
+
+	err = cmd.Execute()
 	assert.Nil(t, err)
 
 	err = w.Close()
@@ -202,13 +178,83 @@ func TestUsageFuncWithTMCTargetPlugin(t *testing.T) {
 
 	got := string(<-c)
 
-	// Check for various segments in the output
-	assert.Contains(t, got, "Usage:")
-	assert.Contains(t, got, "tanzu mission-control test [command]")
-	assert.Contains(t, got, "Available Commands:")
-	assert.Contains(t, got, "fetch         Fetch the plugin tests")
-	assert.Contains(t, got, "push          Push the plugin tests")
-	assert.Contains(t, got, "Additional help topics:")
-	assert.Contains(t, got, "test plugin        Plugin tests")
-	assert.Contains(t, got, `Use "tanzu mission-control test [command] --help" for more information about a command.`)
+	expected := `Test the CLI
+
+Usage:
+  tanzu test [command]
+  tanzu kubernetes test [command]
+
+Aliases:
+  test, t
+
+Available Commands:
+  fetch         Fetch the plugin tests
+  push          Push the plugin tests
+
+Flags:
+  -h, --help   help for test
+
+Additional help topics:
+  test plugin        Plugin tests
+
+Use "tanzu test [command] --help" for more information about a command.
+Use "tanzu kubernetes test [command] --help" for more information about a command.
+`
+	assert.Equal(t, expected, got)
+}
+
+func TestMissionControlTestPluginCommandHelpText(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	// Prepare the root command with MissionControl target
+	rootCmd := SampleTestCommand(t, types.TargetTMC)
+
+	// Set the arguments as if the user typed them in the command line
+	rootCmd.SetArgs([]string{"--help"})
+
+	// Execute the command which will trigger the help
+	err = rootCmd.Execute()
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
+	expected := `Test the CLI
+
+Usage:
+  tanzu mission-control test [command]
+
+Aliases:
+  test, t
+
+Available Commands:
+  fetch         Fetch the plugin tests
+  push          Push the plugin tests
+
+Flags:
+  -h, --help   help for test
+
+Additional help topics:
+  test plugin        Plugin tests
+
+Use "tanzu mission-control test [command] --help" for more information about a command.
+`
+	assert.Equal(t, expected, got)
 }

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -168,7 +168,7 @@ Flags:
   -h, --help         help for test
 
 Additional help topics:
-  test plugin        Plugin tests
+  tanzu test plugin        Plugin tests
 
 Use "tanzu test [command] --help" for more information about a command.
 `
@@ -226,7 +226,8 @@ Flags:
   -h, --help         help for test
 
 Additional help topics:
-  test plugin        Plugin tests
+  tanzu test plugin        Plugin tests
+  tanzu kubernetes test plugin        Plugin tests
 
 Use "tanzu test [command] --help" for more information about a command.
 Use "tanzu kubernetes test [command] --help" for more information about a command.
@@ -284,7 +285,7 @@ Flags:
   -h, --help         help for test
 
 Additional help topics:
-  test plugin        Plugin tests
+  tanzu mission-control test plugin        Plugin tests
 
 Use "tanzu mission-control test [command] --help" for more information about a command.
 `

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -4,16 +4,69 @@
 package plugin
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
-func TestUsageFunc(t *testing.T) {
-	assert := assert.New(t)
+func SampleTestCommand(t *testing.T, target types.Target) *cobra.Command {
+	var pluginsCmd = &cobra.Command{
+		Use:   "plugin",
+		Short: "Plugin tests",
+	}
 
+	var fetchCmd = &cobra.Command{
+		Use:   "fetch",
+		Short: "Fetch the plugin tests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("fetch")
+			return nil
+		},
+	}
+
+	var pushCmd = &cobra.Command{
+		Use:   "push",
+		Short: "Push the plugin tests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("push")
+			return nil
+		},
+	}
+
+	var descriptor = PluginDescriptor{
+		Name:        "test",
+		Target:      target,
+		Aliases:     []string{"tt", "ttt"},
+		Description: "Test the CLI",
+		Group:       AdminCmdGroup,
+		Version:     "v1.1.0",
+		BuildSHA:    "1234567",
+	}
+
+	var local string
+
+	fetchCmd.Flags().StringVarP(&local, "local", "l", "", "path to local repository")
+	_ = fetchCmd.MarkFlagRequired("local")
+
+	p, err := NewPlugin(&descriptor)
+	assert.Nil(t, err)
+
+	p.AddCommands(
+		fetchCmd,
+		pushCmd,
+		pluginsCmd,
+	)
+
+	return p.Cmd
+}
+
+func TestUsageFunc(t *testing.T) {
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Error(err)
@@ -36,9 +89,126 @@ func TestUsageFunc(t *testing.T) {
 		Short: "Sub1 description",
 	}
 	err = UsageFunc(cmd)
-	w.Close()
-	assert.Nil(err)
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
 
 	got := <-c
-	assert.Contains(string(got), "Usage:")
+	assert.Contains(t, string(got), "Usage:")
+}
+
+func TestUsageFuncWithKubernetesTargetPlugin(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	cmd := SampleTestCommand(t, types.TargetK8s)
+	err = UsageFunc(cmd)
+	assert.Nil(t, err)
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
+	// Check for various segments in the output
+	assert.Contains(t, got, "Usage:")
+	assert.Contains(t, got, "tanzu test [command]")
+	assert.Contains(t, got, "tanzu kubernetes test [command]")
+	assert.Contains(t, got, "Available Commands:")
+	assert.Contains(t, got, "fetch         Fetch the plugin tests")
+	assert.Contains(t, got, "push          Push the plugin tests")
+	assert.Contains(t, got, "Additional help topics:")
+	assert.Contains(t, got, "test plugin        Plugin tests")
+	assert.Contains(t, got, `Use "tanzu test [command] --help" for more information about a command.`)
+	assert.Contains(t, got, `Use "tanzu kubernetes test [command] --help" for more information about a command.`)
+}
+
+func TestUsageFuncWithGlobalTargetPlugin(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	cmd := SampleTestCommand(t, types.TargetGlobal)
+	err = UsageFunc(cmd)
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
+	// Check for various segments in the output
+	assert.Contains(t, got, "Usage:")
+	assert.Contains(t, got, "tanzu test [command]")
+	assert.Contains(t, got, "Available Commands:")
+	assert.Contains(t, got, "fetch         Fetch the plugin tests")
+	assert.Contains(t, got, "push          Push the plugin tests")
+	assert.Contains(t, got, "Additional help topics:")
+	assert.Contains(t, got, "test plugin        Plugin tests")
+	assert.Contains(t, got, `Use "tanzu test [command] --help" for more information about a command.`)
+}
+
+func TestUsageFuncWithTMCTargetPlugin(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	cmd := SampleTestCommand(t, types.TargetTMC)
+	err = UsageFunc(cmd)
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
+	// Check for various segments in the output
+	assert.Contains(t, got, "Usage:")
+	assert.Contains(t, got, "tanzu mission-control test [command]")
+	assert.Contains(t, got, "Available Commands:")
+	assert.Contains(t, got, "fetch         Fetch the plugin tests")
+	assert.Contains(t, got, "push          Push the plugin tests")
+	assert.Contains(t, got, "Additional help topics:")
+	assert.Contains(t, got, "test plugin        Plugin tests")
+	assert.Contains(t, got, `Use "tanzu mission-control test [command] --help" for more information about a command.`)
 }

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -168,7 +168,7 @@ Flags:
   -h, --help         help for test
 
 Additional help topics:
-  tanzu test plugin        Plugin tests
+  test plugin        Plugin tests
 
 Use "tanzu test [command] --help" for more information about a command.
 `
@@ -226,8 +226,7 @@ Flags:
   -h, --help         help for test
 
 Additional help topics:
-  tanzu test plugin        Plugin tests
-  tanzu kubernetes test plugin        Plugin tests
+  test plugin        Plugin tests
 
 Use "tanzu test [command] --help" for more information about a command.
 Use "tanzu kubernetes test [command] --help" for more information about a command.
@@ -285,7 +284,7 @@ Flags:
   -h, --help         help for test
 
 Additional help topics:
-  tanzu mission-control test plugin        Plugin tests
+  test plugin        Plugin tests
 
 Use "tanzu mission-control test [command] --help" for more information about a command.
 `


### PR DESCRIPTION
### What this PR does / why we need it

- Refactored the CmdTemplate help text to use the new go lang function that generated the help text templates.
- The same const is used CmdTemplate with internal implementation changed from text template to use go func.
- Additional fix to https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/92

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

- Added unit tests for each plugin target i.e global, k8s, tmc

Manual Testing 

**Global Test Plugin**

**_Before_**  
Usage text doesn't show the tanzu prefix

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu test -h
Test the CLI

Usage:
   test [command]

Aliases:
  test, t

Available Commands:
  fetch         Fetch the plugin tests
  push          Push the plugin tests

Flags:
  -h, --help   help for test

Additional help topics:
  test plugin        Plugin tests

Use "tanzu test [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu test fetch -h
Fetch the plugin tests

Usage:
   test fetch [flags]

Flags:
  -h, --help           help for fetch
  -l, --local string   path to local repository
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)>

```

**_After_**
```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu plugin list
Standalone Plugins
  NAME  DESCRIPTION   TARGET  VERSION     STATUS
  test  Test the CLI  global  v1.1.0-dev  installed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu test -h
Test the CLI

Usage:
  tanzu test [command]

Aliases:
  test, t

Available Commands:
  fetch         Fetch the plugin tests
  push          Push the plugin tests

Flags:
  -h, --help   help for test

Additional help topics:
  test plugin        Plugin tests

Use "tanzu test [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu test fetch -h
Fetch the plugin tests

Usage:
  tanzu test fetch [flags]

Flags:
  -h, --help           help for fetch
  -l, --local string   path to local repository
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)>

```

**Kubernetes Test Plugin**

**_Before_**

Usage text commands are not properly indented

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main) [1]> tanzu test -h
Test the CLI

Usage:
  tanzu test [command]tanzu kubernetes test [command]

Aliases:
  test, t

Available Commands:
  fetch         Fetch the plugin tests
  push          Push the plugin tests

Flags:
  -h, --help   help for test

Additional help topics:
  test plugin        Plugin tests

Use "tanzu test [command] --help" for more information about a command.Use "tanzu kubernetes test [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu test fetch -h
Fetch the plugin tests

Usage:
  tanzu test fetch [flags]tanzu kubernetes test fetch [flags]

Flags:
  -h, --help           help for fetch
  -l, --local string   path to local repository
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu k8s test -h
Test the CLI

Usage:
  tanzu test [command]tanzu kubernetes test [command]

Aliases:
  test, t

Available Commands:
  fetch         Fetch the plugin tests
  push          Push the plugin tests

Flags:
  -h, --help   help for test

Additional help topics:
  test plugin        Plugin tests

Use "tanzu test [command] --help" for more information about a command.Use "tanzu kubernetes test [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu k8s test fetch -h
Fetch the plugin tests

Usage:
  tanzu test fetch [flags]tanzu kubernetes test fetch [flags]

Flags:
  -h, --help           help for fetch
  -l, --local string   path to local repository
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)>

```

**_After_**

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu plugin list
Standalone Plugins
  NAME  DESCRIPTION   TARGET      VERSION     STATUS
  test  Test the CLI  kubernetes  v1.1.0-dev  installed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu test -h
Test the CLI

Usage:
  tanzu test [command]
  tanzu kubernetes test [command]

Aliases:
  test, t

Available Commands:
  fetch         Fetch the plugin tests
  push          Push the plugin tests

Flags:
  -h, --help   help for test

Additional help topics:
  test plugin        Plugin tests

Use "tanzu test [command] --help" for more information about a command.
Use "tanzu kubernetes test [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu test fetch -h
Fetch the plugin tests

Usage:
  tanzu test fetch [flags]
  tanzu kubernetes test fetch [flags]

Flags:
  -h, --help           help for fetch
  -l, --local string   path to local repository
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu k8s test -h
Test the CLI

Usage:
  tanzu test [command]
  tanzu kubernetes test [command]

Aliases:
  test, t

Available Commands:
  fetch         Fetch the plugin tests
  push          Push the plugin tests

Flags:
  -h, --help   help for test

Additional help topics:
  test plugin        Plugin tests

Use "tanzu test [command] --help" for more information about a command.
Use "tanzu kubernetes test [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu k8s test fetch -h
Fetch the plugin tests

Usage:
  tanzu test fetch [flags]
  tanzu kubernetes test fetch [flags]

Flags:
  -h, --help           help for fetch
  -l, --local string   path to local repository
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)>
```

**Mission Control Test Plugin**

```
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu plugin list
Standalone Plugins
  NAME  DESCRIPTION   TARGET           VERSION     STATUS
  test  Test the CLI  mission-control  v1.1.0-dev  installed
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main) [1]> tanzu tmc test -h
Test the CLI

Usage:
  tanzu mission-control test [command]

Aliases:
  test, t

Available Commands:
  fetch         Fetch the plugin tests
  push          Push the plugin tests

Flags:
  -h, --help   help for test

Additional help topics:
  test plugin        Plugin tests

Use "tanzu mission-control test [command] --help" for more information about a command.
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)> tanzu tmc test fetch -h
Fetch the plugin tests

Usage:
  tanzu mission-control test fetch [flags]

Flags:
  -h, --help           help for fetch
  -l, --local string   path to local repository
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (main)>

```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix plugin help text for global, kubernetes, mission-control targets
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
