### PR TITLE
Decouple the Target association with the Context object by introducing ContextType

### DIFF
--- a/config/clientconfig_test.go
+++ b/config/clientconfig_test.go
@@ -324,8 +324,8 @@ func TestEndpointFromContext(t *testing.T) {
 		{
 			name: "success k8s",
 			ctx: &configtypes.Context{
-				Name:   "test-mc",
-				Target: configtypes.TargetK8s,
+				Name:        "test-mc",
+				ContextType: configtypes.ContextTypeK8s,
 				ClusterOpts: &configtypes.ClusterServer{
 					Endpoint:            "test-endpoint",
 					Path:                "test-path",
@@ -337,8 +337,8 @@ func TestEndpointFromContext(t *testing.T) {
 		{
 			name: "success tmc current",
 			ctx: &configtypes.Context{
-				Name:   "test-tmc",
-				Target: configtypes.TargetTMC,
+				Name:        "test-tmc",
+				ContextType: configtypes.ContextTypeTMC,
 				GlobalOpts: &configtypes.GlobalServer{
 					Endpoint: "test-endpoint",
 				},
@@ -347,8 +347,8 @@ func TestEndpointFromContext(t *testing.T) {
 		{
 			name: "failure",
 			ctx: &configtypes.Context{
-				Name:   "test-dummy",
-				Target: "dummy",
+				Name:        "test-dummy",
+				ContextType: "dummy",
 				ClusterOpts: &configtypes.ClusterServer{
 					Endpoint:            "test-endpoint",
 					Path:                "test-path",
@@ -356,7 +356,7 @@ func TestEndpointFromContext(t *testing.T) {
 					IsManagementCluster: true,
 				},
 			},
-			errStr: "unknown server type \"dummy\"",
+			errStr: "unknown context type \"dummy\"",
 		},
 	}
 

--- a/config/config_factory_test.go
+++ b/config/config_factory_test.go
@@ -252,8 +252,9 @@ func TestGetClientConfigWithLockAndWithoutLock(t *testing.T) {
 		assert.NoError(t, err)
 
 		expectedCtx := &configtypes.Context{
-			Name:   "test-mc",
-			Target: configtypes.TargetK8s,
+			Name:        "test-mc",
+			Target:      configtypes.TargetK8s,
+			ContextType: configtypes.ContextTypeK8s,
 			ClusterOpts: &configtypes.ClusterServer{
 				Endpoint:            "test-endpoint",
 				Path:                "test-path",
@@ -324,8 +325,9 @@ func TestGetClientConfigWithLockAndMigratedToNewConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx := &configtypes.Context{
-		Name:   "test-mc",
-		Target: configtypes.TargetK8s,
+		Name:        "test-mc",
+		Target:      configtypes.TargetK8s,
+		ContextType: configtypes.ContextTypeK8s,
 		ClusterOpts: &configtypes.ClusterServer{
 			Endpoint:            "test-endpoint",
 			Path:                "test-path",
@@ -378,8 +380,9 @@ func TestGetClientConfigWithoutLockAndMigratedToNewConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedCtx := &configtypes.Context{
-		Name:   "test-mc",
-		Target: configtypes.TargetK8s,
+		Name:        "test-mc",
+		Target:      configtypes.TargetK8s,
+		ContextType: configtypes.ContextTypeK8s,
 		ClusterOpts: &configtypes.ClusterServer{
 			Endpoint:            "test-endpoint",
 			Path:                "test-path",

--- a/config/contexts_it_test.go
+++ b/config/contexts_it_test.go
@@ -256,6 +256,7 @@ currentContext:
             required: true
     - name: test-mc2
       target: kubernetes
+      contextType: kubernetes
       clusterOpts:
         path: test-path-updated
         context: test-context-updated
@@ -286,8 +287,9 @@ func TestContextsIntegration(t *testing.T) {
 	// Get Context
 	context, err := GetContext("test-mc")
 	expected := &configtypes.Context{
-		Name:   "test-mc",
-		Target: configtypes.TargetK8s,
+		Name:        "test-mc",
+		Target:      configtypes.TargetK8s,
+		ContextType: configtypes.ContextTypeK8s,
 		ClusterOpts: &configtypes.ClusterServer{
 			Endpoint:            "test-endpoint",
 			Path:                "test-path",
@@ -309,8 +311,9 @@ func TestContextsIntegration(t *testing.T) {
 
 	// Add new Context
 	newCtx := &configtypes.Context{
-		Name:   "test-mc2",
-		Target: configtypes.TargetK8s,
+		Name:        "test-mc2",
+		Target:      configtypes.TargetK8s,
+		ContextType: configtypes.ContextTypeK8s,
 		ClusterOpts: &configtypes.ClusterServer{
 			Path:                "test-path",
 			Context:             "test-context",
@@ -337,8 +340,9 @@ func TestContextsIntegration(t *testing.T) {
 
 	// Try to add context with empty name
 	contextWithEmptyName := &configtypes.Context{
-		Name:   "",
-		Target: configtypes.TargetK8s,
+		Name:        "",
+		Target:      configtypes.TargetK8s,
+		ContextType: configtypes.ContextTypeK8s,
 		ClusterOpts: &configtypes.ClusterServer{
 			Path:                "test-path",
 			Context:             "test-context",
@@ -355,15 +359,16 @@ func TestContextsIntegration(t *testing.T) {
 		},
 	}
 	err = SetContext(contextWithEmptyName, true)
-	assert.Equal(t, "context name cannot be empty", err.Error())
+	assert.Equal(t, "error while validating the Context object: context name cannot be empty", err.Error())
 	ctx, err = GetContext("")
 	assert.Equal(t, "context name cannot be empty", err.Error())
 	assert.Nil(t, ctx)
 
 	// Update existing Context
 	updatedCtx := &configtypes.Context{
-		Name:   "test-mc2",
-		Target: configtypes.TargetK8s,
+		Name:        "test-mc2",
+		Target:      configtypes.TargetK8s,
+		ContextType: configtypes.ContextTypeK8s,
 		ClusterOpts: &configtypes.ClusterServer{
 			Path:                "test-path-updated",
 			Context:             "test-context-updated",

--- a/config/contexts_test.go
+++ b/config/contexts_test.go
@@ -4,7 +4,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -489,7 +488,6 @@ func setupForGetContext() error {
 		},
 	}
 	return func() error {
-		os.Unsetenv(EnvConfigKey)
 		LocalDirName = TestLocalDirName
 		err := StoreClientConfig(cfg)
 		return err
@@ -1387,7 +1385,7 @@ var _ = Describe("testing SetCurrentContext", func() {
 
 			_, err = GetCurrentContext(configtypes.TargetTAE)
 			gomega.Expect(err).ToNot(gomega.BeNil())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring(`no current context set for target "application-engine"`))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring(`no current context set for type "application-engine"`))
 		})
 	})
 	Context("tae context as current context after k8s context(mutual-exclusion test between k8s and tae) ", func() {
@@ -1402,7 +1400,7 @@ var _ = Describe("testing SetCurrentContext", func() {
 
 			_, err = GetCurrentContext(configtypes.TargetK8s)
 			gomega.Expect(err).ToNot(gomega.BeNil())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring(`no current context set for target "kubernetes"`))
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring(`no current context set for type "kubernetes"`))
 		})
 	})
 })

--- a/config/contexts_test.go
+++ b/config/contexts_test.go
@@ -470,8 +470,8 @@ func setupForGetContext() error {
 				},
 			},
 			{
-				Name:   "test-tae",
-				Target: configtypes.TargetTAE,
+				Name:        "test-tae",
+				ContextType: configtypes.ContextTypeTAE,
 				GlobalOpts: &configtypes.GlobalServer{
 					Endpoint: "test-endpoint",
 				},
@@ -709,8 +709,8 @@ func TestSetContext(t *testing.T) {
 		{
 			name: "success tae current",
 			ctx: &configtypes.Context{
-				Name:   "test-tae1",
-				Target: configtypes.TargetTAE,
+				Name:        "test-tae1",
+				ContextType: configtypes.ContextTypeTAE,
 				GlobalOpts: &configtypes.GlobalServer{
 					Endpoint: "test-endpoint",
 				},
@@ -729,7 +729,6 @@ func TestSetContext(t *testing.T) {
 			name: "success tae not_current",
 			ctx: &configtypes.Context{
 				Name:        "test-tae2",
-				Target:      configtypes.TargetTAE,
 				ContextType: configtypes.ContextTypeTAE,
 				GlobalOpts: &configtypes.GlobalServer{
 					Endpoint: "test-endpoint",
@@ -748,7 +747,7 @@ func TestSetContext(t *testing.T) {
 			name: "error target and contexttype does not match",
 			ctx: &configtypes.Context{
 				Name:        "test-error",
-				Target:      configtypes.TargetTAE,
+				Target:      configtypes.TargetTMC,
 				ContextType: configtypes.ContextTypeK8s,
 				GlobalOpts: &configtypes.GlobalServer{
 					Endpoint: "test-endpoint",
@@ -759,7 +758,7 @@ func TestSetContext(t *testing.T) {
 					Context:  "test-context",
 				},
 			},
-			errStr: "error while validating the Context object: specified Target(application-engine) and ContextType(kubernetes) for the Context object does not match",
+			errStr: "error while validating the Context object: specified Target(mission-control) and ContextType(kubernetes) for the Context object does not match",
 		},
 	}
 
@@ -797,23 +796,19 @@ func TestRemoveContext(t *testing.T) {
 	tcs := []struct {
 		name    string
 		ctxName string
-		target  configtypes.Target
 		errStr  string
 	}{
 		{
 			name:    "success k8s",
 			ctxName: "test-mc",
-			target:  configtypes.TargetK8s,
 		},
 		{
 			name:    "success tmc",
 			ctxName: "test-tmc",
-			target:  configtypes.TargetTMC,
 		},
 		{
 			name:    "success tae",
 			ctxName: "test-tae",
-			target:  configtypes.TargetTAE,
 		},
 		{
 			name:    "failure",
@@ -857,7 +852,7 @@ func TestGetAllCurrentContexts(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "test-mc-2", currentContextMap[configtypes.TargetK8s].Name)
 	assert.Equal(t, "test-tmc", currentContextMap[configtypes.TargetTMC].Name)
-	assert.Nil(t, currentContextMap[configtypes.TargetTAE])
+	assert.Nil(t, currentContextMap[configtypes.Target(configtypes.ContextTypeTAE)])
 
 	activeContextMap, err := GetAllActiveContextsMap()
 	assert.NoError(t, err)
@@ -880,11 +875,19 @@ func TestGetAllCurrentContexts(t *testing.T) {
 	// set the tae context (k8s and tae current contexts are mutual exclusive)
 	err = SetCurrentContext("test-tae")
 	assert.NoError(t, err)
+	// GetAllCurrentContextsMap does not return TAE context
 	currentContextMap, err = GetAllCurrentContextsMap()
 	assert.NoError(t, err)
 	assert.Nil(t, currentContextMap[configtypes.TargetK8s])
 	assert.Equal(t, "test-tmc", currentContextMap[configtypes.TargetTMC].Name)
-	assert.Equal(t, "test-tae", currentContextMap[configtypes.TargetTAE].Name)
+	assert.Nil(t, currentContextMap[configtypes.Target(configtypes.ContextTypeTAE)])
+	// GetAllActiveContextsMap should return TAE context and should match
+	activeContextMap, err = GetAllActiveContextsMap()
+	assert.NoError(t, err)
+	assert.Nil(t, activeContextMap[configtypes.ContextTypeK8s])
+	assert.Equal(t, "test-tmc", activeContextMap[configtypes.ContextTypeTMC].Name)
+	assert.NotNil(t, activeContextMap[configtypes.ContextTypeTAE])
+	assert.Equal(t, "test-tae", activeContextMap[configtypes.ContextTypeTAE].Name)
 
 	currentContextsList, err = GetAllCurrentContextsList()
 	assert.NoError(t, err)
@@ -893,13 +896,13 @@ func TestGetAllCurrentContexts(t *testing.T) {
 	assert.Contains(t, currentContextsList, "test-tae")
 
 	// remove the tae current context
-	err = RemoveCurrentContext(configtypes.TargetTAE)
+	err = RemoveCurrentContext(configtypes.Target(configtypes.ContextTypeTAE))
 	assert.NoError(t, err)
 	currentContextMap, err = GetAllCurrentContextsMap()
 	assert.NoError(t, err)
 	assert.Nil(t, currentContextMap[configtypes.TargetK8s])
 	assert.Equal(t, "test-tmc", currentContextMap[configtypes.TargetTMC].Name)
-	assert.Nil(t, currentContextMap[configtypes.TargetTAE])
+	assert.Nil(t, currentContextMap[configtypes.Target(configtypes.ContextTypeTAE)])
 
 	currentContextsList, err = GetAllCurrentContextsList()
 	assert.NoError(t, err)
@@ -1320,7 +1323,30 @@ func TestSetContextWithEmptyName(t *testing.T) {
 	}
 }
 
-var _ = Describe("testing SetCurrentContext", func() {
+func TestSetCurrentContext(t *testing.T) {
+	// setup
+	func() {
+		err := setupForGetContext()
+		assert.NoError(t, err)
+	}()
+	defer func() {
+		cleanupDir(LocalDirName)
+	}()
+
+	err := SetCurrentContext("test-tae")
+	assert.NoError(t, err)
+	validateActiveContextV2(t, configtypes.ContextTypeTAE, "test-tae", false, "")
+
+	err = SetCurrentContext("test-mc")
+	assert.NoError(t, err)
+	validateActiveContextV2(t, configtypes.ContextTypeK8s, "test-mc", true, "test-mc")
+
+	_, err = GetCurrentContext(configtypes.Target(configtypes.ContextTypeTAE))
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, `no current context set for type "application-engine"`)
+}
+
+var _ = Describe("testing SetCurrentContext & SetActiveContext", func() {
 	var (
 		err error
 	)
@@ -1338,15 +1364,28 @@ var _ = Describe("testing SetCurrentContext", func() {
 		It("should set tmc context as current context successfully", func() {
 			err = SetCurrentContext("test-tmc")
 			gomega.Expect(err).To(gomega.BeNil())
-			validateCurrentContext(configtypes.TargetTMC, "test-tmc", true, "test-mc-2")
+			validateActiveContext(configtypes.ContextTypeTMC, "test-tmc", true, "test-mc-2")
+		})
+		It("should set tmc context as active context successfully", func() {
+			err = RemoveActiveContext(configtypes.ContextTypeTMC)
+			gomega.Expect(err).To(gomega.BeNil())
+			err = SetActiveContext("test-tmc")
+			gomega.Expect(err).To(gomega.BeNil())
+			validateActiveContext(configtypes.ContextTypeTMC, "test-tmc", true, "test-mc-2")
 		})
 	})
 	Context("k8s context as current context", func() {
 		It("should set k8s context as current context successfully", func() {
 			err = SetCurrentContext("test-mc")
 			gomega.Expect(err).To(gomega.BeNil())
-			validateCurrentContext(configtypes.TargetK8s, "test-mc", true, "test-mc")
-
+			validateActiveContext(configtypes.ContextTypeK8s, "test-mc", true, "test-mc")
+		})
+		It("should set k8s context as active context successfully", func() {
+			err = RemoveActiveContext(configtypes.ContextTypeK8s)
+			gomega.Expect(err).To(gomega.BeNil())
+			err = SetActiveContext("test-mc")
+			gomega.Expect(err).To(gomega.BeNil())
+			validateActiveContext(configtypes.ContextTypeK8s, "test-mc", true, "test-mc")
 		})
 	})
 	Context("tae context as current context", func() {
@@ -1357,7 +1396,17 @@ var _ = Describe("testing SetCurrentContext", func() {
 
 			err = SetCurrentContext("test-tae")
 			gomega.Expect(err).To(gomega.BeNil())
-			validateCurrentContext(configtypes.TargetTAE, "test-tae", false, "")
+			validateActiveContext(configtypes.ContextTypeTAE, "test-tae", false, "")
+
+		})
+		It("should set tae context as active context successfully", func() {
+			//Remove the k8s current context set during initial setup
+			err = RemoveActiveContext(configtypes.ContextTypeK8s)
+			gomega.Expect(err).To(gomega.BeNil())
+
+			err = SetActiveContext("test-tae")
+			gomega.Expect(err).To(gomega.BeNil())
+			validateActiveContext(configtypes.ContextTypeTAE, "test-tae", false, "")
 
 		})
 	})
@@ -1365,11 +1414,21 @@ var _ = Describe("testing SetCurrentContext", func() {
 		It("should have k8s and tmc contexts as current for their respective targets", func() {
 			err = SetCurrentContext("test-tmc")
 			gomega.Expect(err).To(gomega.BeNil())
-			validateCurrentContext(configtypes.TargetTMC, "test-tmc", true, "test-mc-2")
+			validateActiveContext(configtypes.ContextTypeTMC, "test-tmc", true, "test-mc-2")
 
 			err = SetCurrentContext("test-mc")
 			gomega.Expect(err).To(gomega.BeNil())
-			validateCurrentContext(configtypes.TargetK8s, "test-mc", true, "test-mc")
+			validateActiveContext(configtypes.ContextTypeK8s, "test-mc", true, "test-mc")
+
+		})
+		It("should have k8s and tmc contexts as active for their respective context types", func() {
+			err = SetActiveContext("test-tmc")
+			gomega.Expect(err).To(gomega.BeNil())
+			validateActiveContext(configtypes.ContextTypeTMC, "test-tmc", true, "test-mc-2")
+
+			err = SetActiveContext("test-mc")
+			gomega.Expect(err).To(gomega.BeNil())
+			validateActiveContext(configtypes.ContextTypeK8s, "test-mc", true, "test-mc")
 
 		})
 	})
@@ -1377,13 +1436,26 @@ var _ = Describe("testing SetCurrentContext", func() {
 		It("should have only k8s as current context and tae context should be removed from the current context", func() {
 			err = SetCurrentContext("test-tae")
 			gomega.Expect(err).To(gomega.BeNil())
-			validateCurrentContext(configtypes.TargetTAE, "test-tae", false, "")
+			validateActiveContext(configtypes.ContextTypeTAE, "test-tae", false, "")
 
 			err = SetCurrentContext("test-mc")
 			gomega.Expect(err).To(gomega.BeNil())
-			validateCurrentContext(configtypes.TargetK8s, "test-mc", true, "test-mc")
+			validateActiveContext(configtypes.ContextTypeK8s, "test-mc", true, "test-mc")
 
-			_, err = GetCurrentContext(configtypes.TargetTAE)
+			_, err = GetCurrentContext(configtypes.Target(configtypes.ContextTypeTAE))
+			gomega.Expect(err).ToNot(gomega.BeNil())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring(`no current context set for type "application-engine"`))
+		})
+		It("should have only k8s as current context and tae context should be removed from the active context", func() {
+			err = SetActiveContext("test-tae")
+			gomega.Expect(err).To(gomega.BeNil())
+			validateActiveContext(configtypes.ContextTypeTAE, "test-tae", false, "")
+
+			err = SetActiveContext("test-mc")
+			gomega.Expect(err).To(gomega.BeNil())
+			validateActiveContext(configtypes.ContextTypeK8s, "test-mc", true, "test-mc")
+
+			_, err = GetActiveContext(configtypes.ContextTypeTAE)
 			gomega.Expect(err).ToNot(gomega.BeNil())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring(`no current context set for type "application-engine"`))
 		})
@@ -1392,21 +1464,34 @@ var _ = Describe("testing SetCurrentContext", func() {
 		It("should have only tae as current context and k8s context should be removed from the current context", func() {
 			err = SetCurrentContext("test-mc")
 			gomega.Expect(err).To(gomega.BeNil())
-			validateCurrentContext(configtypes.TargetK8s, "test-mc", true, "test-mc")
+			validateActiveContext(configtypes.ContextTypeK8s, "test-mc", true, "test-mc")
 
 			err = SetCurrentContext("test-tae")
 			gomega.Expect(err).To(gomega.BeNil())
-			validateCurrentContext(configtypes.TargetTAE, "test-tae", false, "")
+			validateActiveContext(configtypes.ContextTypeTAE, "test-tae", false, "")
 
 			_, err = GetCurrentContext(configtypes.TargetK8s)
+			gomega.Expect(err).ToNot(gomega.BeNil())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring(`no current context set for type "kubernetes"`))
+		})
+		It("should have only tae as current context and k8s context should be removed from the active context", func() {
+			err = SetActiveContext("test-mc")
+			gomega.Expect(err).To(gomega.BeNil())
+			validateActiveContext(configtypes.ContextTypeK8s, "test-mc", true, "test-mc")
+
+			err = SetActiveContext("test-tae")
+			gomega.Expect(err).To(gomega.BeNil())
+			validateActiveContext(configtypes.ContextTypeTAE, "test-tae", false, "")
+
+			_, err = GetActiveContext(configtypes.ContextTypeK8s)
 			gomega.Expect(err).ToNot(gomega.BeNil())
 			gomega.Expect(err.Error()).To(gomega.ContainSubstring(`no current context set for type "kubernetes"`))
 		})
 	})
 })
 
-func validateCurrentContext(target configtypes.Target, ctxName string, isServerExpected bool, serverName string) {
-	c, err := GetCurrentContext(target)
+func validateActiveContext(contextType configtypes.ContextType, ctxName string, isServerExpected bool, serverName string) {
+	c, err := GetActiveContext(contextType)
 	gomega.Expect(err).To(gomega.BeNil())
 	gomega.Expect(c.Name).To(gomega.Equal(ctxName))
 
@@ -1416,5 +1501,19 @@ func validateCurrentContext(target configtypes.Target, ctxName string, isServerE
 	} else {
 		gomega.Expect(err).To(gomega.BeNil())
 		gomega.Expect(server.Name).To(gomega.Equal(serverName))
+	}
+}
+
+func validateActiveContextV2(t *testing.T, contextType configtypes.ContextType, ctxName string, isServerExpected bool, serverName string) {
+	c, err := GetActiveContext(contextType)
+	assert.NoError(t, err)
+	assert.Equal(t, c.Name, ctxName)
+
+	server, err := GetCurrentServer()
+	if !isServerExpected {
+		assert.Error(t, err)
+	} else {
+		assert.NoError(t, err)
+		assert.Equal(t, server.Name, serverName)
 	}
 }

--- a/config/conversion.go
+++ b/config/conversion.go
@@ -97,6 +97,9 @@ func populateServers(cfg *configtypes.ClientConfig) {
 		cfg.KnownServers = make([]*configtypes.Server, 0, len(cfg.KnownContexts))
 	}
 	for _, c := range cfg.KnownContexts {
+		fillMissingContextTypeInContext(c)
+		fillMissingTargetInContext(c)
+
 		if cfg.HasServer(c.Name) {
 			// context already present in known servers; skip
 			continue
@@ -106,7 +109,7 @@ func populateServers(cfg *configtypes.ClientConfig) {
 		s := convertContextToServer(c)
 		cfg.KnownServers = append(cfg.KnownServers, s)
 
-		if cfg.CurrentServer == "" && (c.IsManagementCluster() || c.Target == configtypes.TargetTMC) && c.Name == cfg.CurrentContext[c.ContextType] {
+		if cfg.CurrentServer == "" && (c.IsManagementCluster() || c.Target == configtypes.TargetK8s || c.Target == configtypes.TargetTMC) && c.Name == cfg.CurrentContext[c.ContextType] {
 			// This is lossy because only one server can be active at a time in the older CLI.
 			// Using the K8s context for a management cluster or TMC, since these are the two
 			// available publicly at the time of deprecation.

--- a/config/conversion.go
+++ b/config/conversion.go
@@ -36,7 +36,7 @@ func PopulateContexts(cfg *configtypes.ClientConfig) bool {
 		cfg.KnownContexts = append(cfg.KnownContexts, c)
 
 		if s.Name == cfg.CurrentServer {
-			err := cfg.SetCurrentContext(c.Target, c.Name)
+			err := cfg.SetActiveContext(c.ContextType, c.Name)
 			if err != nil {
 				log.Warningf(err.Error())
 			}
@@ -109,7 +109,7 @@ func populateServers(cfg *configtypes.ClientConfig) {
 		s := convertContextToServer(c)
 		cfg.KnownServers = append(cfg.KnownServers, s)
 
-		if cfg.CurrentServer == "" && (c.IsManagementCluster() || c.Target == configtypes.TargetK8s || c.Target == configtypes.TargetTMC) && c.Name == cfg.CurrentContext[c.ContextType] {
+		if cfg.CurrentServer == "" && (c.IsManagementCluster() || c.ContextType == configtypes.ContextTypeK8s || c.ContextType == configtypes.ContextTypeTMC) && c.Name == cfg.CurrentContext[c.ContextType] {
 			// This is lossy because only one server can be active at a time in the older CLI.
 			// Using the K8s context for a management cluster or TMC, since these are the two
 			// available publicly at the time of deprecation.

--- a/config/conversion_test.go
+++ b/config/conversion_test.go
@@ -65,9 +65,9 @@ func TestPopulateContexts(t *testing.T) {
 						},
 					},
 				},
-				CurrentContext: map[configtypes.Target]string{
-					configtypes.TargetK8s: "test-mc",
-					configtypes.TargetTMC: "test-tmc",
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeK8s: "test-mc",
+					configtypes.ContextTypeTMC: "test-tmc",
 				},
 			},
 			op: &configtypes.ClientConfig{
@@ -109,9 +109,9 @@ func TestPopulateContexts(t *testing.T) {
 						},
 					},
 				},
-				CurrentContext: map[configtypes.Target]string{
-					configtypes.TargetK8s: "test-mc",
-					configtypes.TargetTMC: "test-tmc",
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeK8s: "test-mc",
+					configtypes.ContextTypeTMC: "test-tmc",
 				},
 			},
 			delta: false,
@@ -147,8 +147,8 @@ func TestPopulateContexts(t *testing.T) {
 						},
 					},
 				},
-				CurrentContext: map[configtypes.Target]string{
-					configtypes.TargetTMC: "test-tmc",
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeTMC: "test-tmc",
 				},
 			},
 			op: &configtypes.ClientConfig{
@@ -190,9 +190,9 @@ func TestPopulateContexts(t *testing.T) {
 						},
 					},
 				},
-				CurrentContext: map[configtypes.Target]string{
-					configtypes.TargetK8s: "test-mc",
-					configtypes.TargetTMC: "test-tmc",
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeK8s: "test-mc",
+					configtypes.ContextTypeTMC: "test-tmc",
 				},
 			},
 			delta: true,
@@ -264,9 +264,9 @@ func TestPopulateServers(t *testing.T) {
 						},
 					},
 				},
-				CurrentContext: map[configtypes.Target]string{
-					configtypes.TargetK8s: "test-mc",
-					configtypes.TargetTMC: "test-tmc",
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeK8s: "test-mc",
+					configtypes.ContextTypeTMC: "test-tmc",
 				},
 			},
 			op: &configtypes.ClientConfig{
@@ -308,9 +308,9 @@ func TestPopulateServers(t *testing.T) {
 						},
 					},
 				},
-				CurrentContext: map[configtypes.Target]string{
-					configtypes.TargetK8s: "test-mc",
-					configtypes.TargetTMC: "test-tmc",
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeK8s: "test-mc",
+					configtypes.ContextTypeTMC: "test-tmc",
 				},
 			},
 		},
@@ -348,9 +348,9 @@ func TestPopulateServers(t *testing.T) {
 						},
 					},
 				},
-				CurrentContext: map[configtypes.Target]string{
-					configtypes.TargetK8s: "test-mc",
-					configtypes.TargetTMC: "test-tmc",
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeK8s: "test-mc",
+					configtypes.ContextTypeTMC: "test-tmc",
 				},
 			},
 			op: &configtypes.ClientConfig{
@@ -392,9 +392,9 @@ func TestPopulateServers(t *testing.T) {
 						},
 					},
 				},
-				CurrentContext: map[configtypes.Target]string{
-					configtypes.TargetK8s: "test-mc",
-					configtypes.TargetTMC: "test-tmc",
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeK8s: "test-mc",
+					configtypes.ContextTypeTMC: "test-tmc",
 				},
 			},
 		},

--- a/config/legacy_clientconfig_factory.go
+++ b/config/legacy_clientconfig_factory.go
@@ -167,7 +167,7 @@ func clientConfigSetCurrentContext(cfg *configtypes.ClientConfig, node *yaml.Nod
 			if contextErr != nil {
 				return contextErr
 			}
-			_, err := setCurrentContext(node, ctx)
+			_, err := setCurrentContext(node, ctx.Name, ctx.ContextType)
 			if err != nil {
 				return err
 			}

--- a/config/legacy_clientconfig_factory.go
+++ b/config/legacy_clientconfig_factory.go
@@ -51,6 +51,8 @@ func StoreClientConfig(cfg *configtypes.ClientConfig) error {
 	populateServers(cfg)
 	// old plugins would be setting only servers, so populate contexts for forwards compatibility
 	PopulateContexts(cfg)
+	//ANUJ: Sync Target and Context Type
+
 	node, err := getClientConfigNodeNoLock()
 	if err != nil {
 		return err

--- a/config/legacy_clientconfig_factory.go
+++ b/config/legacy_clientconfig_factory.go
@@ -51,7 +51,6 @@ func StoreClientConfig(cfg *configtypes.ClientConfig) error {
 	populateServers(cfg)
 	// old plugins would be setting only servers, so populate contexts for forwards compatibility
 	PopulateContexts(cfg)
-	//ANUJ: Sync Target and Context Type
 
 	node, err := getClientConfigNodeNoLock()
 	if err != nil {

--- a/config/servers.go
+++ b/config/servers.go
@@ -72,7 +72,7 @@ func SetCurrentServer(name string) error {
 	}
 	// Front fill CurrentContext
 	c := convertServerToContext(s)
-	persist, err = setCurrentContext(node, c)
+	persist, err = setCurrentContext(node, c.Name, c.ContextType)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func RemoveCurrentServer(name string) error {
 	if err != nil {
 		return err
 	}
-	err = removeCurrentContext(node, c)
+	err = removeCurrentContext(node, c.Name, c.ContextType)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func frontFillContexts(s *configtypes.Server, setCurrent bool, node *yaml.Node) 
 		}
 	}
 	if setCurrent {
-		persist, err = setCurrentContext(node, c)
+		persist, err = setCurrentContext(node, c.Name, c.ContextType)
 		if err != nil {
 			return err
 		}
@@ -235,7 +235,7 @@ func RemoveServer(name string) error {
 	if err != nil {
 		return err
 	}
-	err = removeCurrentContext(node, c)
+	err = removeCurrentContext(node, c.Name, c.ContextType)
 	if err != nil {
 		return err
 	}

--- a/config/servers_it_test.go
+++ b/config/servers_it_test.go
@@ -137,6 +137,7 @@ currentContext:
           contextType: tmc
     - name: test-mc2
       target: kubernetes
+      contextType: kubernetes
       clusterOpts:
         endpoint: test-endpoint-updated
         path: test-path
@@ -275,6 +276,7 @@ func TestServersIntegrationAndMigratedToNewConfig(t *testing.T) {
           contextType: tmc
     - name: test-mc2
       target: kubernetes
+      contextType: kubernetes
       clusterOpts:
         endpoint: test-endpoint-updated
         path: test-path

--- a/config/types/clientconfig.go
+++ b/config/types/clientconfig.go
@@ -10,20 +10,23 @@ import (
 	"strings"
 )
 
-// ContextType is a new Datatype introduced to represent the type of control plane
+// ContextType defines the type of control plane endpoint a context represents
 type ContextType string
 
 const (
 	// ContextTypeK8s represents a type of control plane endpoint that is a Kubernetes cluster
 	ContextTypeK8s ContextType = "kubernetes"
+	contextTypeK8s ContextType = "k8s"
 
 	// ContextTypeTMC represents a type of control plane endpoint that is a TMC SaaS/self-managed endpoint
 	ContextTypeTMC ContextType = "mission-control"
+	contextTypeTMC ContextType = "tmc"
 
 	// ContextTypeTAE is a used to indicate the type of Context used to interact with
 	// Tanzu Application Engine (Unified Control Plane) endpoint
 	// Note!! Experimental, please expect changes
 	ContextTypeTAE ContextType = "application-engine"
+	contextTypeTAE ContextType = "tae"
 )
 
 // Target is the namespace of the CLI to which plugin is applicable
@@ -121,7 +124,7 @@ func (s *Server) IsManagementCluster() bool {
 
 // GetCurrentServer returns the current server.
 //
-// Deprecated: This API is deprecated. Use GetActiveContext() instead.
+// Deprecated: GetCurrentServer is deprecated. Use GetActiveContext() instead.
 func (c *ClientConfig) GetCurrentServer() (*Server, error) {
 	for _, server := range c.KnownServers {
 		if server.Name == c.CurrentServer {
@@ -205,10 +208,10 @@ func (c *ClientConfig) GetAllActiveContextsMap() (map[ContextType]*Context, erro
 	return currentContexts, nil
 }
 
-// GetAllCurrentContextsList returns all current context names as list
-func (c *ClientConfig) GetAllCurrentContextsList() ([]string, error) {
+// GetAllActiveContextsList returns all active context names as list
+func (c *ClientConfig) GetAllActiveContextsList() ([]string, error) {
 	var serverNames []string
-	currentContextsMap, err := c.GetAllCurrentContextsMap()
+	currentContextsMap, err := c.GetAllActiveContextsMap()
 	if err != nil {
 		return nil, err
 	}
@@ -217,6 +220,13 @@ func (c *ClientConfig) GetAllCurrentContextsList() ([]string, error) {
 		serverNames = append(serverNames, context.Name)
 	}
 	return serverNames, nil
+}
+
+// GetAllCurrentContextsList returns all current context names as list
+//
+// Deprecated: GetAllCurrentContextsList is deprecated. Use GetAllActiveContextsList instead
+func (c *ClientConfig) GetAllCurrentContextsList() ([]string, error) {
+	return c.GetAllActiveContextsList()
 }
 
 // SetCurrentContext sets the current context for the given target.
@@ -338,14 +348,6 @@ func (c *ClientConfig) SetEditionSelector(edition EditionSelector) {
 		return
 	}
 	c.ClientOptions.CLI.UnstableVersionSelector = EditionStandard
-}
-
-func SyncContextTypeAndTarget(ctx *Context) {
-	if ctx.ContextType == "" {
-		ctx.ContextType = ConvertTargetToContextType(ctx.Target)
-	} else if ctx.Target == "" {
-		ctx.Target = ConvertContextTypeToTarget(ctx.ContextType)
-	}
 }
 
 func ConvertTargetToContextType(target Target) ContextType {

--- a/config/types/clientconfig.go
+++ b/config/types/clientconfig.go
@@ -48,17 +48,11 @@ const (
 
 	// TargetUnknown specifies that the target is not currently known
 	TargetUnknown Target = ""
-
-	// TargetTAE is a used to indicate the type of Context used to interact with a
-	// Tanzu Application Engine endpoint
-	// Note!! Experimental, please expect changes
-	TargetTAE Target = "application-engine"
-	targetTAE Target = "tae"
 )
 
 var (
 	// SupportedTargets is a list of all supported Target
-	SupportedTargets = []Target{TargetK8s, TargetTMC, TargetTAE}
+	SupportedTargets = []Target{TargetK8s, TargetTMC}
 	// SupportedContextTypes is a list of all supported ContextTypes
 	SupportedContextTypes = []ContextType{ContextTypeK8s, ContextTypeTMC, ContextTypeTAE}
 )
@@ -185,6 +179,7 @@ func (c *ClientConfig) GetActiveContext(context ContextType) (*Context, error) {
 // GetAllCurrentContextsMap returns all current context per Target
 //
 // Deprecated: GetAllCurrentContextsMap is deprecated. Use GetAllActiveContextsMap instead
+// Note: This function will not return newly added ContextType `application-engine` information
 func (c *ClientConfig) GetAllCurrentContextsMap() (map[Target]*Context, error) {
 	currentContexts := make(map[Target]*Context)
 	for _, target := range SupportedTargets {
@@ -246,7 +241,7 @@ func (c *ClientConfig) SetActiveContext(contextType ContextType, ctxName string)
 	if err != nil {
 		return err
 	}
-	if ctx.IsManagementCluster() || ctx.Target == TargetTMC {
+	if ctx.IsManagementCluster() || ctx.ContextType == ContextTypeTMC {
 		c.CurrentServer = ctxName
 	}
 	return nil
@@ -356,7 +351,7 @@ func ConvertTargetToContextType(target Target) ContextType {
 		return ContextTypeK8s
 	case TargetTMC:
 		return ContextTypeTMC
-	case TargetTAE:
+	case Target(ContextTypeTAE):
 		return ContextTypeTAE
 	}
 	return ContextType(target)
@@ -369,7 +364,7 @@ func ConvertContextTypeToTarget(ctxType ContextType) Target {
 	case ContextTypeTMC:
 		return TargetTMC
 	case ContextTypeTAE:
-		return TargetTAE
+		return Target(ContextTypeTAE)
 	}
 	return Target(ctxType)
 }

--- a/config/types/clientconfig_helper.go
+++ b/config/types/clientconfig_helper.go
@@ -3,6 +3,8 @@
 
 package types
 
+import "strings"
+
 // StringToTarget converts string to Target type
 func StringToTarget(target string) Target {
 	if target == string(targetK8s) || target == string(TargetK8s) {
@@ -31,4 +33,17 @@ func IsValidTarget(target string, allowGlobal, allowUnknown bool) bool {
 		target == string(TargetTAE) ||
 		(allowGlobal && target == string(TargetGlobal)) ||
 		(allowUnknown && target == string(TargetUnknown))
+}
+
+// StringToContextType converts string to ContextType
+func StringToContextType(contextType string) ContextType {
+	contextType = strings.ToLower(contextType)
+	if contextType == string(contextTypeK8s) || contextType == string(ContextTypeK8s) {
+		return ContextTypeK8s
+	} else if contextType == string(contextTypeTMC) || contextType == string(ContextTypeTMC) {
+		return ContextTypeTMC
+	} else if contextType == string(contextTypeTAE) || contextType == string(ContextTypeTAE) {
+		return ContextTypeTAE
+	}
+	return ""
 }

--- a/config/types/clientconfig_helper.go
+++ b/config/types/clientconfig_helper.go
@@ -11,8 +11,6 @@ func StringToTarget(target string) Target {
 		return TargetK8s
 	} else if target == string(targetTMC) || target == string(TargetTMC) {
 		return TargetTMC
-	} else if target == string(targetTAE) || target == string(TargetTAE) {
-		return TargetTAE
 	} else if target == string(TargetGlobal) {
 		return TargetGlobal
 	} else if target == string(TargetUnknown) {
@@ -29,8 +27,6 @@ func IsValidTarget(target string, allowGlobal, allowUnknown bool) bool {
 		target == string(TargetK8s) ||
 		target == string(targetTMC) ||
 		target == string(TargetTMC) ||
-		target == string(targetTAE) ||
-		target == string(TargetTAE) ||
 		(allowGlobal && target == string(TargetGlobal)) ||
 		(allowUnknown && target == string(TargetUnknown))
 }
@@ -46,4 +42,13 @@ func StringToContextType(contextType string) ContextType {
 		return ContextTypeTAE
 	}
 	return ""
+}
+
+// IsValidContextType validates the contextType string specified is valid or not
+func IsValidContextType(contextType string) bool {
+	ct := StringToContextType(contextType)
+	if ct == "" && contextType != "" {
+		return false
+	}
+	return true
 }

--- a/config/types/clientconfig_test.go
+++ b/config/types/clientconfig_test.go
@@ -43,9 +43,9 @@ func (suite *ClientTestSuite) SetupTest() {
 				Target: TargetK8s,
 			},
 		},
-		CurrentContext: map[Target]string{
-			TargetTMC: suite.GlobalServer.Name,
-			TargetK8s: suite.ManagementServer.Name,
+		CurrentContext: map[ContextType]string{
+			ContextTypeTMC: suite.GlobalServer.Name,
+			ContextTypeK8s: suite.ManagementServer.Name,
 		},
 	}
 }
@@ -126,21 +126,21 @@ func (suite *ClientTestSuite) TestGetCurrentContext_K8s() {
 func (suite *ClientTestSuite) TestGetCurrentContext_NotFound() {
 	_, err := suite.ClientConfig.GetCurrentContext("test")
 	suite.Error(err)
-	suite.EqualError(err, "no current context set for target \"test\"")
+	suite.EqualError(err, "no current context set for type \"test\"")
 }
 
 func (suite *ClientTestSuite) TestSetCurrentContext_TMC() {
-	delete(suite.ClientConfig.CurrentContext, TargetTMC)
+	delete(suite.ClientConfig.CurrentContext, ContextTypeTMC)
 	err := suite.ClientConfig.SetCurrentContext(TargetTMC, suite.GlobalServer.Name)
 	suite.NoError(err)
-	suite.Equal(suite.GlobalServer.Name, suite.ClientConfig.CurrentContext[TargetTMC])
+	suite.Equal(suite.GlobalServer.Name, suite.ClientConfig.CurrentContext[ContextTypeTMC])
 }
 
 func (suite *ClientTestSuite) TestSetCurrentContext_K8s() {
-	delete(suite.ClientConfig.CurrentContext, TargetK8s)
+	delete(suite.ClientConfig.CurrentContext, ContextTypeK8s)
 	err := suite.ClientConfig.SetCurrentContext(TargetK8s, suite.ManagementServer.Name)
 	suite.NoError(err)
-	suite.Equal(suite.ManagementServer.Name, suite.ClientConfig.CurrentContext[TargetK8s])
+	suite.Equal(suite.ManagementServer.Name, suite.ClientConfig.CurrentContext[ContextTypeK8s])
 }
 
 func (suite *ClientTestSuite) TestIsGlobal_True() {

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -52,7 +52,7 @@ type Server struct {
 // Context configuration for a control plane. This can one of the following,
 // 1. Kubernetes Cluster
 // 2. Tanzu Mission Control endpoint
-// 3. Unified Control Plane endpoint
+// 3. Tanzu Application Engine endpoint
 type Context struct {
 	// Name of the context.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -52,12 +52,17 @@ type Server struct {
 // Context configuration for a control plane. This can one of the following,
 // 1. Kubernetes Cluster
 // 2. Tanzu Mission Control endpoint
+// 3. Unified Control Plane endpoint
 type Context struct {
 	// Name of the context.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	// Target of the context.
+	// Deprecated: This field is deprecated. Please use ContextType
 	Target Target `json:"target,omitempty" yaml:"target,omitempty"`
+
+	// ContextType of the context.
+	ContextType ContextType `json:"contextType,omitempty" yaml:"contextType,omitempty"`
 
 	// GlobalOpts if the context is a global control plane (e.g., TMC).
 	GlobalOpts *GlobalServer `json:"globalOpts,omitempty" yaml:"globalOpts,omitempty"`
@@ -343,7 +348,7 @@ type ClientConfig struct {
 	KnownContexts []*Context `json:"contexts,omitempty" yaml:"contexts,omitempty"`
 
 	// CurrentContext for every type.
-	CurrentContext map[Target]string `json:"currentContext,omitempty" yaml:"currentContext,omitempty"`
+	CurrentContext map[ContextType]string `json:"currentContext,omitempty" yaml:"currentContext,omitempty"`
 
 	// ClientOptions are client specific options like feature flags, environment variables, repositories, discoverySources, etc.
 	ClientOptions *ClientOptions `json:"clientOptions,omitempty" yaml:"clientOptions,omitempty"`

--- a/docs/config.md
+++ b/docs/config.md
@@ -63,11 +63,11 @@ func SetContext(context Context, setCurrent bool) error
 func DeleteContext(name string) error
 func RemoveContext(name string) error
 func ContextExists(name string) (bool, error)
-func GetCurrentContext(contextType ContextType) error
-func GetAllCurrentContextsMap() (map[configtypes.Target]*configtypes.Context, error)
-func GetAllCurrentContextsList() ([]string, error)
-func SetCurrentContext(context Context) error
-func RemoveCurrentContext(contextType ContextType) error
+func GetActiveContext(contextType ContextType) error
+func GetAllActiveContextsMap() (map[configtypes.ContextType]*configtypes.Context, error)
+func GetAllActiveContextsList() ([]string, error)
+func SetActiveContext(context Context) error
+func RemoveActiveContext(contextType ContextType) error
 func EndpointFromContext(s *configtypes.Context) (endpoint string, err error)
 
 // Feature APIs
@@ -188,7 +188,7 @@ import configapi "github.com/vmware-tanzu/tanzu-framework/cli/runtime/apis/confi
 err := configapi.DeleteContext(name)
 ```
 
-##### Example: Retrieve context information for a specific target
+##### Example: Retrieve context information for a specific context-type
 
 If a plugin wants to access the context it should use the GetCurrentContext API
 [context-related APIs](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/config/contexts.go)
@@ -201,12 +201,12 @@ import (
   cfgtypes "github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
-ctx, err := config.GetCurrentContext(cfgtypes.TargetK8s)
+ctx, err := config.GetActiveContext(cfgtypes.ContextTypeK8s)
 ```
 
-##### Example: Set current context - context if present will be set as current active for a specific target
+##### Example: Set current context - context if present will be set as current active for a specific context-type
 
-If a plugin wants to set the current context it should use the SetCurrentContext API
+If a plugin wants to set the current context it should use the SetActiveContext API
 [context-related APIs](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/config/contexts.go)
 in the Tanzu Plugin Runtime library to ensure forward compatibility. For
 example, to add/update the current active context use the below snippet:
@@ -216,5 +216,5 @@ import (
   config "github.com/vmware-tanzu/tanzu-plugin-runtime/config"
 )
 
-err := config.SetCurrentContext(name string)
+err := config.SetActiveContext(name string)
 ```

--- a/plugin/sync_plugins.go
+++ b/plugin/sync_plugins.go
@@ -99,7 +99,32 @@ func runCommand(commandPath string, args []string, opts *cmdOptions) (bytes.Buff
 //	var outBuf bytes.Buffer
 //	var errBuf bytes.Buffer
 //	SyncPluginsForTarget(types.TargetK8s, WithOutputWriter(&outBuf), WithErrorWriter(&errBuf))
+//
+// Deprecated: SyncPluginsForTarget is deprecated. Use SyncPluginsForContextType instead
 func SyncPluginsForTarget(target types.Target, opts ...CommandOptions) (string, error) {
+	return SyncPluginsForContextType(types.ConvertTargetToContextType(target), opts...)
+}
+
+// SyncPluginsForContextType will attempt to install plugins required by the active
+// Context of the provided contextType. This is most useful for any plugin
+// implementation which creates a new Context or updates an existing one as
+// part of its operation, and prefers that the plugins appropriate for the
+// Context are immediately available for use.
+//
+// Note: This API is considered EXPERIMENTAL. Both the function's signature and
+// implementation are subjected to change/removal if an alternative means to
+// provide equivalent functionality can be introduced.
+//
+// By default this API will write to os.Stdout and os.Stderr.
+// To write the logs to different output and error streams as part of the plugin sync
+// command invocation, configure CommandOptions as part of the parameters.
+//
+// Example:
+//
+//	var outBuf bytes.Buffer
+//	var errBuf bytes.Buffer
+//	SyncPluginsForContextType(types.ContextTypeK8s, WithOutputWriter(&outBuf), WithErrorWriter(&errBuf))
+func SyncPluginsForContextType(contextType types.ContextType, opts ...CommandOptions) (string, error) {
 	// For now, the implementation expects env var TANZU_BIN to be set and
 	// pointing to the core CLI binary used to invoke the plugin sync with.
 
@@ -117,7 +142,7 @@ func SyncPluginsForTarget(target types.Target, opts ...CommandOptions) (string, 
 	args := []string{"plugin", "sync"}
 
 	altCommandArgs = append(altCommandArgs, args...)
-	altCommandArgs = append(altCommandArgs, "--target", string(target))
+	altCommandArgs = append(altCommandArgs, "--type", string(contextType))
 
 	// Check if there is an alternate means to perform the plugin syncing
 	// operation, if not fall back to `plugin sync`

--- a/plugin/sync_plugins_test.go
+++ b/plugin/sync_plugins_test.go
@@ -113,14 +113,14 @@ func TestSyncPlugins(t *testing.T) {
 		{
 			test:                 "with alternate command and sync successfully",
 			newCommandExitStatus: "0",
-			expectedOutput:       "newcommand sync --target kubernetes succeeded\n",
+			expectedOutput:       "newcommand sync --type kubernetes succeeded\n",
 			expectedFailure:      false,
 			enableCustomCommand:  true,
 		},
 		{
 			test:                 "with alternate command and sync unsuccessfully",
 			newCommandExitStatus: "1",
-			expectedOutput:       "newcommand sync --target kubernetes failed\n",
+			expectedOutput:       "newcommand sync --type kubernetes failed\n",
 			expectedFailure:      true,
 			enableCustomCommand:  true,
 		},

--- a/tae/tae.go
+++ b/tae/tae.go
@@ -112,8 +112,8 @@ func GetKubeconfigForContext(contextName, projectName, spaceName string) ([]byte
 	if err != nil {
 		return nil, err
 	}
-	if ctx.Target != configtypes.TargetTAE {
-		return nil, errors.Errorf("context must be of type: %s", configtypes.TargetTAE)
+	if ctx.ContextType != configtypes.ContextTypeTAE {
+		return nil, errors.Errorf("context must be of type: %s", configtypes.ContextTypeTAE)
 	}
 
 	kc, err := kubeconfig.ReadKubeConfig(ctx.ClusterOpts.Path)

--- a/tae/tae_test.go
+++ b/tae/tae_test.go
@@ -141,10 +141,10 @@ func setupForGetContext(t *testing.T) {
 				},
 			},
 		},
-		CurrentContext: map[configtypes.Target]string{
-			configtypes.TargetK8s: "test-mc-2",
-			configtypes.TargetTMC: "test-tmc",
-			configtypes.TargetTAE: "test-tae",
+		CurrentContext: map[configtypes.ContextType]string{
+			configtypes.ContextTypeK8s: "test-mc-2",
+			configtypes.ContextTypeTMC: "test-tmc",
+			configtypes.ContextTypeTAE: "test-tae",
 		},
 	}
 	func() {

--- a/tae/tae_test.go
+++ b/tae/tae_test.go
@@ -126,8 +126,8 @@ func setupForGetContext(t *testing.T) {
 				},
 			},
 			{
-				Name:   "test-tae",
-				Target: configtypes.TargetTAE,
+				Name:        "test-tae",
+				ContextType: configtypes.ContextTypeTAE,
 				GlobalOpts: &configtypes.GlobalServer{
 					Endpoint: "test-endpoint",
 				},

--- a/test/compatibility/framework/compatibilitytests/context/context_test_helpers.go
+++ b/test/compatibility/framework/compatibilitytests/context/context_test_helpers.go
@@ -547,7 +547,21 @@ func (b *Helper) CreateSetContextAPICommands() {
 // DefaultSetContextInputOptions helper method to construct SetContext API input options
 func DefaultSetContextInputOptions(version core.RuntimeVersion, contextName string) *context.SetContextInputOptions {
 	switch version {
-	case core.VersionLatest, core.Version090, core.Version0280:
+	case core.VersionLatest:
+		return &context.SetContextInputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			ContextOpts: &types.ContextOpts{
+				Name:        contextName,
+				Target:      types.TargetK8s,
+				ContextType: types.ContextTypeK8s,
+				GlobalOpts: &types.GlobalServerOpts{
+					Endpoint: "default-compatibility-test-endpoint",
+				},
+			},
+		}
+	case core.Version090, core.Version0280:
 		return &context.SetContextInputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
 				RuntimeVersion: version,
@@ -590,7 +604,22 @@ func DefaultGetContextInputOptions(version core.RuntimeVersion, contextName stri
 // DefaultGetContextOutputOptions helper method to construct GetContext API output options
 func DefaultGetContextOutputOptions(version core.RuntimeVersion, contextName string) *context.GetContextOutputOptions {
 	switch version {
-	case core.VersionLatest, core.Version090, core.Version0280:
+	case core.VersionLatest:
+		return &context.GetContextOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			ContextOpts: &types.ContextOpts{
+				Name:        contextName,
+				Target:      types.TargetK8s,
+				ContextType: types.ContextTypeK8s,
+				GlobalOpts: &types.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+			ValidationStrategy: core.ValidationStrategyStrict,
+		}
+	case core.Version090, core.Version0280:
 		return &context.GetContextOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
 				RuntimeVersion: version,
@@ -676,7 +705,22 @@ func DefaultGetCurrentContextInputOptions(version core.RuntimeVersion) *context.
 // DefaultGetCurrentContextOutputOptions helper method to construct GetCurrentContext API output options
 func DefaultGetCurrentContextOutputOptions(version core.RuntimeVersion, contextName string) *context.GetCurrentContextOutputOptions {
 	switch version {
-	case core.VersionLatest, core.Version090, core.Version0280:
+	case core.VersionLatest:
+		return &context.GetCurrentContextOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: core.VersionLatest,
+			},
+			ContextOpts: &types.ContextOpts{
+				Name:        contextName,
+				Target:      types.TargetK8s,
+				ContextType: types.ContextTypeK8s,
+				GlobalOpts: &types.GlobalServerOpts{
+					Endpoint: common.DefaultEndpoint,
+				},
+			},
+			ValidationStrategy: core.ValidationStrategyStrict,
+		}
+	case core.Version090, core.Version0280:
 		return &context.GetCurrentContextOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
 				RuntimeVersion: core.VersionLatest,
@@ -708,9 +752,16 @@ func DefaultGetCurrentContextOutputOptions(version core.RuntimeVersion, contextN
 }
 
 // DefaultGetCurrentContextOutputOptionsWithError helper method to construct GetCurrentContext API output options with error
-func DefaultGetCurrentContextOutputOptionsWithError(version core.RuntimeVersion) *context.GetCurrentContextOutputOptions {
+func DefaultGetCurrentContextOutputOptionsWithError(version core.RuntimeVersion) *context.GetCurrentContextOutputOptions { //nolint:dupl
 	switch version {
-	case core.VersionLatest, core.Version090, core.Version0280:
+	case core.VersionLatest:
+		return &context.GetCurrentContextOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			Error: fmt.Sprintf("no current context set for type \"%v\"", types.TargetK8s),
+		}
+	case core.Version090, core.Version0280:
 		return &context.GetCurrentContextOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
 				RuntimeVersion: version,
@@ -743,9 +794,16 @@ func DefaultRemoveCurrentContextInputOptions(version core.RuntimeVersion) *conte
 }
 
 // DefaultRemoveCurrentContextOutputOptionsWithError helper method to construct RemoveCurrentContext API output option
-func DefaultRemoveCurrentContextOutputOptionsWithError(version core.RuntimeVersion) *context.RemoveCurrentContextOutputOptions {
+func DefaultRemoveCurrentContextOutputOptionsWithError(version core.RuntimeVersion) *context.RemoveCurrentContextOutputOptions { //nolint:dupl
 	switch version {
-	case core.VersionLatest, core.Version090, core.Version0280:
+	case core.VersionLatest:
+		return &context.RemoveCurrentContextOutputOptions{
+			RuntimeAPIVersion: &core.RuntimeAPIVersion{
+				RuntimeVersion: version,
+			},
+			Error: fmt.Sprintf("no current context set for type \"%v\"", types.ContextTypeK8s),
+		}
+	case core.Version090, core.Version0280:
 		return &context.RemoveCurrentContextOutputOptions{
 			RuntimeAPIVersion: &core.RuntimeAPIVersion{
 				RuntimeVersion: version,

--- a/test/compatibility/framework/compatibilitytests/legacyclientconfig/legacyclientconfig_test.go
+++ b/test/compatibility/framework/compatibilitytests/legacyclientconfig/legacyclientconfig_test.go
@@ -36,7 +36,7 @@ var _ = ginkgo.Describe("Cross-version Legacy Client Config APIs compatibility t
 			testCase.Add(legacyclientconfig.DefaultStoreClientConfigCommand(core.VersionLatest, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
 
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.VersionLatest, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
-			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
+			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.Version090)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0280, legacyclientconfig.WithDefaultContextAndServer(core.Version0280)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0254, legacyclientconfig.WithDefaultContextAndServer(core.Version0254)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0116, legacyclientconfig.WithDefaultContextAndServer(core.Version0116)))
@@ -82,7 +82,7 @@ var _ = ginkgo.Describe("Cross-version Legacy Client Config APIs compatibility t
 			testCase.Add(legacyclientconfig.DefaultStoreClientConfigCommand(core.VersionLatest, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
 
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.VersionLatest, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
-			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
+			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.Version090)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0280, legacyclientconfig.WithDefaultContextAndServer(core.Version0280)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0254, legacyclientconfig.WithDefaultContextAndServer(core.Version0254)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0116, legacyclientconfig.WithDefaultContextAndServer(core.Version0116)))
@@ -128,7 +128,7 @@ var _ = ginkgo.Describe("Cross-version Legacy Client Config APIs compatibility t
 			testCase.Add(legacyclientconfig.DefaultStoreClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.Version090)))
 
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.VersionLatest, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
-			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
+			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.Version090)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0280, legacyclientconfig.WithDefaultContextAndServer(core.Version0280)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0254, legacyclientconfig.WithDefaultContextAndServer(core.Version0254)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0116, legacyclientconfig.WithDefaultContextAndServer(core.Version0116)))
@@ -174,7 +174,7 @@ var _ = ginkgo.Describe("Cross-version Legacy Client Config APIs compatibility t
 			testCase.Add(legacyclientconfig.DefaultStoreClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.Version090)))
 
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.VersionLatest, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
-			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
+			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.Version090)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0280, legacyclientconfig.WithDefaultContextAndServer(core.Version0280)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0254, legacyclientconfig.WithDefaultContextAndServer(core.Version0254)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0116, legacyclientconfig.WithDefaultContextAndServer(core.Version0116)))
@@ -220,7 +220,7 @@ var _ = ginkgo.Describe("Cross-version Legacy Client Config APIs compatibility t
 			testCase.Add(legacyclientconfig.DefaultStoreClientConfigCommand(core.Version0280, legacyclientconfig.WithDefaultContextAndServer(core.Version0280)))
 
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.VersionLatest, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
-			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.VersionLatest)))
+			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version090, legacyclientconfig.WithDefaultContextAndServer(core.Version090)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0280, legacyclientconfig.WithDefaultContextAndServer(core.Version0280)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0254, legacyclientconfig.WithDefaultContextAndServer(core.Version0254)))
 			testCase.Add(legacyclientconfig.DefaultGetClientConfigCommand(core.Version0116, legacyclientconfig.WithDefaultContextAndServer(core.Version0116)))

--- a/test/compatibility/framework/legacyclientconfig/legacyclientconfig_options.go
+++ b/test/compatibility/framework/legacyclientconfig/legacyclientconfig_options.go
@@ -135,7 +135,34 @@ func WithDefaultServer(version core.RuntimeVersion) CfgClientConfigArgsOption {
 func WithDefaultContextAndServer(version core.RuntimeVersion) CfgClientConfigArgsOption {
 	return func(c *CfgClientConfigArgs) {
 		switch version {
-		case core.VersionLatest, core.Version090, core.Version0280:
+		case core.VersionLatest:
+			c.ClientConfigOpts = &types.ClientConfigOpts{
+				KnownServers: []*types.ServerOpts{
+					{
+						Name: common.CompatibilityTestOne,
+						Type: types.ManagementClusterServerType,
+						GlobalOpts: &types.GlobalServerOpts{
+							Endpoint: common.DefaultEndpoint,
+						},
+					},
+				},
+				CurrentServer: common.CompatibilityTestOne,
+				CurrentContext: map[string]string{
+					string(types.TargetK8s): common.CompatibilityTestOne,
+				},
+				KnownContexts: []*types.ContextOpts{
+					{
+						Name: common.CompatibilityTestOne,
+						// Note: We are not setting Target anymore with the latest CLI because
+						// it should be automatically configured by API for backwards compatibility
+						ContextType: types.ContextTypeK8s,
+						GlobalOpts: &types.GlobalServerOpts{
+							Endpoint: "default-compatibility-test-endpoint",
+						},
+					},
+				},
+			}
+		case core.Version090, core.Version0280:
 			c.ClientConfigOpts = &types.ClientConfigOpts{
 				KnownServers: []*types.ServerOpts{
 					{

--- a/test/compatibility/framework/types/cfg_options.go
+++ b/test/compatibility/framework/types/cfg_options.go
@@ -43,6 +43,15 @@ const (
 
 	// CtxTypeTMC is a Tanzu Mission Control server.
 	CtxTypeTMC ContextType = "tmc"
+
+	// ContextTypeK8s is a kubernetes type of context
+	ContextTypeK8s ContextType = "kubernetes"
+
+	// ContextTypeTMC is a Tanzu Mission Control type of context.
+	ContextTypeTMC ContextType = "misson-control"
+
+	// ContextTypeTAE is a Tanzu Application Engine type of context.
+	ContextTypeTAE ContextType = "application-engine"
 )
 
 // Target is the namespace of the CLI to which plugin is applicable
@@ -254,6 +263,9 @@ type ContextOpts struct {
 
 	// Target of the context.
 	Target Target `json:"target,omitempty" yaml:"target,omitempty"`
+
+	// ContextType of the context.
+	ContextType ContextType `json:"contextType,omitempty" yaml:"contextType,omitempty"`
 
 	// GlobalOpts if the context is a global control plane (e.g., TMC).
 	GlobalOpts *GlobalServerOpts `json:"globalOpts,omitempty" yaml:"globalOpts,omitempty"`

--- a/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_context_apis.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_context_apis.go
@@ -145,7 +145,7 @@ func deleteContext(contextName string) *core.APIResponse {
 }
 
 func setCurrentContext(contextName string) *core.APIResponse {
-	err := configlib.SetCurrentContext(contextName)
+	err := configlib.SetActiveContext(contextName)
 	if err != nil {
 		return &core.APIResponse{
 			ResponseType: core.ErrorResponse,
@@ -179,7 +179,7 @@ func getCurrentContext(target configtypes.Target) *core.APIResponse {
 }
 
 func removeCurrentContext(target configtypes.Target) *core.APIResponse {
-	err := configlib.RemoveCurrentContext(target)
+	err := configlib.RemoveCurrentContext(target) //nolint:staticcheck // Deprecated
 	if err != nil {
 		return &core.APIResponse{
 			ResponseType: core.ErrorResponse,

--- a/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_context_apis.go
+++ b/test/compatibility/testplugins/runtime-test-plugin-latest/cmd/trigger_context_apis.go
@@ -159,7 +159,7 @@ func setCurrentContext(contextName string) *core.APIResponse {
 }
 
 func getCurrentContext(target configtypes.Target) *core.APIResponse {
-	ctx, err := configlib.GetCurrentContext(target)
+	ctx, err := configlib.GetCurrentContext(target) //nolint:staticcheck // Deprecated
 	if err != nil {
 		return &core.APIResponse{
 			ResponseType: core.ErrorResponse,


### PR DESCRIPTION
### What this PR does / why we need it

**Background:**

* Today, Tanzu CLI does not have a concept of Context-Type and we use the same concept Target to represent different types of Context as well as how we group plugins under the Tanzu CLI command tree.
* In the existing Tanzu CLI code implementation, a single custom datatype Target is used to represent both the Context-Type and Target concept making both concepts tightly coupled.
* Today, Target also has some values like `global` which does not make sense as a Context-Type value and the code assumes that value cannot be a value of a Context-Type.
* Because of the above, Creating a new Target has the effect of representing a new type of context and groups a set of plugins, but sometimes one of the consequences is unintended.

**Change:**
* As part of this PR we are introducing a new field called `ContextType` within the `Context` object and Deprecating the existing `Target` field.
* The `Target` field will be kept and set correctly to support CLI and plugins using the previous version of Tanzu Plugin Runtime.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #116

### Describe testing done for PR

* Added/Updated Unit tests
* Added/Updated Compatibility tests

**Test Cases that I am trying to cover:**

**Unit Test Cases:**
1. Set Context with Target only, Get the Context and it should contain Target and ContextType both
1. Set Context with ContextType Only, Get the Context and it should contain Target and ContextType both
1. Set Context with Target:X and ContextType:Y, It should throw validation error while setting.

**Compatibility Test Cases:**
1. Set the Context with v1.1.0 CLI (with setting only ContextType) , Get the Context with previous version of CLIs and it should contain correct Target
1. Set the Context with v1.1.0 CLI (with setting only Target),  Get the Context with previous version of CLIs and it should contain correct Target
1. Set the Context with v0.90 CLI (with Target), 
1. Get the Context with v0.28, v0.90 version of CLI should return context with correct Target
1. Get the Context with v1.1.0 version of CLI should return context with correct Target and ContextType


<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Decouple the Target association with the Context object by introducing ContextType

The following APIs are marked as Deprecated:
- `SetCurrentContext` is deprecated. Use `SetActiveContext` instead
- `GetCurrentContext` is deprecated. Use `GetActiveContext` instead
- `RemoveCurrentContext` is deprecated. Use `RemoveActiveContext` instead
- `GetAllCurrentContextsMap` is deprecated. Use `GetAllActiveContextsMap` instead
- `GetAllCurrentContextsList` is deprecated. Use `GetAllActiveContextsList` instead
- `SyncPluginsForTarget` is deprecated. Use `SyncPluginsForContextType` instead

API Change:
- The `ClientConfig` API contains a notable datatype change of the `CurrentContext` field from `map[Target]string` to `map[ContextType]string`.
- If you are using the `CurrentContext` directly by processing the entire `ClientConfig` object some change might be required. However, we encourage teams to use fine-grained API `GetActiveContext` to get active context.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
