### PR TITLE
Update `tanzu` context APIs to support ClusterGroup

### DIFF
--- a/config/tanzu_context.go
+++ b/config/tanzu_context.go
@@ -176,7 +176,7 @@ func GetKubeconfigForContext(contextName string, opts ...ResourceOptions) ([]byt
 		return nil, errors.Errorf("context must be of type: %s", configtypes.ContextTypeTanzu)
 	}
 	if rOptions.spaceName != "" && rOptions.clusterGroupName != "" {
-		return nil, errors.Errorf("incorrect resource options provided. Both space and clustergroup are set but only one can be set.")
+		return nil, errors.Errorf("incorrect resource options provided. Both space and clustergroup are set but only one can be set")
 	}
 
 	kc, err := kubeconfig.ReadKubeConfig(ctx.ClusterOpts.Path)

--- a/config/tanzu_context_test.go
+++ b/config/tanzu_context_test.go
@@ -189,6 +189,20 @@ func TestGetTanzuContextActiveResource(t *testing.T) {
 	assert.Equal(t, activeResources.OrgID, "fake-org-id")
 	assert.Equal(t, activeResources.ProjectName, "fake-project")
 	assert.Equal(t, activeResources.SpaceName, "fake-space")
+	assert.Equal(t, activeResources.ClusterGroupName, "")
+
+	// Test getting the Tanzu active resource of a context with active resource as clustergroup
+	c.AdditionalMetadata[ProjectNameKey] = "fake-project"
+	c.AdditionalMetadata[SpaceNameKey] = ""
+	c.AdditionalMetadata[ClusterGroupNameKey] = "fake-clustergroup"
+	err = SetContext(c, false)
+	assert.NoError(t, err)
+	activeResources, err = GetTanzuContextActiveResource("test-tanzu")
+	assert.NoError(t, err)
+	assert.Equal(t, activeResources.OrgID, "fake-org-id")
+	assert.Equal(t, activeResources.ProjectName, "fake-project")
+	assert.Equal(t, activeResources.ClusterGroupName, "fake-clustergroup")
+	assert.Equal(t, activeResources.SpaceName, "")
 
 	// If context activeMetadata is not set(error case)
 	c.AdditionalMetadata = nil

--- a/config/tanzu_context_test.go
+++ b/config/tanzu_context_test.go
@@ -108,7 +108,7 @@ func TestGetKubeconfigForContext(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test getting the kubeconfig for an arbitrary Tanzu resource
-	kubeconfigBytes, err := GetKubeconfigForContext(c.Name, "project1", "space1")
+	kubeconfigBytes, err := GetKubeconfigForContext(c.Name, ForProject("project1"), ForSpace("space1"))
 	assert.NoError(t, err)
 	c, err = GetContext("test-tanzu")
 	assert.NoError(t, err)
@@ -119,7 +119,7 @@ func TestGetKubeconfigForContext(t *testing.T) {
 	assert.Equal(t, cluster.Cluster.Server, c.ClusterOpts.Endpoint+"/project/project1/space/space1")
 
 	// Test getting the kubeconfig for an arbitrary Tanzu resource
-	kubeconfigBytes, err = GetKubeconfigForContext(c.Name, "project2", "")
+	kubeconfigBytes, err = GetKubeconfigForContext(c.Name, ForProject("project2"))
 	assert.NoError(t, err)
 	c, err = GetContext("test-tanzu")
 	assert.NoError(t, err)
@@ -131,7 +131,7 @@ func TestGetKubeconfigForContext(t *testing.T) {
 	// Test getting the kubeconfig for an arbitrary Tanzu resource for non Tanzu context
 	nonTanzuCtx, err := GetContext("test-mc")
 	assert.NoError(t, err)
-	_, err = GetKubeconfigForContext(nonTanzuCtx.Name, "project2", "")
+	_, err = GetKubeconfigForContext(nonTanzuCtx.Name, ForProject("project2"))
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "context must be of type: tanzu")
 }
@@ -269,7 +269,7 @@ func TestSetTanzuContextActiveResource(t *testing.T) {
 
 			// Test-1:
 			// - verify correct string gets printed to default stdout and stderr
-			err = SetTanzuContextActiveResource("test-context", "projectA", "spaceA")
+			err = SetTanzuContextActiveResource("test-context", ResourceInfo{ProjectName: "projectA", SpaceName: "spaceA"})
 			w.Close()
 			stdoutRecieved := <-c
 
@@ -284,7 +284,7 @@ func TestSetTanzuContextActiveResource(t *testing.T) {
 			// Test-2: when external stdout and stderr are provided with WithStdout, WithStderr options,
 			// verify correct string gets printed to provided custom stdout/stderr
 			var combinedOutputBuff bytes.Buffer
-			err = SetTanzuContextActiveResource("test-context", "projectA", "spaceA", WithOutputWriter(&combinedOutputBuff), WithErrorWriter(&combinedOutputBuff))
+			err = SetTanzuContextActiveResource("test-context", ResourceInfo{ProjectName: "projectA", SpaceName: "spaceA"}, WithOutputWriter(&combinedOutputBuff), WithErrorWriter(&combinedOutputBuff))
 			if spec.expectedFailure {
 				assert.NotNil(err)
 			} else {

--- a/config/tanzu_context_test.go
+++ b/config/tanzu_context_test.go
@@ -180,7 +180,7 @@ func TestGetTanzuContextActiveResource(t *testing.T) {
 	assert.Empty(t, activeResources.SpaceName)
 
 	// Test getting the Tanzu active resource of a context with active resource as space
-	c.AdditionalMetadata[ProjectNameKey] = "fake-project"
+	c.AdditionalMetadata[ProjectNameKey] = "fake-project" //nolint:goconst
 	c.AdditionalMetadata[SpaceNameKey] = "fake-space"
 	err = SetContext(c, false)
 	assert.NoError(t, err)


### PR DESCRIPTION
### What this PR does / why we need it
- Updates `tanzu` context APIs to support ClusterGroup
- **Updates the `GetKubeconfigForContext` to make it more generalized. Users can pass resource options as `opts` argument.**
```
- func GetKubeconfigForContext(contextName, projectName, spaceName string) ([]byte, error) {
+ func GetKubeconfigForContext(contextName string, opts ...ResourceOptions) ([]byte, error) {
```
Example usage of `GetKubeconfigForContext`:
```
GetKubeconfigForContext("context-name-1", ForProject("test-project"))
GetKubeconfigForContext("context-name-1", ForProject("test-project"), ForClusterGroup("clustergroup1"))
GetKubeconfigForContext("context-name-1", ForProject("test-project"), ForSpace("space1"))
```

- **Updates the `SetTanzuContextActiveResource` to make it more generalized that now takes the `resourceInfo` object.**
```
- func SetTanzuContextActiveResource(contextName, projectName, spaceName string, opts ...CommandOptions) error {
+ func SetTanzuContextActiveResource(contextName string, resourceInfo ResourceInfo, opts ...CommandOptions) error {
```
Example usage of `SetTanzuContextActiveResource`:
```
SetTanzuContextActiveResource("test-context", ResourceInfo{ProjectName: "projectA", SpaceName: "spaceA"})
SetTanzuContextActiveResource("test-context", ResourceInfo{ProjectName: "projectA", ClusterGroupName: "clustergroupB"})
```


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #143

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support for `clustergroup` for the `tanzu` context. This updates the API signature for the `GetKubeconfigForContext` and the `SetTanzuContextActiveResource`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
