### PR TITLE
Support requesting CustomPath endpoint for kubeconfig with GetKubeconfigForContext API

### DIFF
--- a/config/tanzu_context.go
+++ b/config/tanzu_context.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -110,6 +111,8 @@ type resourceOptions struct {
 	spaceName string
 	// clusterGroupName name of the ClusterGroup
 	clusterGroupName string
+	// customPath use specified path when constructing kubeconfig
+	customPath string
 }
 
 type ResourceOptions func(o *resourceOptions)
@@ -127,6 +130,11 @@ func ForSpace(spaceName string) ResourceOptions {
 func ForClusterGroup(clusterGroupName string) ResourceOptions {
 	return func(o *resourceOptions) {
 		o.clusterGroupName = strings.TrimSpace(clusterGroupName)
+	}
+}
+func ForCustomPath(customPath string) ResourceOptions {
+	return func(o *resourceOptions) {
+		o.customPath = customPath
 	}
 }
 
@@ -199,6 +207,12 @@ func GetKubeconfigForContext(contextName string, opts ...ResourceOptions) ([]byt
 
 func prepareClusterServerURL(context *configtypes.Context, rOptions *resourceOptions) string {
 	serverURL := context.ClusterOpts.Endpoint
+
+	// If customPath is set, append customPath after endpoint to form endpoint URL
+	if rOptions.customPath != "" {
+		return fmt.Sprintf("%s/%s", strings.TrimRight(context.GlobalOpts.Endpoint, "/"), strings.TrimLeft(rOptions.customPath, "/"))
+	}
+
 	if rOptions.projectName == "" {
 		return serverURL
 	}

--- a/config/tanzu_context_test.go
+++ b/config/tanzu_context_test.go
@@ -151,6 +151,16 @@ func TestGetKubeconfigForContext(t *testing.T) {
 	_, err = GetKubeconfigForContext(nonTanzuCtx.Name, ForProject("project2"))
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "context must be of type: tanzu")
+
+	// Test getting the kubeconfig for a custom endpoint path
+	tanzuCtx, err := GetContext("test-tanzu")
+	assert.NoError(t, err)
+	kubeconfigBytes, err = GetKubeconfigForContext(tanzuCtx.Name, ForCustomPath("/custom-path"))
+	assert.NoError(t, err)
+	err = yaml.Unmarshal(kubeconfigBytes, &kc)
+	assert.NoError(t, err)
+	cluster = kubeconfig.GetCluster(&kc, "tanzu-cli-mytanzu/current")
+	assert.Equal(t, cluster.Cluster.Server, tanzuCtx.GlobalOpts.Endpoint+"/custom-path")
 }
 
 func TestGetTanzuContextActiveResource(t *testing.T) {

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -260,6 +260,8 @@ type KubernetesDiscovery struct {
 	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 	// The context to use (if required), defaults to current.
 	Context string `json:"context,omitempty" yaml:"context,omitempty"`
+	// The bytes with the entire kube configuration
+	KubeConfigBytes []byte `json:"kubeConfigBytes,omitempty" yaml:"kubeConfigBytes,omitempty"`
 	// Version of the CLIPlugins API to query.
 	// E.g., v1alpha1
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`

--- a/config/types/clientconfig_types.go
+++ b/config/types/clientconfig_types.go
@@ -260,7 +260,8 @@ type KubernetesDiscovery struct {
 	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 	// The context to use (if required), defaults to current.
 	Context string `json:"context,omitempty" yaml:"context,omitempty"`
-	// The bytes with the entire kube configuration
+	// KubeConfigBytes is the entire kube configuration
+	// Note: Either Path or KubeConfigBytes should be configured and not both
 	KubeConfigBytes []byte `json:"kubeConfigBytes,omitempty" yaml:"kubeConfigBytes,omitempty"`
 	// Version of the CLIPlugins API to query.
 	// E.g., v1alpha1


### PR DESCRIPTION
### What this PR does / why we need it

- Support requesting CustomPath endpoint for kubeconfig with `GetKubeconfigForContext` API
- Add `KubeConfigBytes` to the `KubernetesDiscovery` struct

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support requesting CustomPath endpoint for kubeconfig with GetKubeconfigForContext API
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
