### PR TITLE
Add API to set active UCP resource for UCP context

### DIFF
--- a/ucp/ucp_test.go
+++ b/ucp/ucp_test.go
@@ -4,7 +4,11 @@
 package ucp
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +20,58 @@ import (
 )
 
 const ConfigFilePermissions = 0o600
+const (
+	fakePluginScriptFmtString string = `#!/bin/bash
+# Fake tanzu core binary
+
+# fake command that simulates a context lcm operation
+context() {
+	if [ "%s" -eq "0" ]; then
+		# regular output to stderr
+		>&2 echo "$@ succeeded"
+	else
+		# error to stderr
+		>&2 echo "$@ failed"
+	fi
+
+	exit %s
+}
+
+# fake alternate command to use
+newcommand() {
+	if [ "%s" -eq "0" ]; then
+		# regular output to stdout
+		echo "$@ succeeded"
+	else
+		# error to stderr
+		>&2 echo "$@ failed"
+	fi
+
+	exit %s
+}
+
+case "$1" in
+    # simulate returning an alternative set of args to invoke with, which
+    # translates to running the command 'newcommand'
+    %s) shift && shift && echo "newcommand $@";;
+    newcommand)   $1 "$@";;
+    context)   $1 "$@";;
+    *) cat << EOF
+Tanzu Core CLI Fake
+
+Usage:
+  tanzu [command]
+
+Available Commands:
+  update          fake command
+  newcommand      fake new command
+  _custom_command provide alternate command to invoke, if available
+EOF
+       exit 1
+       ;;
+esac
+`
+)
 
 func cleanupTestingDir(t *testing.T) {
 	p, err := config.LocalDir()
@@ -29,6 +85,13 @@ func copyFile(t *testing.T, sourceFile, destFile string) {
 	assert.NoError(t, err)
 	err = os.WriteFile(destFile, input, ConfigFilePermissions)
 	assert.NoError(t, err)
+}
+func readOutput(t *testing.T, r io.Reader, c chan<- []byte) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Error(err)
+	}
+	c <- data
 }
 
 func setupForGetContext(t *testing.T) {
@@ -74,7 +137,7 @@ func setupForGetContext(t *testing.T) {
 					Context:  "test-context",
 				},
 				AdditionalMetadata: map[string]interface{}{
-					OrgID: "fake-org-id",
+					OrgIDKey: "fake-org-id",
 				},
 			},
 		},
@@ -138,4 +201,120 @@ func TestGetKubeconfigForContext(t *testing.T) {
 	_, err = GetKubeconfigForContext(nonUCPCtx.Name, "project2", "")
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "context must be of type: ucp")
+}
+
+func setupFakeCLI(dir string, exitStatus string, newCommandExitStatus string, enableCustomCommand bool) (string, error) {
+	filePath := filepath.Join(dir, "tanzu")
+
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	fakeCustomCommandName := "unused_command"
+	// when enabled, the fake CLI script generated will be capable of
+	// returning an alternate set of args for a provided set of args
+	if enableCustomCommand {
+		fakeCustomCommandName = customCommandName
+	}
+
+	fmt.Fprintf(f, fakePluginScriptFmtString, exitStatus, exitStatus, newCommandExitStatus, newCommandExitStatus, fakeCustomCommandName)
+
+	return filePath, nil
+}
+
+func TestSetUCPContextActiveResource(t *testing.T) {
+	tests := []struct {
+		test                 string
+		exitStatus           string
+		newCommandExitStatus string
+		expectedOutput       string
+		expectedFailure      bool
+		enableCustomCommand  bool
+	}{
+		{
+			test:            "with no alternate command and ucp active resource update successfully",
+			exitStatus:      "0",
+			expectedOutput:  "context update ucp-active-resource test-context --project projectA --space spaceA succeeded\n",
+			expectedFailure: false,
+		},
+		{
+			test:            "with no alternate command and ucp active resource update unsuccessfully",
+			exitStatus:      "1",
+			expectedOutput:  "context update ucp-active-resource test-context --project projectA --space spaceA failed\n",
+			expectedFailure: true,
+		},
+		{
+			test:                 "with alternate command and ucp active resource update successfully",
+			newCommandExitStatus: "0",
+			expectedOutput:       "newcommand update ucp-active-resource test-context --project projectA --space spaceA succeeded\n",
+			expectedFailure:      false,
+			enableCustomCommand:  true,
+		},
+		{
+			test:                 "with alternate command and ucp active resource update unsuccessfully",
+			newCommandExitStatus: "1",
+			expectedOutput:       "newcommand update ucp-active-resource test-context --project projectA --space spaceA failed\n",
+			expectedFailure:      true,
+			enableCustomCommand:  true,
+		},
+	}
+
+	for _, spec := range tests {
+		dir, err := os.MkdirTemp("", "tanzu-set-ucp-active-resource-api")
+		assert.Nil(t, err)
+		defer os.RemoveAll(dir)
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Set up stdout and stderr for our test
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Error(err)
+			}
+			c := make(chan []byte)
+			go readOutput(t, r, c)
+			stdout := os.Stdout
+			stderr := os.Stderr
+			defer func() {
+				os.Stdout = stdout
+				os.Stderr = stderr
+			}()
+			os.Stdout = w
+			os.Stderr = w
+
+			cliPath, err := setupFakeCLI(dir, spec.exitStatus, spec.newCommandExitStatus, spec.enableCustomCommand)
+			assert.Nil(err)
+			os.Setenv("TANZU_BIN", cliPath)
+
+			// Test-1:
+			// - verify correct combinedOutput string returned as part of the output
+			// - verify correct string gets printed to default stdout and stderr
+			err = SetUCPContextActiveResource("test-context", "projectA", "spaceA")
+			w.Close()
+			stdoutRecieved := <-c
+
+			if spec.expectedFailure {
+				assert.NotNil(err)
+			} else {
+				assert.Nil(err)
+			}
+
+			assert.Equal(spec.expectedOutput, string(stdoutRecieved), "incorrect combinedOutput result")
+
+			// Test-2: when external stdout and stderr are provided with WithStdout, WithStderr options,
+			// verify correct string gets printed to provided custom stdout/stderr
+			var combinedOutputBuff bytes.Buffer
+			err = SetUCPContextActiveResource("test-context", "projectA", "spaceA", WithOutputWriter(&combinedOutputBuff), WithErrorWriter(&combinedOutputBuff))
+			if spec.expectedFailure {
+				assert.NotNil(err)
+			} else {
+				assert.Nil(err)
+			}
+			assert.Equal(spec.expectedOutput, combinedOutputBuff.String(), "incorrect combinedOutputBuff result")
+
+			os.Unsetenv("TANZU_BIN")
+		})
+	}
 }


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds the API to set UCP active resource for the given UCP context.

