### PR TITLE
Add Context sorter to sort by context name then target

### DIFF
--- a/config/types/clientconfig_sorter.go
+++ b/config/types/clientconfig_sorter.go
@@ -1,0 +1,26 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package types specifies the types for clientconfig
+package types
+
+// ContextSorter is a type that implements the sort interface for Contexts to sort by name and target.
+type ContextSorter []*Context
+
+// Len returns the length of the ContextSorter.
+func (c ContextSorter) Len() int {
+	return len(c)
+}
+
+// Swap swaps the elements at the given indices.
+func (c ContextSorter) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+// Less compares the Contexts (by name and then by target) at the given indices.
+func (c ContextSorter) Less(i, j int) bool {
+	if c[i].Name == c[j].Name {
+		return c[i].Target < c[j].Target
+	}
+	return c[i].Name < c[j].Name
+}

--- a/config/types/clientconfig_sorter_test.go
+++ b/config/types/clientconfig_sorter_test.go
@@ -1,0 +1,35 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package types specifies the types for clientconfig
+package types
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestContextSorter_Sort(t *testing.T) {
+	// Create a list of Context instances to be sorted
+	contexts := []*Context{
+		{Name: "Context1", Target: "tmc"},
+		{Name: "Context2", Target: "k8s"},
+		{Name: "Context1", Target: "k8s"},
+	}
+
+	// Sort the contexts using the ContextSorter
+	sort.Sort(ContextSorter(contexts))
+
+	// Verify the sorted order, which should be by name and then by target
+	expectedOrder := []*Context{
+		{Name: "Context1", Target: "k8s"},
+		{Name: "Context1", Target: "tmc"},
+		{Name: "Context2", Target: "k8s"},
+	}
+
+	for i, context := range contexts {
+		if context.Name != expectedOrder[i].Name || context.Target != expectedOrder[i].Target {
+			t.Errorf("Expected %v, but got %v", expectedOrder[i], context)
+		}
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds a sorter for the Context type to sort contexts, first by context name and then by context type.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
1) Unit tests are added
2) Manual test output:
Before fix: Context's are not sorted by name:
![image](https://github.com/vmware-tanzu/tanzu-plugin-runtime/assets/4702817/5fcd334a-96d7-4075-a5ca-9851640be24f)

After fix: Context's are sorted by name:
![image](https://github.com/vmware-tanzu/tanzu-plugin-runtime/assets/4702817/468b8370-ba6e-47f7-bfbc-c256ecfa7d87)

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
