### PR TITLE
Update help text template to fix target usage (#94)

### DIFF
--- a/plugin/root.go
+++ b/plugin/root.go
@@ -30,7 +30,7 @@ func newRootCmd(descriptor *PluginDescriptor) *cobra.Command {
 		},
 	}
 	cobra.AddTemplateFuncs(TemplateFuncs)
-	cmd.SetUsageTemplate(CmdTemplate)
+	cmd.SetUsageTemplate(cmdTemplate)
 
 	cmd.AddCommand(
 		newDescribeCmd(descriptor.Description),

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -5,16 +5,18 @@ package plugin
 
 import (
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/tanzu-plugin-runtime/component"
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 // UsageFunc is the usage func for a plugin.
 var UsageFunc = func(c *cobra.Command) error {
-	t, err := template.New("usage").Funcs(TemplateFuncs).Parse(CmdTemplate)
+	t, err := template.New("usage").Funcs(TemplateFuncs).Parse(cmdTemplate)
 	if err != nil {
 		return err
 	}
@@ -22,6 +24,7 @@ var UsageFunc = func(c *cobra.Command) error {
 }
 
 // CmdTemplate is the template for plugin commands.
+// Deprecated: This variable is deprecated.
 const CmdTemplate = `{{ bold "Usage:" }}
   {{if .Runnable}}{{ $target := index .Annotations "target" }}{{ if or (eq $target "kubernetes") (eq $target "k8s") }}tanzu {{.UseLine}}{{ end }}{{ if and (ne $target "global") (ne $target "") }}tanzu {{ $target }} {{ else }} {{ end }}{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}{{ $target := index .Annotations "target" }}{{ if or (eq $target "kubernetes") (eq $target "k8s") }}tanzu {{.CommandPath}} [command]{{end}}{{ if and (ne $target "global") (ne $target "") }}tanzu {{ $target }} {{ else }} {{ end }}{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
@@ -46,8 +49,142 @@ const CmdTemplate = `{{ bold "Usage:" }}
 {{ $target := index .Annotations "target" }}{{ if or (eq $target "kubernetes") (eq $target "k8s") }}Use "{{if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{else}}tanzu {{.CommandPath}}{{end}} [command] --help" for more information about a command.{{end}}Use "{{if beginsWith .CommandPath "tanzu "}}{{.CommandPath}}{{else}}tanzu{{ $target := index .Annotations "target" }}{{ if and (ne $target "global") (ne $target "") }} {{ $target }} {{ else }} {{ end }}{{.CommandPath}}{{end}} [command] --help" for more information about a command.{{end}}
 `
 
+// cmdTemplate is the template for plugin commands.
+const cmdTemplate = `{{ printHelp . }}`
+
+// Constants for help text labels
+const (
+	usageStr                = "Usage:"
+	aliasesStr              = "Aliases:"
+	examplesStr             = "Examples:"
+	availableCommandsStr    = "Available Commands:"
+	flagsStr                = "Flags:"
+	globalFlagsStr          = "Global Flags:"
+	additionalHelpTopicsStr = "Additional help topics:"
+	indentStr               = "  "
+)
+
+// Helper to format the usage help section.
+func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
+	var output strings.Builder
+
+	output.WriteString(component.Bold(usageStr) + "\n")
+	base := indentStr + "tanzu "
+
+	if cmd.Runnable() {
+		// For kubernetes, k8s, global, or no target display tanzu command path without target
+		if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
+			output.WriteString(base + cmd.UseLine() + "\n")
+		}
+
+		// For non global, or no target ;display tanzu command path with target
+		if target != types.TargetGlobal && target != types.TargetUnknown {
+			output.WriteString(base + string(target) + " " + cmd.UseLine() + "\n")
+		}
+	}
+
+	if cmd.HasAvailableSubCommands() {
+		if cmd.Runnable() {
+			// If the command is both Runnable and has sub-commands, let's insert an empty
+			// line between the usage for the Runnable and the one for the sub-commands
+			output.WriteString("\n")
+		}
+		// For kubernetes, k8s, global, or no target display tanzu command path without target
+		if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
+			output.WriteString(base + cmd.CommandPath() + " [command]\n")
+		}
+
+		// For non global, or no target display tanzu command path with target
+		if target != types.TargetGlobal && target != types.TargetUnknown {
+			output.WriteString(base + string(target) + " " + cmd.CommandPath() + " [command]\n")
+		}
+	}
+	return output.String()
+}
+
+// Helper to format the help footer.
+func formatHelpFooter(cmd *cobra.Command, target types.Target) string {
+	var footer strings.Builder
+	if !cmd.HasAvailableSubCommands() {
+		return ""
+	}
+
+	footer.WriteString("\n")
+
+	// For kubernetes, k8s, global, or no target display tanzu command path without target
+	if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
+		footer.WriteString(`Use "`)
+		if !strings.HasPrefix(cmd.CommandPath(), "tanzu ") {
+			footer.WriteString("tanzu ")
+		}
+		footer.WriteString(cmd.CommandPath() + ` [command] --help" for more information about a command.` + "\n")
+	}
+
+	// For non global, or no target display tanzu command path with target
+	if target != types.TargetGlobal && target != types.TargetUnknown {
+		footer.WriteString(`Use "`)
+		if !strings.HasPrefix(cmd.CommandPath(), "tanzu ") {
+			footer.WriteString("tanzu ")
+		}
+		footer.WriteString(string(target) + " " + cmd.CommandPath() + ` [command] --help" for more information about a command.` + "\n")
+	}
+
+	return footer.String()
+}
+
+func printHelp(cmd *cobra.Command) string {
+	var output strings.Builder
+	target := types.StringToTarget(cmd.Annotations["target"])
+
+	output.WriteString(formatUsageHelpSection(cmd, target))
+
+	if len(cmd.Aliases) > 0 {
+		output.WriteString("\n" + component.Bold(aliasesStr) + "\n")
+		output.WriteString(indentStr + cmd.NameAndAliases() + "\n")
+	}
+
+	if cmd.HasExample() {
+		output.WriteString("\n" + component.Bold(examplesStr) + "\n")
+		output.WriteString(indentStr + cmd.Example + "\n")
+	}
+
+	if cmd.HasAvailableSubCommands() {
+		output.WriteString("\n" + component.Bold(availableCommandsStr) + "\n")
+		for _, c := range cmd.Commands() {
+			if c.IsAvailableCommand() {
+				output.WriteString(indentStr + component.Rpad(c.Name(), c.NamePadding()) + " " + c.Short + "\n")
+			}
+		}
+	}
+
+	if cmd.HasAvailableLocalFlags() {
+		output.WriteString("\n" + component.Bold(flagsStr) + "\n")
+		output.WriteString(strings.TrimRight(cmd.LocalFlags().FlagUsages(), " "))
+	}
+
+	if cmd.HasAvailableInheritedFlags() {
+		output.WriteString("\n" + component.Bold(globalFlagsStr) + "\n")
+		output.WriteString(strings.TrimRight(cmd.InheritedFlags().FlagUsages(), " "))
+	}
+
+	if cmd.HasHelpSubCommands() {
+		output.WriteString("\n" + component.Bold(additionalHelpTopicsStr) + "\n")
+		for _, c := range cmd.Commands() {
+			if c.IsAdditionalHelpTopicCommand() {
+				output.WriteString(indentStr + component.Rpad(c.CommandPath(), c.CommandPathPadding()) + " " + c.Short + "\n")
+			}
+		}
+	}
+	output.WriteString(formatHelpFooter(cmd, target))
+
+	return output.String()
+}
+
 // TemplateFuncs are the template usage funcs.
 var TemplateFuncs = template.FuncMap{
+	"printHelp": printHelp,
+	// The below are not needed but are kept for backwards-compatibility
+	// in case it is being used through the API
 	"rpad":                    component.Rpad,
 	"bold":                    component.Bold,
 	"underline":               component.Underline,

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -4,16 +4,17 @@
 package plugin
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 func TestUsageFunc(t *testing.T) {
-	assert := assert.New(t)
-
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Error(err)
@@ -36,9 +37,410 @@ func TestUsageFunc(t *testing.T) {
 		Short: "Sub1 description",
 	}
 	err = UsageFunc(cmd)
-	w.Close()
-	assert.Nil(err)
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
 
 	got := <-c
-	assert.Contains(string(got), "Usage:")
+	assert.Contains(t, string(got), "Usage:")
+}
+
+func SampleTestPlugin(t *testing.T, target types.Target) *Plugin {
+	var pluginsCmd = &cobra.Command{
+		Use:   "plugin",
+		Short: "Plugin tests",
+	}
+
+	var fetchCmd = &cobra.Command{
+		Use:   "fetch",
+		Short: "Fetch the plugin tests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("fetch")
+			return nil
+		},
+	}
+
+	var pushCmd = &cobra.Command{
+		Use:   "push",
+		Short: "Push the plugin tests",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("push")
+			return nil
+		},
+	}
+
+	var descriptor = PluginDescriptor{
+		Name:        "test",
+		Target:      target,
+		Aliases:     []string{"t"},
+		Description: "Test the CLI",
+		Group:       AdminCmdGroup,
+		Version:     "v1.1.0",
+		BuildSHA:    "1234567",
+	}
+
+	var local string
+	var url string
+
+	fetchCmd.Flags().StringVarP(&local, "local", "l", "", "path to local repository")
+	_ = fetchCmd.MarkFlagRequired("local")
+
+	fetchCmd.PersistentFlags().StringVarP(&url, "url", "u", "", "url to remote repository")
+	_ = fetchCmd.MarkFlagRequired("url")
+
+	fetchCmd.Example = "sample example usage of the fetch command"
+
+	p, err := NewPlugin(&descriptor)
+	assert.Nil(t, err)
+
+	var env string
+	p.Cmd.PersistentFlags().StringVarP(&env, "env", "e", "", "env to test")
+
+	p.Cmd.Example = "sample example usage of the test command"
+	p.AddCommands(
+		fetchCmd,
+		pushCmd,
+		pluginsCmd,
+	)
+
+	return p
+}
+
+func TestGlobalTestPluginCommandHelpText(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	// Prepare the root command with Global target
+	p := SampleTestPlugin(t, types.TargetGlobal)
+
+	// Set the arguments as if the user typed them in the command line
+	p.Cmd.SetArgs([]string{"--help"})
+
+	// Execute the command which will trigger the help
+	err = p.Execute()
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
+	expected := `Test the CLI
+
+Usage:
+  tanzu test [command]
+
+Aliases:
+  test, t
+
+Examples:
+  sample example usage of the test command
+
+Available Commands:
+  fetch         Fetch the plugin tests
+  push          Push the plugin tests
+
+Flags:
+  -e, --env string   env to test
+  -h, --help         help for test
+
+Additional help topics:
+  test plugin        Plugin tests
+
+Use "tanzu test [command] --help" for more information about a command.
+`
+	assert.Equal(t, expected, got)
+}
+
+func TestKubernetesTestPluginCommandHelpText(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	// Prepare the root command with Kubernetes target
+	p := SampleTestPlugin(t, types.TargetK8s)
+
+	// Set the arguments as if the user typed them in the command line
+	p.Cmd.SetArgs([]string{"--help"})
+
+	// Execute the command which will trigger the help
+	err = p.Execute()
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
+	expected := `Test the CLI
+
+Usage:
+  tanzu test [command]
+  tanzu kubernetes test [command]
+
+Aliases:
+  test, t
+
+Examples:
+  sample example usage of the test command
+
+Available Commands:
+  fetch         Fetch the plugin tests
+  push          Push the plugin tests
+
+Flags:
+  -e, --env string   env to test
+  -h, --help         help for test
+
+Additional help topics:
+  test plugin        Plugin tests
+
+Use "tanzu test [command] --help" for more information about a command.
+Use "tanzu kubernetes test [command] --help" for more information about a command.
+`
+	assert.Equal(t, expected, got)
+}
+
+func TestMissionControlTestPluginCommandHelpText(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	// Prepare the root command with MissionControl target
+	p := SampleTestPlugin(t, types.TargetTMC)
+
+	// Set the arguments as if the user typed them in the command line
+	p.Cmd.SetArgs([]string{"--help"})
+
+	// Execute the command which will trigger the help
+	err = p.Execute()
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
+	expected := `Test the CLI
+
+Usage:
+  tanzu mission-control test [command]
+
+Aliases:
+  test, t
+
+Examples:
+  sample example usage of the test command
+
+Available Commands:
+  fetch         Fetch the plugin tests
+  push          Push the plugin tests
+
+Flags:
+  -e, --env string   env to test
+  -h, --help         help for test
+
+Additional help topics:
+  test plugin        Plugin tests
+
+Use "tanzu mission-control test [command] --help" for more information about a command.
+`
+	assert.Equal(t, expected, got)
+}
+
+func TestGlobalTestPluginFetchCommandHelpText(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	// Prepare the root command with Global target
+	p := SampleTestPlugin(t, types.TargetGlobal)
+
+	// Set the arguments as if the user typed them in the command line
+	p.Cmd.SetArgs([]string{"fetch", "--help"})
+
+	// Execute the command which will trigger the help
+	err = p.Execute()
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+	expected := `Fetch the plugin tests
+
+Usage:
+  tanzu test fetch [flags]
+
+Examples:
+  sample example usage of the fetch command
+
+Flags:
+  -h, --help           help for fetch
+  -l, --local string   path to local repository
+  -u, --url string     url to remote repository
+
+Global Flags:
+  -e, --env string   env to test
+`
+	assert.Equal(t, expected, got)
+}
+
+func TestKubernetesTestPluginFetchCommandHelpText(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	// Prepare the root command with Kubernetes target
+	p := SampleTestPlugin(t, types.TargetK8s)
+
+	// Set the arguments as if the user typed them in the command line
+	p.Cmd.SetArgs([]string{"fetch", "--help"})
+
+	// Execute the command which will trigger the help
+	err = p.Execute()
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
+	expected := `Fetch the plugin tests
+
+Usage:
+  tanzu test fetch [flags]
+  tanzu kubernetes test fetch [flags]
+
+Examples:
+  sample example usage of the fetch command
+
+Flags:
+  -h, --help           help for fetch
+  -l, --local string   path to local repository
+  -u, --url string     url to remote repository
+
+Global Flags:
+  -e, --env string   env to test
+`
+	assert.Equal(t, expected, got)
+}
+
+func TestMissionControlTestPluginFetchCommandHelpText(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	// Prepare the root command with MissionControl target
+	p := SampleTestPlugin(t, types.TargetTMC)
+
+	// Set the arguments as if the user typed them in the command line
+	p.Cmd.SetArgs([]string{"fetch", "--help"})
+
+	// Execute the command which will trigger the help
+	err = p.Execute()
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
+	expected := `Fetch the plugin tests
+
+Usage:
+  tanzu mission-control test fetch [flags]
+
+Examples:
+  sample example usage of the fetch command
+
+Flags:
+  -h, --help           help for fetch
+  -l, --local string   path to local repository
+  -u, --url string     url to remote repository
+
+Global Flags:
+  -e, --env string   env to test
+`
+	assert.Equal(t, expected, got)
 }


### PR DESCRIPTION
* Update help text template to fix target usage

* Add two spaces for tanzu command

* Convert the help template to go code

Signed-off-by: Marc Khouzam <kmarc@vmware.com>

* testing the lint and tests

* refactor the print help

* refactor the indentation

* Update check to HasPrefix from HasSuffix

* Update tests to include global flags and fetch --help command

* Update additional help topics section with tanzu and target prefix

* Revert additional help topics targeted prefix

* Deprecate CmdTemplate and introduce private cmdTemplate variable and update all usages

* Fix sub command unit tests by executing plugin instead of command

* Fix spacing in examples section and update tests

---------

Signed-off-by: Marc Khouzam <kmarc@vmware.com>
Co-authored-by: Marc Khouzam <kmarc@vmware.com>
(cherry picked from commit 3923e33828cf832fe68d769a9a4a9d04eeb0ab7e)

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Deprecate CmdTemplate and Update help text template go function to specify plugin target
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
