### PR TITLE
Implement new APIs NewOutputWriterWithOptions, NewOutputWriterSpinnerWithOptions

### DIFF
--- a/component/README.md
+++ b/component/README.md
@@ -68,12 +68,26 @@ This package provides a way to write output to different formats. It defines the
 #### Initialization
 
 ``` go
-func NewOutputWriter(output io.Writer, outputFormat string, headers ...string) OutputWriter
+func NewOutputWriterWithOptions(output io.Writer, outputFormat string, opts []OutputWriterOption, headers ...string) OutputWriter
 func NewObjectWriter(output io.Writer, outputFormat string, data interface{}) OutputWriter
 ```
 
-- `NewOutputWriter` returns a new instance of `OutputWriter` and it accepts an `io.Writer`, an `outputFormat` (one of `TableOutputType`, `YAMLOutputType`, `JSONOutputType`, `ListTableOutputType`), and a variadic list of headers for the table.
-- `NewObjectWriter` is the same as `NewOutputWriter` but it is used for writing objects instead of tables. It accepts an `io.Writer`, an `outputFormat` (one of `YAMLOutputType`, `JSONOutputType`), and an object that should be written.
+- `NewOutputWriterWithOptions` returns a new instance of `OutputWriter` and it accepts an `io.Writer`, an `outputFormat` (one of `TableOutputType`, `YAMLOutputType`, `JSONOutputType`, `ListTableOutputType`), and a variadic list of headers for the table.
+
+- `NewObjectWriter` is the same as `NewOutputWriterWithOptions` but it is used for writing objects instead of tables. It accepts an `io.Writer`, an `outputFormat` (one of `YAMLOutputType`, `JSONOutputType`), and an object that should be written.
+- It also accepts a list of OutputWriterOption's that can be used to further customize its output.
+
+Note that NewOutputWriter has been deprecated in favor of NewOutputWriterWithOptions
+One difference in the default rendering behavior for YAML/JSON output between
+the writer created with NewOutputWriter vs that created with NewOutputWriterWithOptions
+is that row fields no longer gets auto stringified in the latter.
+
+To retain the stringify behavior (unlikely what if needed except for backward compatibility
+reasons), create the output writer like so:
+
+``` go
+    writer := output.NewOutputWriter(os.Stdout, output.TableOutputType, []OutputWriterOption{WithAutoStringify()}, "Name", "Age")
+```
 
 #### Usage
 
@@ -98,7 +112,7 @@ func (obw *objectwriter) Render()
 
 `Render` emits the generated output to the output stream.
 
-If `NewOutputWriter` was used for initialization, `Render` will generate output in the format specified by the `outputFormat` parameter.
+If `NewOutputWriterWithOptions` was used for initialization, `Render` will generate output in the format specified by the `outputFormat` parameter.
 
 If `NewObjectWriter` was used for initialization, `Render` will generate output in the format specified by the `outputFormat` parameter, and it will use the provided object for output.
 
