### PR TITLE
Provide a 'LastRefresh' field for OCI discoveries

### DIFF
--- a/config/cli_discovery_sources_it_test.go
+++ b/config/cli_discovery_sources_it_test.go
@@ -79,6 +79,7 @@ currentContext:
     - oci:
         name: default
         image: "/:"
+        lastrefresh: 2023-12-04 11:45:53 -0500 EST
         unknown: cli-unknown
     - local:
         name: admin-local
@@ -150,6 +151,7 @@ current: test-mc
         - oci:
             name: default
             image: "default-image"
+            lastrefresh: 2023-12-04 11:45:53 -0500 EST
             unknown: cli-unknown
         - local:
             name: admin-local
@@ -157,6 +159,7 @@ current: test-mc
         - oci:
             name: new-default
             image: new-default-image
+            lastrefresh: 2023-12-04 11:45:53 -0500 EST
 contexts:
     - name: test-mc
       target: kubernetes
@@ -209,8 +212,9 @@ func TestCLIDiscoverySourceIntegration(t *testing.T) {
 	// Add new OCI CLI DiscoverySource
 	ds := &configtypes.PluginDiscovery{
 		OCI: &configtypes.OCIDiscovery{
-			Name:  "new-default",
-			Image: "new-default-image",
+			Name:        "new-default",
+			Image:       "new-default-image",
+			LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 		},
 	}
 	err = SetCLIDiscoverySource(*ds)
@@ -228,8 +232,9 @@ func TestCLIDiscoverySourceIntegration(t *testing.T) {
 	// Update existing OCI CLI DiscoverySource
 	ds = &configtypes.PluginDiscovery{
 		OCI: &configtypes.OCIDiscovery{
-			Name:  "default",
-			Image: "default-image",
+			Name:        "default",
+			Image:       "default-image",
+			LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 		},
 	}
 	err = SetCLIDiscoverySource(*ds)
@@ -261,6 +266,7 @@ func setupDataWithPatchStrategy() (string, string, string, string) {
     - oci:
         name: default
         image: "/:"
+        lastrefresh: 2023-12-04 11:45:53 -0500 EST
         unknown: cli-unknown
         annotation: new-annotation
       contextType: k8s
@@ -275,6 +281,7 @@ func setupDataWithPatchStrategy() (string, string, string, string) {
         - oci:
             name: default
             image: "update-default-image"
+            lastrefresh: 2023-12-04 11:45:53 -0500 EST
             unknown: cli-unknown
           contextType: k8s
         - local:
@@ -283,6 +290,7 @@ func setupDataWithPatchStrategy() (string, string, string, string) {
         - oci:
             name: new-default
             image: new-default-image
+            lastrefresh: 2023-12-04 11:45:53 -0500 EST
 `
 
 	return "", expectedCfg, cfg2, expectedCfg2
@@ -307,8 +315,9 @@ func TestCLIDiscoverySourceIntegrationWithPatchStrategy(t *testing.T) {
 	// Add new OCI CLI DiscoverySource
 	ds := &configtypes.PluginDiscovery{
 		OCI: &configtypes.OCIDiscovery{
-			Name:  "new-default",
-			Image: "new-default-image",
+			Name:        "new-default",
+			Image:       "new-default-image",
+			LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 		},
 	}
 	err = SetCLIDiscoverySource(*ds)
@@ -327,8 +336,9 @@ func TestCLIDiscoverySourceIntegrationWithPatchStrategy(t *testing.T) {
 	// Update existing OCI CLI DiscoverySource
 	ds = &configtypes.PluginDiscovery{
 		OCI: &configtypes.OCIDiscovery{
-			Name:  "default",
-			Image: "update-default-image",
+			Name:        "default",
+			Image:       "update-default-image",
+			LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 		},
 	}
 	err = SetCLIDiscoverySource(*ds)

--- a/config/cli_discovery_sources_test.go
+++ b/config/cli_discovery_sources_test.go
@@ -22,8 +22,9 @@ func TestGetCLIDiscoverySources(t *testing.T) {
 	discoveries := []configtypes.PluginDiscovery{
 		{
 			OCI: &configtypes.OCIDiscovery{
-				Name:  "test",
-				Image: "image",
+				Name:        "test",
+				Image:       "image",
+				LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 			},
 		},
 	}
@@ -60,8 +61,9 @@ func TestGetCLIDiscoverySource(t *testing.T) {
 
 	discovery := &configtypes.PluginDiscovery{
 		OCI: &configtypes.OCIDiscovery{
-			Name:  "test",
-			Image: "image",
+			Name:        "test",
+			Image:       "image",
+			LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 		},
 	}
 
@@ -125,7 +127,7 @@ func TestSetCLIDiscoverySources(t *testing.T) {
 		errStr string
 	}{
 		{
-			name: "success add test",
+			name: "success add test 1",
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
@@ -143,7 +145,7 @@ func TestSetCLIDiscoverySources(t *testing.T) {
 			total: 2,
 		},
 		{
-			name: "success add test",
+			name: "success add test 2",
 			input: []configtypes.PluginDiscovery{
 				{
 					Local: &configtypes.LocalDiscovery{
@@ -155,7 +157,7 @@ func TestSetCLIDiscoverySources(t *testing.T) {
 			total: 3,
 		},
 		{
-			name: "success add test",
+			name: "success add test 3",
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
@@ -191,12 +193,26 @@ func TestSetCLIDiscoverySources(t *testing.T) {
 			total: 3,
 		},
 		{
-			name: "success add default oci",
+			name: "success add default oci with last refresh 0",
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default",
-						Image: "image",
+						Name:        "default",
+						Image:       "image",
+						LastRefresh: "0", // The CLI uses "0" to reset the LastRefresh field
+					},
+				},
+			},
+			total: 3,
+		},
+		{
+			name: "success add default oci full last refresh time",
+			input: []configtypes.PluginDiscovery{
+				{
+					OCI: &configtypes.OCIDiscovery{
+						Name:        "default",
+						Image:       "image",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},
@@ -288,8 +304,9 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 			src: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "test",
-						Image: "image",
+						Name:        "test",
+						Image:       "image",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},
@@ -302,8 +319,9 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 			src: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "test",
-						Image: "image",
+						Name:        "test",
+						Image:       "image",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},
@@ -315,14 +333,16 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 			src: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "test",
-						Image: "image",
+						Name:        "test",
+						Image:       "image",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "test2",
-						Image: "image2",
+						Name:        "test2",
+						Image:       "image2",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},
@@ -334,8 +354,9 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 			src: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "test",
-						Image: "image",
+						Name:        "test",
+						Image:       "image",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 				{
@@ -383,8 +404,9 @@ func TestIntegrationSetGetDeleteCLIDiscoverySource(t *testing.T) {
 	sources := []configtypes.PluginDiscovery{
 		{
 			OCI: &configtypes.OCIDiscovery{
-				Name:  "default",
-				Image: "image",
+				Name:        "default",
+				Image:       "image",
+				LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 			},
 		},
 	}
@@ -486,8 +508,9 @@ func TestSetCLIDiscoverySourceWithDefaultAndDefaultLocal(t *testing.T) {
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default-test",
-						Image: "image",
+						Name:        "default-test",
+						Image:       "image",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},
@@ -498,8 +521,9 @@ func TestSetCLIDiscoverySourceWithDefaultAndDefaultLocal(t *testing.T) {
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default",
-						Image: "image",
+						Name:        "default",
+						Image:       "image",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},
@@ -510,8 +534,9 @@ func TestSetCLIDiscoverySourceWithDefaultAndDefaultLocal(t *testing.T) {
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default-local",
-						Image: "image",
+						Name:        "default-local",
+						Image:       "image",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},
@@ -523,8 +548,9 @@ func TestSetCLIDiscoverySourceWithDefaultAndDefaultLocal(t *testing.T) {
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default",
-						Image: "updatedImage",
+						Name:        "default",
+						Image:       "updatedImage",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},
@@ -536,8 +562,9 @@ func TestSetCLIDiscoverySourceWithDefaultAndDefaultLocal(t *testing.T) {
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default-local",
-						Image: "updatedImage",
+						Name:        "default-local",
+						Image:       "updatedImage",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},
@@ -549,8 +576,9 @@ func TestSetCLIDiscoverySourceWithDefaultAndDefaultLocal(t *testing.T) {
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default",
-						Image: "updatedImage",
+						Name:        "default",
+						Image:       "updatedImage",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 				{
@@ -567,14 +595,16 @@ func TestSetCLIDiscoverySourceWithDefaultAndDefaultLocal(t *testing.T) {
 				},
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default",
-						Image: "updatedImage2",
+						Name:        "default",
+						Image:       "updatedImage2",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "test-oci1",
-						Image: "updatedImage",
+						Name:        "test-oci1",
+						Image:       "updatedImage",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 				{
@@ -628,8 +658,9 @@ func TestSetCLIDiscoverySourceMultiTypes(t *testing.T) {
 			input: []configtypes.PluginDiscovery{
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default",
-						Image: "defaultImage",
+						Name:        "default",
+						Image:       "defaultImage",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 				{
@@ -646,14 +677,16 @@ func TestSetCLIDiscoverySourceMultiTypes(t *testing.T) {
 				},
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "default",
-						Image: "defaultImage2",
+						Name:        "default",
+						Image:       "defaultImage2",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "test-oci1",
-						Image: "updatedImage",
+						Name:        "test-oci1",
+						Image:       "updatedImage",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 				{
@@ -670,8 +703,9 @@ func TestSetCLIDiscoverySourceMultiTypes(t *testing.T) {
 				},
 				{
 					OCI: &configtypes.OCIDiscovery{
-						Name:  "test-oci2",
-						Image: "updatedImage",
+						Name:        "test-oci2",
+						Image:       "updatedImage",
+						LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 					},
 				},
 			},

--- a/config/patchstrategy_it_test.go
+++ b/config/patchstrategy_it_test.go
@@ -56,11 +56,13 @@ current: test-mc
     - oci:
         name: test
         image: image
+        lastrefresh: 2023-12-04 11:45:53 -0500 EST
         annotation: one
         required: true
     - oci:
         name: test2
         image: image2
+        lastrefresh: 2023-12-04 11:45:53 -0500 EST
         annotation: one
         required: true
     - local:
@@ -90,15 +92,18 @@ currentContext:
         - oci:
             name: test
             image: image
+            lastrefresh: 2023-12-04 11:45:53 -0500 EST
             annotation: one
         - oci:
             name: test2
             image: image2
+            lastrefresh: 2023-12-04 11:45:53 -0500 EST
             annotation: one
             required: true
         - oci:
             name: test-local
             image: test-local-image-path
+            lastrefresh: 2023-12-04 11:45:53 -0500 EST
 contexts:
     - name: test-mc
       target: kubernetes
@@ -144,14 +149,16 @@ func TestIntegrationWithReplacePatchStrategy(t *testing.T) {
 	expectedSources := []configtypes.PluginDiscovery{
 		{
 			OCI: &configtypes.OCIDiscovery{
-				Name:  "test",
-				Image: "image",
+				Name:        "test",
+				Image:       "image",
+				LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 			},
 		},
 		{
 			OCI: &configtypes.OCIDiscovery{
-				Name:  "test2",
-				Image: "image2",
+				Name:        "test2",
+				Image:       "image2",
+				LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 			},
 		},
 		{
@@ -168,8 +175,9 @@ func TestIntegrationWithReplacePatchStrategy(t *testing.T) {
 	// Get CLI Discovery Source
 	expectedSource := &configtypes.PluginDiscovery{
 		OCI: &configtypes.OCIDiscovery{
-			Name:  "test",
-			Image: "image",
+			Name:        "test",
+			Image:       "image",
+			LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 		},
 	}
 
@@ -181,14 +189,16 @@ func TestIntegrationWithReplacePatchStrategy(t *testing.T) {
 	updatedSources := []configtypes.PluginDiscovery{
 		{
 			OCI: &configtypes.OCIDiscovery{
-				Name:  "test",
-				Image: "image",
+				Name:        "test",
+				Image:       "image",
+				LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 			},
 		},
 		{
 			OCI: &configtypes.OCIDiscovery{
-				Name:  "test-local",
-				Image: "test-local-image-path",
+				Name:        "test-local",
+				Image:       "test-local-image-path",
+				LastRefresh: "2023-12-04 11:45:53 -0500 EST",
 			},
 		},
 	}

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -234,6 +234,8 @@ type OCIDiscovery struct {
 	// Contains a directory containing YAML files, each of which contains single
 	// CLIPlugin API resource.
 	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+	// LastRefresh allows to store the last time the OCI image was refreshed by the CLI
+	LastRefresh string `json:"lastrefresh,omitempty" yaml:"lastrefresh,omitempty"`
 }
 
 // GenericRESTDiscovery provides a plugin discovery mechanism via any REST API


### PR DESCRIPTION
### What this PR does / why we need it

This is meant to be used by the CLI to only refresh the plugin inventory DB at a certain interval, to make the plugin-lifecycle commands more responsive.

I included this field in an OCI discovery so that when we support more than once discovery, we are prepared.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

Let CI run.
The rest of the testing is done through the tanzu-cli PR that will use this new field.
I will update this PR with the other PR once it is opened.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add `LastRefresh` to an OCI discovery source. 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
