### PR TITLE
UX: Updated the output writer with text format

### DIFF
--- a/component/output.go
+++ b/component/output.go
@@ -23,6 +23,7 @@ const (
 type OutputWriter interface {
 	SetKeys(headerKeys ...string)
 	AddRow(items ...interface{})
+	SetText(text string)
 	Render()
 }
 
@@ -38,6 +39,8 @@ const (
 	JSONOutputType OutputType = "json"
 	// ListTableOutputType specified output should be in a list table format.
 	ListTableOutputType OutputType = "listtable"
+	// TextOutputType specifies output should be in text format.
+	Text OutputType = "text"
 )
 
 // outputwriter is our internal implementation.
@@ -45,6 +48,7 @@ type outputwriter struct {
 	out                 io.Writer
 	keys                []string
 	values              [][]interface{}
+	text                string
 	outputFormat        OutputType
 	autoStringifyFields bool
 }
@@ -100,6 +104,11 @@ func (ow *outputwriter) SetKeys(headerKeys ...string) {
 	ow.keys = headerKeys
 }
 
+// SetText sets the text to be rendered.
+func (ow *outputwriter) SetText(text string) {
+	ow.text = text
+}
+
 func stringify(items []interface{}) []interface{} {
 	var results []interface{}
 	for i := range items {
@@ -131,6 +140,8 @@ func (ow *outputwriter) Render() {
 		renderYAML(ow.out, ow.dataStruct())
 	case ListTableOutputType:
 		renderListTable(ow)
+	case Text:
+		fmt.Fprint(ow.out, ow.text)
 	default:
 		renderTable(ow)
 	}
@@ -185,6 +196,12 @@ func (obw *objectwriter) SetKeys(_ ...string) {
 func (obw *objectwriter) AddRow(_ ...interface{}) {
 	// Object writer does not have the concept of keys
 	fmt.Fprintln(obw.out, "Programming error, attempt to add rows to object output")
+}
+
+// SetText sets the text to be rendered.
+func (obw *objectwriter) SetText(_ string) {
+	// Object writer does not have the concept of text
+	fmt.Fprintln(obw.out, "Programming error, attempt to add text to object output")
 }
 
 // Render emits the generated table to the output once ready

--- a/component/output_spinner.go
+++ b/component/output_spinner.go
@@ -68,7 +68,7 @@ func NewOutputWriterSpinnerWithOptions(output io.Writer, outputFormat, spinnerTe
 func (ows *outputwriterspinner) RenderWithSpinner() {
 	if ows.spinner != nil && ows.spinner.Active() {
 		ows.spinner.Stop()
-		fmt.Fprintln(ows.out)
+		fmt.Fprint(ows.out)
 	}
 	ows.Render()
 }
@@ -77,6 +77,6 @@ func (ows *outputwriterspinner) RenderWithSpinner() {
 func (ows *outputwriterspinner) StopSpinner() {
 	if ows.spinner != nil && ows.spinner.Active() {
 		ows.spinner.Stop()
-		fmt.Fprintln(ows.out)
+		fmt.Fprint(ows.out)
 	}
 }

--- a/component/output_test.go
+++ b/component/output_test.go
@@ -538,6 +538,17 @@ func TestObjectWriterYAML(t *testing.T) {
 	require.Contains(t, lines[1], "spacename: Jupiter")
 }
 
+// TestNewOutputWriterText verifies that text output is rendered as-is.
+func TestNewOutputWriterText(t *testing.T) {
+	var b bytes.Buffer
+	msg := "this is a test"
+	txt := NewOutputWriterWithOptions(&b, string(Text), nil)
+	require.NotNil(t, txt)
+	txt.SetText(msg)
+	txt.Render()
+	require.Equal(t, msg, b.String())
+}
+
 type testStruct struct {
 	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
 	Namespace string `json:"spacename,omitempty" yaml:"spacename,omitempty"`


### PR DESCRIPTION
### What this PR does / why we need it
This pull request updates the output writer to include text format support and replaces `fmt.Fprintln` with `fmt.Fprint` in the spinner output. If the API user wants to add a new line at the end of the text or message, it can be appended.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Unit tests are added
Also manual test has done by adding the text format:
```
❯ ts plugin install setting --target tmc
[i] Refreshing plugin inventory cache for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
[i] Reading plugin inventory for "projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest", this will take a few seconds.
\ Installing plugin 'setting:v0.2.13' with target 'mission-control'
```
<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