@@ -131,8 +145,11 @@ import (
 )
 
 func main() {
-    // Example usage of NewOutputWriter
-    writer := output.NewOutputWriter(os.Stdout, output.TableOutputType, "Name", "Age")
+    // Example usage of NewOutputWriterWithOptions
+
+    // Create a OutputWriter with default options
+    writer := output.NewOutputWriterWithOptions(os.Stdout, output.TableOutputType, []OutputWriterOption{}, "Name", "Age")
+
     writer.AddRow("John", 30)
     writer.AddRow("Bob", 45)
     writer.Render()
@@ -162,18 +179,27 @@ This will output:
 
 ## OutputWriterSpinner Component
 
-`OutputWriterSpinner` is a Go package that provides an interface to `OutputWriter` augmented with a spinner. It allows for rendering output with a spinner while also providing the ability to stop the spinner and render the final output.
+`OutputWriterSpinner` provides an interface to `OutputWriter` augmented with a spinner. It allows for rendering output with a spinner while also providing the ability to stop the spinner and render the final output.
 
 ### Usage
 
-To use `OutputWriterSpinner`, you can import the package in your Go code and create an instance of the `OutputWriterSpinner` interface using the `NewOutputWriterWithSpinner` function.
+To use `OutputWriterSpinner`, you can import the package in your Go code and create an instance of the `OutputWriterSpinner` interface using the `NewOutputWriterSpinnerWithOptions` function.
+
+Note that NewOutputWriterWithSpinner has been deprecated in favor of NewOutputWriterSpinnerWithOptions
+One difference in the default rendering behavior for YAML/JSON output between
+the writer created with NewOutputWriterWithSpinner vs that created with NewOutputWriterSpinnerWithOptions
+is that row fields no longer gets auto stringified in the latter.
+
+To retain the stringify behavior (unlikely what if needed except for backward compatibility
+reasons), create the output writer by including WithAutoStringify() in the
+options list .
 
 ``` go
 import "github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 
 
 // create new OutputWriterSpinner
-outputWriterSpinner, err := component.NewOutputWriterWithSpinner(os.Stdout, "json", "Loading...", true)
+outputWriterSpinner, err := component.NewOutputWriterSpinnerWithOptions(os.Stdout, "json", "Loading...", true, []OutputWriterOption{})
 if err != nil {
     fmt.Println("Error creating OutputWriterSpinner:", err)
     return

--- a/component/output.go
+++ b/component/output.go
@@ -42,21 +42,56 @@ const (
 
 // outputwriter is our internal implementation.
 type outputwriter struct {
-	out          io.Writer
-	keys         []string
-	values       [][]interface{}
-	outputFormat OutputType
+	out                 io.Writer
+	keys                []string
+	values              [][]interface{}
+	outputFormat        OutputType
+	autoStringifyFields bool
+}
+
+// OutputWriterOption is an option for outputwriter
+type OutputWriterOption func(*outputwriter)
+
+// WithAutoStringify configures the output writer to automatically convert
+// row fields to their golang string representations. It is used to maintain
+// backward compatibility with old rendering behavior, and should be _avoided_
+// if that need does not apply.
+func WithAutoStringify() OutputWriterOption {
+	return func(ow *outputwriter) {
+		ow.autoStringifyFields = true
+	}
 }
 
 // NewOutputWriter gets a new instance of our output writer.
+//
+// Deprecated: NewOutputWriter is being deprecated in favor of NewOutputWriterWithOptions
+// Until it is removed, it will retain the existing behavior of converting
+// incoming row values to their golang string representation for backward
+// compatibility reasons
 func NewOutputWriter(output io.Writer, outputFormat string, headers ...string) OutputWriter {
+	// for retaining old json/yaml rendering behavior
+	opts := []OutputWriterOption{WithAutoStringify()}
+
+	return NewOutputWriterWithOptions(output, outputFormat, opts, headers...)
+}
+
+// NewOutputWriterWithOptions gets a new instance of our output writer with some customization options.
+func NewOutputWriterWithOptions(output io.Writer, outputFormat string, opts []OutputWriterOption, headers ...string) OutputWriter {
 	// Initialize the output writer that we use under the covers
 	ow := &outputwriter{}
 	ow.out = output
 	ow.outputFormat = OutputType(outputFormat)
 	ow.keys = headers
 
+	ow.applyOptions(opts)
+
 	return ow
+}
+
+func (ow *outputwriter) applyOptions(opts []OutputWriterOption) {
+	for i := range opts {
+		opts[i](ow)
+	}
 }
 
 // SetKeys sets the values to use as the keys for the output values.
@@ -65,10 +100,25 @@ func (ow *outputwriter) SetKeys(headerKeys ...string) {
 	ow.keys = headerKeys
 }
 
+func stringify(items []interface{}) []interface{} {
+	var results []interface{}
+	for i := range items {
+		results = append(results, fmt.Sprintf("%v", items[i]))
+	}
+	return results
+}
+
 // AddRow appends a new row to our table.
 func (ow *outputwriter) AddRow(items ...interface{}) {
 	row := []interface{}{}
-	row = append(row, items...)
+
+	var rowValues []interface{}
+	rowValues = items
+	if ow.autoStringifyFields {
+		rowValues = stringify(items)
+	}
+
+	row = append(row, rowValues...)
 	ow.values = append(ow.values, row)
 }
 

--- a/component/output_spinner.go
+++ b/component/output_spinner.go
@@ -28,11 +28,25 @@ type outputwriterspinner struct {
 }
 
 // NewOutputWriterWithSpinner returns implementation of OutputWriterSpinner.
+//
+// Deprecated: NewOutputWriterWithSpinner is being deprecated in favor of
+// NewOutputWriterspinnerWithOptions.
+// Until it is removed, it will retain the existing behavior of converting
+// incoming row values to their golang string representation for backward
+// compatibility reasons
 func NewOutputWriterWithSpinner(output io.Writer, outputFormat, spinnerText string, startSpinner bool, headers ...string) (OutputWriterSpinner, error) {
+	opts := []OutputWriterOption{WithAutoStringify()}
+	return NewOutputWriterSpinnerWithOptions(output, outputFormat, spinnerText, startSpinner, opts, headers...)
+}
+
+// NewOutputWriterSpinnerWithOptions returns implementation of OutputWriterSpinner.
+func NewOutputWriterSpinnerWithOptions(output io.Writer, outputFormat, spinnerText string, startSpinner bool, opts []OutputWriterOption, headers ...string) (OutputWriterSpinner, error) {
 	ows := &outputwriterspinner{}
 	ows.out = output
 	ows.outputFormat = OutputType(outputFormat)
 	ows.keys = headers
+	ows.applyOptions(opts)
+
 	if ows.outputFormat != JSONOutputType && ows.outputFormat != YAMLOutputType {
 		ows.spinnerText = spinnerText
 		ows.spinner = spinner.New(spinner.CharSets[9], 100*time.Millisecond)

--- a/component/output_test.go
+++ b/component/output_test.go
@@ -16,6 +16,45 @@ var mapValue = map[string]string{
 	"b": "bar",
 }
 
+const (
+	// leading newline, added for readability, should be trimmed during compare
+
+	expectedYAMLStringified = `
+- a: "1"
+  b: map[b:bar f:foo]
+  c: "2"
+`
+
+	expectedYAML = `
+- a: "1"
+  b:
+    b: bar
+    f: foo
+  c: 2
+`
+
+	expectedJSONStringified = `
+[
+  {
+    "a": "1",
+    "b": "map[b:bar f:foo]",
+    "c": "2"
+  }
+]`
+
+	expectedJSON = `
+[
+  {
+    "a": "1",
+    "b": {
+      "b": "bar",
+      "f": "foo"
+    },
+    "c": 2
+  }
+]`
+)
+
 func TestNewOutputWriterTable(t *testing.T) {
 	var b bytes.Buffer
 	tab := NewOutputWriter(&b, string(TableOutputType), "a", "b", "c")
@@ -296,15 +335,21 @@ func TestNewOutputWriterYAMLNonStrings(t *testing.T) {
 	output := b.String()
 	require.NotNil(t, output)
 
-	// leading newline, added for readability, should be trimmed during compare
-	expected := `
-- a: "1"
-  b:
-    b: bar
-    f: foo
-  c: 2
-`
-	require.Equal(t, expected[1:], output)
+	require.Equal(t, expectedYAMLStringified[1:], output)
+}
+
+func TestNewOutputWriterWithOptionsYAML(t *testing.T) {
+	var b bytes.Buffer
+
+	tab := NewOutputWriterWithOptions(&b, string(YAMLOutputType), []OutputWriterOption{}, "a", "b", "c")
+	require.NotNil(t, tab)
+	tab.AddRow("1", mapValue, 2)
+	tab.Render()
+
+	output := b.String()
+	require.NotNil(t, output)
+
+	require.Equal(t, expectedYAML[1:], output)
 }
 
 func TestNewOutputWriterJSONNonStrings(t *testing.T) {
@@ -317,20 +362,49 @@ func TestNewOutputWriterJSONNonStrings(t *testing.T) {
 	output := b.String()
 	require.NotNil(t, output)
 
-	// leading newline, added for readability, should be trimmed during compare
-	expected := `
-[
-  {
-    "a": "1",
-    "b": {
-      "b": "bar",
-      "f": "foo"
-    },
-    "c": 2
-  }
-]`
+	require.Equal(t, expectedJSONStringified[1:], output)
+}
 
-	require.Equal(t, expected[1:], output)
+func TestNewOutputWriterWithOptionsJSON(t *testing.T) {
+	var b bytes.Buffer
+
+	tab := NewOutputWriterWithOptions(&b, string(JSONOutputType), []OutputWriterOption{}, "a", "b", "c")
+	require.NotNil(t, tab)
+	tab.AddRow("1", mapValue, 2)
+	tab.Render()
+
+	output := b.String()
+	require.NotNil(t, output)
+
+	require.Equal(t, expectedJSON[1:], output)
+}
+
+func TestNewOutputWriterWithOptionsJSONAutoStringify(t *testing.T) {
+	var b bytes.Buffer
+
+	tab := NewOutputWriterWithOptions(&b, string(JSONOutputType), []OutputWriterOption{WithAutoStringify()}, "a", "b", "c")
+	require.NotNil(t, tab)
+	tab.AddRow("1", mapValue, 2)
+	tab.Render()
+
+	output := b.String()
+	require.NotNil(t, output)
+
+	require.Equal(t, expectedJSONStringified[1:], output)
+}
+
+func TestNewOutputWriterWithOptionsYAMLAutoStringify(t *testing.T) {
+	var b bytes.Buffer
+
+	tab := NewOutputWriterWithOptions(&b, string(YAMLOutputType), []OutputWriterOption{WithAutoStringify()}, "a", "b", "c")
+	require.NotNil(t, tab)
+	tab.AddRow("1", mapValue, 2)
+	tab.Render()
+
+	output := b.String()
+	require.NotNil(t, output)
+
+	require.Equal(t, expectedYAMLStringified[1:], output)
 }
 
 func TestNewOutputWriterTableListNonStrings(t *testing.T) {
@@ -351,6 +425,65 @@ B:           map[b:bar f:foo], 4
 C:           2, 5
 `
 	require.Equal(t, expected[1:], output)
+}
+
+func TestNewOutputWriterSpinnerJSONNonStrings(t *testing.T) {
+	var b bytes.Buffer
+	tab, err := NewOutputWriterWithSpinner(&b, string(JSONOutputType), "unused", true, "a", "b", "c")
+	require.Nil(t, err)
+	require.NotNil(t, tab)
+	tab.AddRow("1", mapValue, 2)
+	tab.RenderWithSpinner()
+
+	output := b.String()
+	require.NotNil(t, output)
+
+	require.Equal(t, expectedJSONStringified[1:], output)
+}
+
+func TestNewOutputWriterSpinnerWithOptionsJSON(t *testing.T) {
+	var b bytes.Buffer
+
+	tab, err := NewOutputWriterSpinnerWithOptions(&b, string(JSONOutputType), "unused", true, []OutputWriterOption{}, "a", "b", "c")
+	require.Nil(t, err)
+	require.NotNil(t, tab)
+	tab.AddRow("1", mapValue, 2)
+	tab.RenderWithSpinner()
+
+	output := b.String()
+	require.NotNil(t, output)
+
+	require.Equal(t, expectedJSON[1:], output)
+}
+
+func TestNewOutputWriterSpinnerWithOptionsJSONAutoStringify(t *testing.T) {
+	var b bytes.Buffer
+
+	tab, err := NewOutputWriterSpinnerWithOptions(&b, string(JSONOutputType), "unused", true, []OutputWriterOption{WithAutoStringify()}, "a", "b", "c")
+	require.Nil(t, err)
+	require.NotNil(t, tab)
+	tab.AddRow("1", mapValue, 2)
+	tab.RenderWithSpinner()
+
+	output := b.String()
+	require.NotNil(t, output)
+
+	require.Equal(t, expectedJSONStringified[1:], output)
+}
+
+func TestNewOutputWriterSpinnerWithOptionsYAMLAutoStringify(t *testing.T) {
+	var b bytes.Buffer
+
+	tab, err := NewOutputWriterSpinnerWithOptions(&b, string(YAMLOutputType), "unused", true, []OutputWriterOption{WithAutoStringify()}, "a", "b", "c")
+	require.Nil(t, err)
+	require.NotNil(t, tab)
+	tab.AddRow("1", mapValue, 2)
+	tab.RenderWithSpinner()
+
+	output := b.String()
+	require.NotNil(t, output)
+
+	require.Equal(t, expectedYAMLStringified[1:], output)
 }
 
 func TestOutputWriterCharactersInKeys(t *testing.T) {

--- a/plugin/lint/lint.go
+++ b/plugin/lint/lint.go
@@ -71,7 +71,8 @@ func (c *CobraLintRunner) Run() bool {
 
 // Output writes the results of linting in a table form.
 func (c *CobraLintRunner) Output() {
-	t := component.NewOutputWriter(c.config.cmd.OutOrStdout(), "table", "command", "lint")
+	opts := []component.OutputWriterOption{}
+	t := component.NewOutputWriterWithOptions(c.config.cmd.OutOrStdout(), "table", opts, "command", "lint")
 	for k, vs := range *c.results {
 		for _, v := range vs {
 			t.AddRow(k, v)


### PR DESCRIPTION
This is followup on #103, updating it to provide the JSON/YAML rendering fix while retaining the existing behavior.

These provides additional customizability and subsumes the functionality of NewOutputWriter and NewOutputWriterWithSpinner, which are Deprecated.

By using `NewOutputWriterWithOptions`, `NewOutputWriterSpinnerWithOptions`,  JSON and YAML output will render nonstring types correctly. (See issue #102). For backward compatibility, callers that wish to retain the JSON/YAML output behavior of the deprecated APIs may update to use the new API counterparts, by additionally providing a WithAutoStringify() option in the OutputWriterOption list.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes: #102

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NewOutputWriter and NewOutputWriterWithSpinner APIs are deprecated in favor of NewOutputWriterWithOptions and NewOutputWriterSpinnerWithOptions respective. By default the writers created by the new APIs will render nonstrings in YAML/JSON output correctly. Callers that wish to retain the JSON/YAML output behavior of the deprecated APIs may update to use the new API counterparts, by additionally providing a WithAutoStringify() option in the OutputWriterOption list.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
