### PR TITLE
Data as interface in outputwriter

### DIFF
--- a/component/output_test.go
+++ b/component/output_test.go
@@ -276,7 +276,7 @@ func TestNewOutputWriterNonStrings(t *testing.T) {
 	output := b.String()
 	require.NotNil(t, output)
 
-	// extra leading newline for better formatting
+	// leading newline, added for readability, should be trimmed during compare
 	// note: the trailing spaces in this string are intentional
 	expected := `
   A  B                 C  
@@ -296,11 +296,13 @@ func TestNewOutputWriterYAMLNonStrings(t *testing.T) {
 	output := b.String()
 	require.NotNil(t, output)
 
-	// extra leading newline for better formatting
+	// leading newline, added for readability, should be trimmed during compare
 	expected := `
 - a: "1"
-  b: map[b:bar f:foo]
-  c: "2"
+  b:
+    b: bar
+    f: foo
+  c: 2
 `
 	require.Equal(t, expected[1:], output)
 }
@@ -315,15 +317,19 @@ func TestNewOutputWriterJSONNonStrings(t *testing.T) {
 	output := b.String()
 	require.NotNil(t, output)
 
-	// extra leading newline for better formatting
+	// leading newline, added for readability, should be trimmed during compare
 	expected := `
 [
   {
     "a": "1",
-    "b": "map[b:bar f:foo]",
-    "c": "2"
+    "b": {
+      "b": "bar",
+      "f": "foo"
+    },
+    "c": 2
   }
 ]`
+
 	require.Equal(t, expected[1:], output)
 }
 
@@ -338,7 +344,7 @@ func TestNewOutputWriterTableListNonStrings(t *testing.T) {
 	output := b.String()
 	require.NotNil(t, output)
 
-	// extra leading newline for better formatting
+	// leading newline, added for readability, should be trimmed during compare
 	expected := `
 A:           1, 3
 B:           map[b:bar f:foo], 4


### PR DESCRIPTION
### What this PR does / why we need it
```
    Store outputwriter data as 2d array of interfaces

    ... instead of 2d array of strings done prior to this commit.

    AddRow accepts a variatic list of interface{}s, yet immediately converts
    each of them to their golang string representation.

    This change retains these values as interface{}'s instead.
    The idea is to delay any necessary conversion to the point when we are
    actually rendering the values.

    This is particular useful when rendering container values like
    maps/lists in their valid YAML/JSON forms.
```

### Which issue(s) this PR fixes

Fixes #102

### Describe testing done for PR

make test

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
OutputWriter's JSON/YAML outputs non-string tabular fields correctly
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
