### PR TITLE
Implement sync threshold values set using env variable TANZU_CLI_LOG_LEVEL

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -81,87 +81,76 @@ type LoggerImpl interface {
 	WithCallDepth(callDepth int) LoggerImpl
 }
 
+var l = NewLogger()
+
 // Info logs a non-error message with the given key/value pairs as context.
 func Info(msg string, kvs ...interface{}) {
-	l := NewLogger()
 	l.Print(msg, nil, string(LogTypeINFO), kvs...)
 }
 
 // Infof logs a non-error message with the given key/value pairs as context.
 func Infof(format string, args ...interface{}) {
-	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeINFO))
 }
 
 // Error logs an error message with the given key/value pairs as context.
 func Error(err error, msg string, kvs ...interface{}) {
-	l := NewLogger()
 	l.Print(msg, err, string(LogTypeERROR), kvs...)
 }
 
 // Errorf logs a error message with the given key/value pairs as context.
 func Errorf(format string, args ...interface{}) {
-	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeERROR))
 }
 
 // Warning logs a warning messages with the given key/value pairs as context.
 func Warning(msg string, kvs ...interface{}) {
-	l := NewLogger()
 	l.Print(msg, nil, string(LogTypeWARN), kvs...)
 }
 
 // Warningf logs a warning messages with the given message format with format specifier and arguments.
 func Warningf(format string, args ...interface{}) {
-	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeWARN))
 }
 
 // Success logs a success messages with the given key/value pairs as context.
 func Success(msg string, kvs ...interface{}) {
-	l := NewLogger()
 	l.Print(msg, nil, string(LogTypeSUCCESS), kvs...)
 }
 
 // Successf logs a success messages with the given message format with format specifier and arguments.
 func Successf(format string, args ...interface{}) {
-	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeSUCCESS))
 }
 
 // Fatal logs a fatal message with the given key/value pairs as context and returns with os.Exit(1)
 func Fatal(err error, msg string, kvs ...interface{}) {
-	l := NewLogger()
 	l.Print(msg, err, string(LogTypeERROR), kvs...)
 	os.Exit(1)
 }
 
 // Outputf writes a message to stdout
 func Outputf(format string, args ...interface{}) {
-	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeOUTPUT))
 }
 
 // V returns an InfoLogger value for a specific verbosity level.
 func V(level int) LoggerImpl {
-	l := NewLogger()
 	return l.CloneWithLevel(level)
 }
 
 // WithName adds a new element to the logger's name.
 func WithName(name string) LoggerImpl {
-	l := NewLogger()
 	return l.Clone().WithName(name)
 }
 
 // WithValues adds some key-value pairs of context to a logger.
 func WithValues(kvList ...interface{}) LoggerImpl {
-	l := NewLogger()
 	return l.Clone().WithValues(kvList...)
 }
 
