### PR TITLE
Add arch type to the output of the plugin info cmd

### DIFF
--- a/plugin/info.go
+++ b/plugin/info.go
@@ -6,6 +6,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"runtime/debug"
 
 	"github.com/spf13/cobra"
@@ -24,6 +25,11 @@ type pluginInfo struct {
 	// PluginRuntimeVersion of the plugin. Must be a valid semantic version https://semver.org/
 	// This version specifies the version of Plugin Runtime that was used to build the plugin
 	PluginRuntimeVersion string `json:"pluginRuntimeVersion" yaml:"pluginRuntimeVersion"`
+
+	// The machine architecture of the plugin binary.
+	// This information can prove useful on Darwin (MacOS) ARM64 machine
+	// which can also execute AMD64 binaries in the Rosetta emulator.
+	BinaryArch string `json:"binaryArch" yaml:"binaryArch"`
 }
 
 func newInfoCmd(desc *PluginDescriptor) *cobra.Command {
@@ -35,6 +41,7 @@ func newInfoCmd(desc *PluginDescriptor) *cobra.Command {
 			pi := pluginInfo{
 				PluginDescriptor:     *desc,
 				PluginRuntimeVersion: getPluginRuntimeVersion(),
+				BinaryArch:           runtime.GOARCH,
 			}
 			b, err := json.Marshal(pi)
 			if err != nil {

--- a/plugin/info_test.go
+++ b/plugin/info_test.go
@@ -6,6 +6,7 @@ package plugin
 import (
 	"encoding/json"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,6 +52,7 @@ func TestInfo(t *testing.T) {
 
 	expectedInfo := pluginInfo{
 		PluginDescriptor: descriptor,
+		BinaryArch:       runtime.GOARCH,
 	}
 
 	gotInfo := &pluginInfo{}
@@ -65,5 +67,6 @@ func TestInfo(t *testing.T) {
 	assert.Equal(expectedInfo.BuildSHA, gotInfo.BuildSHA)
 	assert.Equal(expectedInfo.DocURL, gotInfo.DocURL)
 	assert.Equal(expectedInfo.Hidden, gotInfo.Hidden)
+	assert.Equal(expectedInfo.BinaryArch, gotInfo.BinaryArch)
 	assert.Empty(gotInfo.PluginRuntimeVersion, "Should be empty since unit tests doesn't have the self (tanzu-plugin-runtime) module dependency")
 }


### PR DESCRIPTION
### What this PR does / why we need it

On Darwin ARM64 machines, the CLI can install plugins using either an ARM64 or an AMD64 build, depending of plugin binary availability. Showing the arch type in the output of `tanzu <plugin> info` will help in troubleshooting.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Build the builder plugin for both ARM64 and AMD64 using the plugin-runtime with this PR:
```
$ cd tanzu-cli
$ rm -rf artifacts
$ make plugin-build
```

```
# Install the newly built builder plugin for ARM64
$ tz plugin install --local-source artifacts/plugins/darwin/arm64 builder
[i] Installing plugin 'builder:v1.1.0-dev' with target 'global'
[ok] successfully installed 'builder' plugin

# Notice the "binaryArch" info
$ tz builder info
{"name":"builder","description":"Build Tanzu components","target":"global","version":"v1.1.0-dev","buildSHA":"1283b075b-dirty","digest":"","group":"Admin","docURL":"","completionType":0,"pluginRuntimeVersion":"v1.1.0-dev.0.20231010050932-6807eb0c63cf","binaryArch":"arm64"}

# Install the newly built builder plugin for AMD64
# We need an AMD64 CLI to do that, so I installed one
$ file ~/bin/tanzu.v1.0.0
/Users/kmarc/bin/tanzu.v1.0.0: Mach-O 64-bit executable x86_64
$ ~/bin/tanzu.v1.0.0 plugin install --local-source artifacts/plugins/darwin/amd64 builder
[i] Installing plugin 'builder:v1.1.0-dev' with target 'global'
[ok] successfully installed 'builder' plugin

# Notice the "binaryArch" info
$ tz builder info
{"name":"builder","description":"Build Tanzu components","target":"global","version":"v1.1.0-dev","buildSHA":"1283b075b-dirty","digest":"","group":"Admin","docURL":"","completionType":0,"pluginRuntimeVersion":"v1.1.0-dev.0.20231010050932-6807eb0c63cf","binaryArch":"amd64"}
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Display the machine architecture of the plugin binary in the output of `tanzu <plugin> info`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
