### PR TITLE
Add API to manage plugin owned settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ of the main packages that each and every plugin will need to import to
 integrate with the Tanzu CLI. For more information about
 the development process, see the [Tanzu CLI Plugin Development guide](https://github.com/vmware-tanzu/tanzu-cli/blob/main/docs/plugindev/README.md)
 
+To Manage plugin owned settings
+
+Use
+
+``` go
+// Plugin owned APIs
+// GetTanzuPluginConfigDir Retrieve the tanzu configuration directory that can be used by the plugins to
+// create a plugin specific directory to manage plugin owned configurations.
+func GetTanzuPluginConfigDir() (string, error)
+```
+
+Example: For handling settings specific to the `management-cluster` plugin:
+Utilize `GetTanzuPluginConfigDir()` to retrieve the plugin configuration directory,
+which is `.config/tanzu/plugins`. Subsequently, establish a `management-cluster` directory within the plugin configuration directory to oversee the relevant settings.
+
 ### Command Helpers
 
 This package implements command specific helper functions like command deprecation, etc.

--- a/config/plugin-owned.go
+++ b/config/plugin-owned.go
@@ -1,0 +1,34 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// PluginsBaseDir is the name of the plugins owned base directory in which plugin owned settings is stored.
+	PluginsBaseDir = "plugins"
+)
+
+// GetTanzuPluginConfigDir Retrieve the tanzu configuration directory that can be used by the plugins to // create a plugin specific directory to manage plugin owned configurations.
+// .config/tanzu/plugins
+func GetTanzuPluginConfigDir() (string, error) {
+	// Fetch the base tanzu config directory
+	tanzuDir, err := LocalDir()
+	if err != nil {
+		return "", errors.Wrap(err, "could not find local tanzu dir for OS")
+	}
+
+	// Create plugins directory in tanzu config
+	pluginsBaseDir := filepath.Join(tanzuDir, PluginsBaseDir)
+	if err := os.MkdirAll(pluginsBaseDir, 0755); err != nil {
+		return "", errors.Wrap(err, "could not make local tanzu plugins directory")
+	}
+
+	return pluginsBaseDir, nil
+}

--- a/config/plugin-owned_test.go
+++ b/config/plugin-owned_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTanzuPluginConfigDir(t *testing.T) {
+	// setup
+	func() {
+		LocalDirName = ".config2/tanzu"
+	}()
+	defer func() {
+		cleanupDir(LocalDirName)
+	}()
+
+	expectedPath := ".config2/tanzu/plugins"
+
+	dir, err := GetTanzuPluginConfigDir()
+
+	require.NoError(t, err, "Expected no error from GetTanzuPluginConfigDir")
+	assert.NotEmpty(t, dir, "Expected a non-empty directory path")
+
+	assert.Contains(t, dir, expectedPath)
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -51,6 +51,11 @@ said information in the files being manipulated.
 ### Available Runtime Config APIs
 
 ``` go
+// Plugin owned APIs
+// GetTanzuPluginConfigDir Retrieve the tanzu configuration directory that can be used by the plugins to
+// create a plugin specific directory to manage plugin owned configurations.
+func GetTanzuPluginConfigDir() (string, error)
+
 // Context APIs
 func GetContext(name string) (context Context, error)
 func AddContext(context Context, setCurrent bool) error


### PR DESCRIPTION
### What this PR does / why we need it

- Provide an API to manage plugin owned settings

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- Added unit tests

Manually testing
- Triggered the new API in a test plugin to retrieve the plugins dir
```

**Test plugin with plugins command**

var pluginsCmd = &cobra.Command{
	Use:   "plugin",
	Short: "Plugin tests",
	Run: func(cmd *cobra.Command, args []string) {
		pluginsDir, err := configlib.GetTanzuPluginConfigDir()
		if err != nil {
			log.Fatal(err, "")
		}
		log.Info(pluginsDir)
	},
}

mpanchajanya@mpanchajanF09MK ~ % tanzu test plugin
[i] /Users/mpanchajanya/.config/tanzu/plugins
mpanchajanya@mpanchajanF09MK ~ %

```


<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add new API to return config directory to manage plugin owned settings
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