@@ -193,7 +182,6 @@ func ShowTimestamp(show bool) {
 
 // SetVerbosity sets verbosity level and also updates default verbosity level
 func SetVerbosity(verbosity int32) {
-	l := NewLogger()
 	l.SetThreshold(&verbosity)
 	logWriter.SetVerbosity(verbosity)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -81,76 +81,87 @@ type LoggerImpl interface {
 	WithCallDepth(callDepth int) LoggerImpl
 }
 
-var l = NewLogger()
-
 // Info logs a non-error message with the given key/value pairs as context.
 func Info(msg string, kvs ...interface{}) {
+	l := NewLogger()
 	l.Print(msg, nil, string(LogTypeINFO), kvs...)
 }
 
 // Infof logs a non-error message with the given key/value pairs as context.
 func Infof(format string, args ...interface{}) {
+	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeINFO))
 }
 
 // Error logs an error message with the given key/value pairs as context.
 func Error(err error, msg string, kvs ...interface{}) {
+	l := NewLogger()
 	l.Print(msg, err, string(LogTypeERROR), kvs...)
 }
 
 // Errorf logs a error message with the given key/value pairs as context.
 func Errorf(format string, args ...interface{}) {
+	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeERROR))
 }
 
 // Warning logs a warning messages with the given key/value pairs as context.
 func Warning(msg string, kvs ...interface{}) {
+	l := NewLogger()
 	l.Print(msg, nil, string(LogTypeWARN), kvs...)
 }
 
 // Warningf logs a warning messages with the given message format with format specifier and arguments.
 func Warningf(format string, args ...interface{}) {
+	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeWARN))
 }
 
 // Success logs a success messages with the given key/value pairs as context.
 func Success(msg string, kvs ...interface{}) {
+	l := NewLogger()
 	l.Print(msg, nil, string(LogTypeSUCCESS), kvs...)
 }
 
 // Successf logs a success messages with the given message format with format specifier and arguments.
 func Successf(format string, args ...interface{}) {
+	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeSUCCESS))
 }
 
 // Fatal logs a fatal message with the given key/value pairs as context and returns with os.Exit(1)
 func Fatal(err error, msg string, kvs ...interface{}) {
+	l := NewLogger()
 	l.Print(msg, err, string(LogTypeERROR), kvs...)
 	os.Exit(1)
 }
 
 // Outputf writes a message to stdout
 func Outputf(format string, args ...interface{}) {
+	l := NewLogger()
 	msg := fmt.Sprintf(format, args...)
 	l.Print(msg, nil, string(LogTypeOUTPUT))
 }
 
 // V returns an InfoLogger value for a specific verbosity level.
 func V(level int) LoggerImpl {
+	l := NewLogger()
 	return l.CloneWithLevel(level)
 }
 
 // WithName adds a new element to the logger's name.
 func WithName(name string) LoggerImpl {
+	l := NewLogger()
 	return l.Clone().WithName(name)
 }
 
 // WithValues adds some key-value pairs of context to a logger.
 func WithValues(kvList ...interface{}) LoggerImpl {
+	l := NewLogger()
 	return l.Clone().WithValues(kvList...)
 }
 
