### PR TITLE
Add API to get and set accepted EULA versions

### DIFF
--- a/config/config_keys.go
+++ b/config/config_keys.go
@@ -24,6 +24,7 @@ const (
 	KeyCompatibilityFilePath   = "compatibilityFilePath"
 	KeyCEIPOptIn               = "ceipOptIn"
 	KeyEULAStatus              = "eulaStatus"
+	KeyEULAVersions            = "eulaAcceptedVersions"
 	KeyCerts                   = "certs"
 	KeyTelemetry               = "telemetry"
 	KeyCLIId                   = "cliId"

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -303,6 +303,8 @@ type CoreCliOptions struct {
 	CEIPOptIn string `json:"ceipOptIn,omitempty" yaml:"ceipOptIn,omitempty"`
 	// EULAStatus is the EULA acceptance status.
 	EULAStatus string `json:"eulaStatus,omitempty" yaml:"eulaStatus,omitempty"`
+	// EULAAcceptedVersions is comma-separated list of EULA versions accepted.
+	EULAAcceptedVersions string `json:"eulaAcceptedVersions,omitempty" yaml:"eulaAcceptedVersions,omitempty"`
 	// DiscoverySources determine where to discover plugins
 	DiscoverySources []PluginDiscovery `json:"discoverySources,omitempty" yaml:"discoverySources,omitempty"`
 	// CliID is the uuid uniquely identifying the CLI instance


### PR DESCRIPTION
### What this PR does / why we need it

Add API to get and set accepted EULA versions
This change adds APIs to get set a new eulaAcceptedVersions field in the config ng file

```
  cli:
       ...
      eulaAcceptedVersions: v1.0.0,v1.0.1,v1.2.0
```
The field will contain a string of one or more semver sorted versions separated by comma
The field will be used to register the EULA versions accepted.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Ran added unit tests.

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Adds API to get and set accepted EULA versions from/to the config file
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
