### PR TITLE
Refactor Spinner component and Add `SetText` and `StartSpinner` APIs

### DIFF
--- a/component/README.md
+++ b/component/README.md
@@ -193,8 +193,8 @@ The main difference is how the parameters are provided when creating a `OutputWr
 ``` go
 import "github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 
-// Create new OutputWriterSpinner component
-owSpinner, err := component.NewOutputWriterSpinner(component.WithOutputStream(os.Stderr),
+// Create new OutputWriterSpinner component. If `WithOutputStream` option is not provided, it will use os.Stdout as default output stream
+owSpinner, err := component.NewOutputWriterSpinner(
         component.WithOutputFormat(component.TableOutputType), // For JSON use JSONOutputType and for YAML use YAMLOutputType
         component.WithSpinnerText("Fetching data..."),
         component.WithSpinnerStarted(),
@@ -219,7 +219,7 @@ owSpinner.Render()
 import "github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 
 // Create new OutputWriterSpinner component
-spinner, err := component.NewOutputWriterSpinner()
+spinner, err := component.NewOutputWriterSpinner(component.WithOutputStream(os.Stderr))
 if err != nil {
     fmt.Println("Error creating spinner:", err)
     return

--- a/component/README.md
+++ b/component/README.md
@@ -177,40 +177,39 @@ This will output:
 {"Age":30,"Name":"John"}
 ```
 
-## Spinner Component
+## OutputWriterSpinner Component
 
-`Spinner` provides an interface to `OutputWriter` augmented with a spinner. It allows for rendering output of multiple types (Text, Table, Yaml, Json) with a spinner while also providing the ability to stop the spinner and render the final output.
+`OutputWriterSpinner` provides an interface to `OutputWriter` augmented with a spinner. It allows for rendering output of multiple types (Text, Table, Yaml, Json) with a spinner while also providing the ability to stop the spinner and render the final output.
 
 ### Usage
 
-To use `Spinner`, you can import the package in your Go code and create an instance of the `Spinner` interface using the `NewSpinner` function.
+To use `OutputWriterSpinner`, you can import the package in your Go code and create an instance of the `OutputWriterSpinner` interface using the `NewOutputWriterSpinner` function.
 
-Note that NewOutputWriterWithSpinner and NewOutputWriterSpinnerWithOptions has been deprecated in favor of NewSpinner
-The main difference is how the parameters are provided when creating a spinner component.
+Note that `NewOutputWriterWithSpinner` and `NewOutputWriterSpinnerWithOptions` has been deprecated in favor of `NewOutputWriterSpinner`.
+The main difference is how the parameters are provided when creating a `OutputWriterSpinner` component.
 
 #### Using Spinner to display Table/JSON/YAML output
 
 ``` go
 import "github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 
-
-// Create new Spinner component
-spinner, err := component.NewSpinner(component.WithOutputStream(os.Stderr),
-		component.WithOutputFormat(component.TableOutputType), // For JSON use JSONOutputType and for YAML use YAMLOutputType
-		component.WithSpinnerText("Fetching data..."),
-		component.WithSpinnerStarted(),
+// Create new OutputWriterSpinner component
+owSpinner, err := component.NewOutputWriterSpinner(component.WithOutputStream(os.Stderr),
+        component.WithOutputFormat(component.TableOutputType), // For JSON use JSONOutputType and for YAML use YAMLOutputType
+        component.WithSpinnerText("Fetching data..."),
+        component.WithSpinnerStarted(),
         component.WithHeaders("Namespace", "Name", "Ready"))
 if err != nil {
-    fmt.Println("Error creating spinner:", err)
+    fmt.Println("Error creating OutputWriterSpinner:", err)
     return
 }
 
 // Do some processing to fetch the data from server and fill rows for table
-spinner.AddRow("default", "pod1", "False")
-spinner.AddRow("default", "pod2", "True")
+owSpinner.AddRow("default", "pod1", "False")
+owSpinner.AddRow("default", "pod2", "True")
 
 // Render output to stop the spinner and render output in table format
-spinner.Render()
+owSpinner.Render()
 
 ```
 
@@ -219,9 +218,8 @@ spinner.Render()
 ``` go
 import "github.com/vmware-tanzu/tanzu-plugin-runtime/component"
 
-
-// Create new Spinner component
-spinner, err := component.NewSpinner()
+// Create new OutputWriterSpinner component
+spinner, err := component.NewOutputWriterSpinner()
 if err != nil {
     fmt.Println("Error creating spinner:", err)
     return
@@ -244,19 +242,25 @@ spinner.StopSpinner()
 
 ```
 
+The `NewOutputWriterSpinner` function takes in the following optional options:
 
-The `NewSpinner` function takes in the following optional options:
+- `WithOutputStream(writer io.Writer)`: sets the output stream for the OutputWriterSpinner component.
+- `WithOutputFormat(outputFormat OutputType)`: sets output format for the OutputWriterSpinner component.
+- `WithOutputWriterOptions(opts ...OutputWriterOption)`: configures OutputWriterOptions to the OutputWriterSpinner component.
+- `WithSpinnerText(text string)`: sets the spinner text
+- `WithSpinnerFinalText(finalText string, prefix log.LogType)`: sets the spinner final text and prefix log indicator
+- `WithSpinnerStarted()`: starts the spinner when the OutputWriterSpinner component gets created
+- `WithHeaders(headers ...string)`: Sets the headers for the OutputWriterOptions component
 
-- `output io.Writer`: The output writer for the spinner and final output.
-- `outputFormat string`: The output format for the final output. It can be either "json" or "yaml".
-- `spinnerText string`: The text to display next to the spinner.
-- `startSpinner bool`: Whether to start the spinner immediately or not.
-- `headers ...string`: Optional headers for the final output.
+The created `OutputWriterSpinner` instance provides following methods:
 
-The created `OutputWriterSpinner` instance provides two methods:
-
-- `RenderWithSpinner()`: Renders the output with a spinner.
-- `StopSpinner()`: Stops the spinner and renders the final output.
+- `SetKeys(headerKeys ...string)`: sets the headers for the OutputWriter component
+- `AddRow(items ...interface{})`: adds rows to the OutputWriter component
+- `SetText(text string)`: sets the spinner text
+- `SetFinalText(finalText string, prefix log.LogType)`: sets the spinner final text and prefix log indicator
+- `StartSpinner()`: start the spinner instance and renders the spinnerText
+- `StopSpinner()`: stops the running spinner instance and renders FinalText if set
+- `Render()`: stops the spinner and render the output
 
 ## Prompt Component
 

--- a/component/README.md
+++ b/component/README.md
@@ -179,7 +179,7 @@ This will output:
 
 ## OutputWriterSpinner Component
 
-`OutputWriterSpinner` provides an interface to `OutputWriter` augmented with a spinner. It allows for rendering output of multiple types (Text, Table, Yaml, Json) with a spinner while also providing the ability to stop the spinner and render the final output.
+`OutputWriterSpinner` provides an interface to `OutputWriter` augmented with a spinner. It allows for displaying output of multiple types (Text, Table, Yaml, Json) with a spinner while also providing the ability to stop the spinner, display the final text and render the output.
 
 ### Usage
 
@@ -208,7 +208,7 @@ if err != nil {
 owSpinner.AddRow("default", "pod1", "False")
 owSpinner.AddRow("default", "pod2", "True")
 
-// Render output to stop the spinner and render output in table format
+// Stop the running spinner instance, displays FinalText if set, then renders the tabular output
 owSpinner.Render()
 
 ```
@@ -237,7 +237,7 @@ if err != nil {
     spinner.SetFinalText("Successfully installed the plugin 'apps'", log.LogTypeSuccess)
 }
 
-// Stop the spinner and render/output FinalText
+// Stop the spinner and displays FinalText
 spinner.StopSpinner()
 
 ```
@@ -258,9 +258,9 @@ The created `OutputWriterSpinner` instance provides following methods:
 - `AddRow(items ...interface{})`: adds rows to the OutputWriter component
 - `SetText(text string)`: sets the spinner text
 - `SetFinalText(finalText string, prefix log.LogType)`: sets the spinner final text and prefix log indicator
-- `StartSpinner()`: start the spinner instance and renders the spinnerText
-- `StopSpinner()`: stops the running spinner instance and renders FinalText if set
-- `Render()`: stops the spinner and render the output
+- `StartSpinner()`: starts the spinner instance, showing the spinnerText
+- `StopSpinner()`: stops the running spinner instance, displays FinalText if set
+- `Render()`: stops the running spinner instance, displays FinalText if set, then renders the output
 
 ## Prompt Component
 

--- a/component/output_spinner.go
+++ b/component/output_spinner.go
@@ -21,9 +21,9 @@ type OutputWriterSpinner interface {
 	// RenderWithSpinner will stop spinner and render the output
 	// Deprecated: RenderWithSpinner is being deprecated in favor of Render.
 	RenderWithSpinner()
-	// StartSpinner start the spinner instance and renders the spinnerText
+	// StartSpinner starts the spinner instance, showing the spinnerText
 	StartSpinner()
-	// StopSpinner stops the running spinner instance and renders FinalText if set
+	// StopSpinner stops the running spinner instance, displays FinalText if set
 	StopSpinner()
 	// SetText sets the spinner text
 	SetText(text string)
@@ -138,12 +138,8 @@ func initializeSpinner(ows *outputwriterspinner) OutputWriterSpinner {
 			spinner.WithWriter(ows.out),
 			spinner.WithFinalMSG(ows.spinnerFinalText),
 			spinner.WithSuffix(fmt.Sprintf(" %s", ows.spinnerText)),
+			spinner.WithColor("bold"),
 		)
-
-		// If the colors cannot be assigned to the spinner, we do not want to throw and error
-		// as spinner will use default coloring. Note this color scheme is only applicable to spinner object
-		// and not to the text we display along with the spinner object
-		_ = ows.spinner.Color("bgBlack", "bold", "fgWhite")
 
 		// Start the spinner only if attached to terminal
 		attachedToTerminal := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
@@ -154,20 +150,20 @@ func initializeSpinner(ows *outputwriterspinner) OutputWriterSpinner {
 	return ows
 }
 
-// RenderWithSpinner will stop spinner and render the output
+// RenderWithSpinner stops the running spinner instance, displays FinalText if set, then renders the output
 //
 // Deprecated: RenderWithSpinner is being deprecated in favor of Render.
 func (ows *outputwriterspinner) RenderWithSpinner() {
 	ows.Render()
 }
 
-// Render will stop spinner and render the output
+// Render stops the running spinner instance, displays FinalText if set, then renders the output
 func (ows *outputwriterspinner) Render() {
 	ows.StopSpinner()
 	ows.outputwriter.Render()
 }
 
-// StartSpinner start the spinner instance and renders the spinnerText
+// StartSpinner starts the spinner instance, showing the spinnerText
 func (ows *outputwriterspinner) StartSpinner() {
 	attachedToTerminal := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 	if ows.spinner != nil && !ows.spinner.Active() && attachedToTerminal {
@@ -175,7 +171,7 @@ func (ows *outputwriterspinner) StartSpinner() {
 	}
 }
 
-// StopSpinner stops the running spinner instance and renders FinalText if set
+// StopSpinner stops the running spinner instance, displays FinalText if set
 func (ows *outputwriterspinner) StopSpinner() {
 	if ows.spinner != nil && ows.spinner.Active() {
 		ows.spinner.Stop()

--- a/component/output_spinner_test.go
+++ b/component/output_spinner_test.go
@@ -59,31 +59,34 @@ func TestNewOutputWriterSpinnerWithOptions(t *testing.T) {
 	assert.NotNil(t, ows)
 }
 
-func TestNewOutputWriterSpinnerWithSpinnerOptions(t *testing.T) {
+func TestNewOutputWriterSpinner(t *testing.T) {
 	output := bytes.Buffer{}
 	spinnerText := loading
 	headers := []string{"Name", "Age"}
 
-	// Test creating an OutputWriterSpinner with spinner options and a spinner
-	opts := OutputWriterSpinnerOptions{
-		OutputWriterOptions: []OutputWriterOption{WithAutoStringify()},
-		SpinnerOptions:      []OutputWriterSpinnerOption{WithSpinnerFinalText("Done!", log.LogTypeSUCCESS)},
-	}
-	ows, err := NewOutputWriterSpinnerWithSpinnerOptions(&output, "table", spinnerText, true, opts, headers...)
+	ows, err := NewOutputWriterSpinner(WithOutputStream(&output),
+		WithOutputFormat(TableOutputType),
+		WithSpinnerText(spinnerText),
+		WithSpinnerStarted(),
+		WithOutputWriterOptions(WithAutoStringify()),
+		WithHeaders(headers...),
+		WithSpinnerFinalText("Done!", log.LogTypeSUCCESS))
 	assert.NoError(t, err)
 	assert.NotNil(t, ows)
 
-	// Test creating an OutputWriterSpinner with spinner options without a spinner
-	opts = OutputWriterSpinnerOptions{
-		SpinnerOptions: []OutputWriterSpinnerOption{WithSpinnerFinalText("Done!", log.LogTypeSUCCESS)},
-	}
-	ows, err = NewOutputWriterSpinnerWithSpinnerOptions(&output, "table", spinnerText, false, opts, headers...)
+	ows, err = NewOutputWriterSpinner(WithOutputStream(&output),
+		WithOutputFormat(TableOutputType),
+		WithSpinnerText(spinnerText),
+		WithHeaders(headers...),
+		WithSpinnerFinalText("Done!", log.LogTypeSUCCESS))
 	assert.NoError(t, err)
 	assert.NotNil(t, ows)
 
-	// Test creating an OutputWriterSpinner with unsupported output format
-	opts = OutputWriterSpinnerOptions{}
-	ows, err = NewOutputWriterSpinnerWithSpinnerOptions(&output, "unsupported", spinnerText, true, opts, headers...)
+	ows, err = NewOutputWriterSpinner(WithOutputStream(&output),
+		WithOutputFormat("unsupported"),
+		WithSpinnerText(spinnerText),
+		WithSpinnerStarted(),
+		WithHeaders(headers...))
 	assert.NoError(t, err)
 	assert.NotNil(t, ows)
 }


### PR DESCRIPTION
### What this PR does / why we need it

- Refactors Spinner component to eliminate use of parameters and uses `OutputWriterSpinnerOptions` to create Spinner
- Add `SetText` and `StartSpinner` APIs

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Manual Testing

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
`NewOutputWriterSpinnerWithOptions` is being deprecated in favor of the more flexible `NewOutputWriterSpinner` implementation.

`NewOutputWriterSpinner` now supports `SetText` and `StartSpinner` APIs.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