@@ -182,6 +193,7 @@ func ShowTimestamp(show bool) {
 
 // SetVerbosity sets verbosity level and also updates default verbosity level
 func SetVerbosity(verbosity int32) {
+	l := NewLogger()
 	l.SetThreshold(&verbosity)
 	logWriter.SetVerbosity(verbosity)
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -35,22 +35,24 @@ type logEntry struct {
 
 // NewLogger returns a new instance of the logger.
 func NewLogger() LoggerImpl {
-	logThreshold := getLogThreshold()
+	logThreshold := getLogThreshold(defaultLogThreshold)
 	return &logger{
 		threshold: &logThreshold,
 	}
 }
 
-func getLogThreshold() int32 {
+func getLogThreshold(defaultThreshold int32) int32 {
 	reqLogLevelStr := os.Getenv(EnvTanzuCLILogLevel)
 	if reqLogLevelStr != "" {
 		requestedLogLevel, err := strconv.ParseUint(reqLogLevelStr, 10, 32)
 		if err == nil {
 			return int32(requestedLogLevel)
 		}
+
 		fmt.Fprintf(os.Stderr, "invalid value %q for %s\n", reqLogLevelStr, EnvTanzuCLILogLevel)
 	}
-	return defaultLogThreshold
+
+	return defaultThreshold
 }
 
 // logger defines a logr.Logger
@@ -65,8 +67,22 @@ type logger struct {
 
 var _ LoggerImpl = &logger{}
 
+// SyncThreshold syncs the threshold value for a logger based on what is set on logger and TANZU_CLI_LOG_LEVEL.
+// TANZU_CLI_LOG_LEVEL value takes precedence over SetThreshold
+func (l *logger) syncThreshold() {
+	var logThreshold int32
+
+	// If threshold is already set then use that value as default fallback if TANZU_CLI_LOG_LEVEL is not set
+	if l.threshold != nil {
+		logThreshold = getLogThreshold(*l.threshold)
+	} else {
+		logThreshold = getLogThreshold(defaultLogThreshold)
+	}
+	l.threshold = &logThreshold
+}
+
 // SetThreshold implements a New Option that allows to set the threshold level for a logger.
-// The logger will write only log messages with a level/V(x) equal or higher to the threshold.
+// The logger will write only log messages with a level/V(x) equal or lower to the threshold.
 func (l *logger) SetThreshold(threshold *int32) {
 	l.threshold = threshold
 }
@@ -193,6 +209,7 @@ func (l *logger) CloneWithLevel(level int) LoggerImpl {
 }
 
 func (l *logger) Print(msg string, err error, logType string, kvs ...interface{}) {
+	l.syncThreshold()
 	msg = fmt.Sprintf("%s%s", l.getLogTypeIndicator(logType), msg)
 	values := copySlice(l.values)
 	values = append(values, kvs...)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -19,6 +19,7 @@ func TestLogger(t *testing.T) {
 		containStrings        []string
 		doesNotContainStrings []string
 	}{
+
 		{
 			title:                 "when TANZU_CLI_LOG_LEVEL is not configured and then set to 3",
 			initialLogLevel:       "",
@@ -67,6 +68,7 @@ func TestLogger(t *testing.T) {
 		t.Run(spec.title, func(t *testing.T) {
 			defer os.Setenv(EnvTanzuCLILogLevel, "")
 
+			l = NewLogger()
 			stderr := &bytes.Buffer{}
 			SetStderr(stderr)
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -12,46 +12,51 @@ import (
 )
 
 func TestLogger(t *testing.T) {
-	assert := assert.New(t)
-
 	tests := []struct {
-		test                  string
+		title                 string
+		initialLogLevel       string
 		logLevel              string
 		containStrings        []string
 		doesNotContainStrings []string
 	}{
 		{
-			test:                  "when TANZU_CLI_LOG_LEVEL is not configured",
-			logLevel:              "",
-			containStrings:        []string{"log-default", "log-0", "log-1", "log-3"},
-			doesNotContainStrings: []string{"log-5", "log-8"},
-		},
-		{
-			test:                  "when TANZU_CLI_LOG_LEVEL is set to 3",
+			title:                 "when TANZU_CLI_LOG_LEVEL is not configured and then set to 3",
+			initialLogLevel:       "",
 			logLevel:              "3",
 			containStrings:        []string{"log-default", "log-0", "log-1", "log-3"},
 			doesNotContainStrings: []string{"log-5", "log-8"},
 		},
 		{
-			test:                  "when TANZU_CLI_LOG_LEVEL is set to 6",
+			title:                 "when TANZU_CLI_LOG_LEVEL is set to 1 and 5",
+			initialLogLevel:       "1",
+			logLevel:              "5",
+			containStrings:        []string{"log-default", "log-0", "log-1", "log-5"},
+			doesNotContainStrings: []string{"log-3", "log-8"},
+		},
+		{
+			title:                 "when TANZU_CLI_LOG_LEVEL is set to 3 and 6",
+			initialLogLevel:       "3",
 			logLevel:              "6",
 			containStrings:        []string{"log-default", "log-0", "log-1", "log-3", "log-5"},
 			doesNotContainStrings: []string{"log-8"},
 		},
 		{
-			test:                  "when TANZU_CLI_LOG_LEVEL is set to 8",
+			title:                 "when TANZU_CLI_LOG_LEVEL is set to 3 and 8",
+			initialLogLevel:       "3",
 			logLevel:              "8",
 			containStrings:        []string{"log-default", "log-0", "log-1", "log-3", "log-5", "log-8"},
 			doesNotContainStrings: []string{},
 		},
 		{
-			test:                  "when TANZU_CLI_LOG_LEVEL is set to 9",
+			title:                 "when TANZU_CLI_LOG_LEVEL is set to 5 and 9",
+			initialLogLevel:       "5",
 			logLevel:              "9",
 			containStrings:        []string{"log-default", "log-0", "log-1", "log-3", "log-5", "log-8"},
 			doesNotContainStrings: []string{},
 		},
 		{
-			test:                  "when TANZU_CLI_LOG_LEVEL is configured with incorrect value",
+			title:                 "when TANZU_CLI_LOG_LEVEL is configured with incorrect value",
+			initialLogLevel:       "a",
 			logLevel:              "a",
 			containStrings:        []string{"log-default", "log-0", "log-1", "log-3"},
 			doesNotContainStrings: []string{"log-5", "log-8"},
@@ -59,25 +64,30 @@ func TestLogger(t *testing.T) {
 	}
 
 	for _, spec := range tests {
-		defer os.Setenv(EnvTanzuCLILogLevel, "")
-		os.Setenv(EnvTanzuCLILogLevel, spec.logLevel)
+		t.Run(spec.title, func(t *testing.T) {
+			defer os.Setenv(EnvTanzuCLILogLevel, "")
 
-		l = NewLogger()
-		stderr := &bytes.Buffer{}
-		SetStderr(stderr)
+			stderr := &bytes.Buffer{}
+			SetStderr(stderr)
 
-		Info("log-default")
-		V(0).Info("log-0")
-		V(1).Info("log-1")
-		V(3).Info("log-3")
-		V(5).Info("log-5")
-		V(8).Info("log-8")
+			os.Setenv(EnvTanzuCLILogLevel, spec.initialLogLevel)
 
-		for _, logStr := range spec.containStrings {
-			assert.Contains(stderr.String(), logStr, spec.test)
-		}
-		for _, logStr := range spec.doesNotContainStrings {
-			assert.NotContains(stderr.String(), logStr, spec.test)
-		}
+			Info("log-default")
+			V(0).Info("log-0")
+			V(1).Info("log-1")
+			V(3).Info("log-3")
+
+			os.Setenv(EnvTanzuCLILogLevel, spec.logLevel)
+
+			V(5).Info("log-5")
+			V(8).Info("log-8")
+
+			for _, logStr := range spec.containStrings {
+				assert.Contains(t, stderr.String(), logStr, spec.title)
+			}
+			for _, logStr := range spec.doesNotContainStrings {
+				assert.NotContains(t, stderr.String(), logStr, spec.title)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it
- Logger not picking the latest os level env variables
- Since the logger instance is created once any dynamic env variables set for TANZU_CLI_LOG_LEVEL are not picked by the logger causing desired log levels not printing.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
 -Manual testing the tanzu cli with logging custom log levels


```

**Case 1 :-**

In Tanzu CLI
	log.SetVerbosity(4)
	log.V(6).Info("testing logger with 6")


# Log is not printed since verbosity is set lower

mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> tz config get
clientOptions:
    features:
        global:
            context-target-v2: "true"
    env:
        any-plugin: baarr
cli:
    ceipOptIn: "true"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 736bddac-be88-4084-a00d-137a4972b487
    telemetry:
        source: /Users/mpanchajanya/.config/tanzu-cli-telemetry/cli_metrics.db
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> tz version
version: v1.2.0-dev
buildDate: 2024-02-01
sha: 4b232f86-dirty
arch: arm64
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> 


# Log is printed if TANZU_CLI_LOG_LEVEL is set since the env variable takes precedence

mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> tz config set env.TANZU_CLI_LOG_LEVEL 9
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> tz version
[i] testing logger with 6
version: v1.2.0-dev
buildDate: 2024-02-01
sha: 4b232f86-dirty
arch: arm64
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> 


**Case 2:-**

# In Tanzu CLI
	log.SetVerbosity(9)
	log.V(6).Info("testing logger with 6")

# Log is printed since verbosity is set higher

mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> tz version
[i] testing logger with 6
version: v1.2.0-dev
buildDate: 2024-02-01
sha: 4b232f86-dirty
arch: arm64
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> tz config get
[i] testing logger with 6
clientOptions:
    features:
        global:
            context-target-v2: "true"
    env:
        any-plugin: baarr
cli:
    ceipOptIn: "true"
    eulaStatus: accepted
    discoverySources:
        - oci:
            name: default
            image: projects.registry.vmware.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: 736bddac-be88-4084-a00d-137a4972b487
    telemetry:
        source: /Users/mpanchajanya/.config/tanzu-cli-telemetry/cli_metrics.db
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> 

# Log is not printed since TANZU_CLI_LOG_LEVEL is set to lower since the env variable takes precedence

mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> tz config set env.TANZU_CLI_LOG_LEVEL 4
[i] testing logger with 6
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> tz version
version: v1.2.0-dev
buildDate: 2024-02-01
sha: 4b232f86-dirty
arch: arm64
mpanchajanya@mpanchajanF09MK ~/v/r/tanzu-cli (bug-fix/cert-update)> 


```


<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