Changes summary:
- Added API to set active UCP resource for given UCP context. API would call the CLI command to set the active UCP resource for the given UCP context

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Unit tests are passed.
Also ran few tests using the below test stub (in ucp.test.go) with ucp context("myucp") already created in CLI.
```
func TestSetUCPContextActiveResourceSample(t *testing.T) {
        // Test updating the UCP context active resource to space
        os.Setenv("TANZU_BIN", "/Users/pkalle/projects/tanzu-cli/artifacts/darwin/amd64/cli/core/v1.1.0-dev/tanzu-cli-darwin_amd64")
        projectName := "projectA"
        spaceName:="spaceA"
        err := SetUCPContextActiveResource("myucp", projectName, spaceName)
        assert.NoError(t, err)
}

```

Tested setting the UCP active resource to projectA/SpaceA and validated the context in CLI config file is updated as well as the kubeconfig server URL as shown below
```
// kubeconfig snippet after update
apiVersion: v1
clusters:
- cluster:
    server: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252/project/projectA/space/spaceA
  name: tanzu-cli-myucp/current


// context snippet after update
      clusterOpts:
        endpoint: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252
        path: /Users/pkalle/.kube/config
        context: tanzu-cli-myucp
      discoverySources: []
      additionalMetadata:
        ucpOrgID: ee04bfae-a665-4f20-a5b9-d8b043180252
        ucpProjectName: projectA
        ucpSpaceName: spaceA

```
Tested setting the UCP active resource to projectA/spaceB and validated the context in CLI config file is updated as well as the kubeconfig server URL as shown below

```
// kubeconfig snippet after update
apiVersion: v1
clusters:
- cluster:
    server: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252/project/projectA/space/spaceB
  name: tanzu-cli-myucp/current


// context snippet after update
      clusterOpts:
        endpoint: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252
        path: /Users/pkalle/.kube/config
        context: tanzu-cli-myucp
      discoverySources: []
      additionalMetadata:
        ucpOrgID: ee04bfae-a665-4f20-a5b9-d8b043180252
        ucpProjectName: projectA
        ucpSpaceName: spaceB
```

Tested setting the UCP active resource to projectA and validated the context in CLI config file is updated as well as the kubeconfig server URL as shown below

```
// kubeconfig snippet after update
apiVersion: v1
clusters:
- cluster:
    server: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252/project/projectA
  name: tanzu-cli-myucp/current


// context snippet after update
      clusterOpts:
        endpoint: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252
        path: /Users/pkalle/.kube/config
        context: tanzu-cli-myucp
      discoverySources: []
      additionalMetadata:
        ucpOrgID: ee04bfae-a665-4f20-a5b9-d8b043180252
        ucpProjectName: projectA
        ucpSpaceName: ""
```

Tested setting the UCP active resource to back to Org level and validated the context in CLI config file is updated as well as the kubeconfig server URL as shown below

```
// kubeconfig snippet after update
apiVersion: v1
clusters:
- cluster:
    server: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252
  name: tanzu-cli-myucp/current


// context snippet after update
     clusterOpts:
        endpoint: https://ucp-aria.stacks.bluesky.tmc-dev.cloud.vmware.com/org/ee04bfae-a665-4f20-a5b9-d8b043180252
        path: /Users/pkalle/.kube/config
        context: tanzu-cli-myucp
      discoverySources: []
      additionalMetadata:
        ucpOrgID: ee04bfae-a665-4f20-a5b9-d8b043180252
        ucpProjectName: ""
        ucpSpaceName: ""
```
<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add API to set active UCP resource for UCP context
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
