### PR TITLE
Fix: Update spinner api

### DIFF
--- a/component/output_spinner.go
+++ b/component/output_spinner.go
@@ -41,9 +41,9 @@ type OutputWriterSpinnerOptions struct {
 // OutputWriterSpinnerOption is an option for outputwriterspinner
 type OutputWriterSpinnerOption func(*outputwriterspinner)
 
-// WithSpinnerFinalMsg sets the spinner final text and prefix log indicator
+// WithSpinnerFinalText sets the spinner final text and prefix log indicator
 // (log.LogTypeOUTPUT can be used for no prefix)
-func WithSpinnerFinalMsg(finalText string, prefix log.LogType) OutputWriterSpinnerOption {
+func WithSpinnerFinalText(finalText string, prefix log.LogType) OutputWriterSpinnerOption {
 	finalText = fmt.Sprintf("%s%s", log.GetLogTypeIndicator(prefix), finalText)
 	return func(ows *outputwriterspinner) {
 		ows.spinnerFinalText = finalText

--- a/component/output_spinner_test.go
+++ b/component/output_spinner_test.go
@@ -67,7 +67,7 @@ func TestNewOutputWriterSpinnerWithSpinnerOptions(t *testing.T) {
 	// Test creating an OutputWriterSpinner with spinner options and a spinner
 	opts := OutputWriterSpinnerOptions{
 		OutputWriterOptions: []OutputWriterOption{WithAutoStringify()},
-		SpinnerOptions:      []OutputWriterSpinnerOption{WithSpinnerFinalMsg("Done!", log.LogTypeSUCCESS)},
+		SpinnerOptions:      []OutputWriterSpinnerOption{WithSpinnerFinalText("Done!", log.LogTypeSUCCESS)},
 	}
 	ows, err := NewOutputWriterSpinnerWithSpinnerOptions(&output, "table", spinnerText, true, opts, headers...)
 	assert.NoError(t, err)
@@ -75,7 +75,7 @@ func TestNewOutputWriterSpinnerWithSpinnerOptions(t *testing.T) {
 
 	// Test creating an OutputWriterSpinner with spinner options without a spinner
 	opts = OutputWriterSpinnerOptions{
-		SpinnerOptions: []OutputWriterSpinnerOption{WithSpinnerFinalMsg("Done!", log.LogTypeSUCCESS)},
+		SpinnerOptions: []OutputWriterSpinnerOption{WithSpinnerFinalText("Done!", log.LogTypeSUCCESS)},
 	}
 	ows, err = NewOutputWriterSpinnerWithSpinnerOptions(&output, "table", spinnerText, false, opts, headers...)
 	assert.NoError(t, err)


### PR DESCRIPTION
### What this PR does / why we need it
This PR is to rename the spinner API `WithSpinnerFinalMsg` to `WithSpinnerFinalText`
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
Manual testing has done to install plugins by using the updated runtime spinner api:
 
![Uploading image.png…]()

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
