### PR TITLE
Augment PluginDescription with fields used in remapping commands

### DIFF
--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -62,14 +62,16 @@ func TestAddCommands(t *testing.T) {
 	assert := assert.New(t)
 
 	descriptor := PluginDescriptor{
-		Name:        "Test Plugin",
-		Target:      types.TargetGlobal,
-		Description: "Description of the plugin",
-		Version:     "v1.2.3",
-		BuildSHA:    "cafecafe",
-		Group:       "TestGroup",
-		DocURL:      "https://docs.example.com",
-		Hidden:      false,
+		Name:                 "dummy",
+		Target:               types.TargetK8s,
+		Description:          "Description of the plugin",
+		Version:              "v1.2.3",
+		BuildSHA:             "cafecafe",
+		Group:                "TestGroup",
+		DocURL:               "https://docs.example.com",
+		Hidden:               false,
+		InvokedAs:            []string{"dummy2"},
+		SupportedContextType: []types.ContextType{types.ContextTypeTanzu},
 	}
 
 	cmd, err := NewPlugin(&descriptor)

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -104,4 +104,19 @@ type PluginDescriptor struct {
 
 	// DefaultFeatureFlags is default featureflags to be configured if missing when invoking plugin
 	DefaultFeatureFlags map[string]bool `json:"defaultFeatureFlags,omitempty" yaml:"defaultFeatureFlags,omitempty"`
+
+	// InvokedAs provides a specific mapping to how any command provided by this plugin should be invoked as.
+	// If unset (which is equivalent to setting it to ["<PluginDescriptor.Name>"]), commands will typically be invocable
+	// with the Tanzu CLI using "<PluginDescriptor.Name> <command name> commandargs...."
+	// Can be used to specify additional levels in the command hierarchy via values with space-delimited parts.
+	// e.g. ["operations cluster"] implies plugin's command foo will be invoked by the Tanzu CLI using
+	// 'tanzu operations cluster foo...'
+	// EXPERIMENTAL: subject to change prior to the next official minor release
+	InvokedAs []string `json:"invokedAs,omitempty" yaml:"invokedAs,omitempty"`
+
+	// SupportedContextType specifies one or more ContextType that this plugin will specifically apply to.
+	// When no context of matching type is active, the command tree specified by this plugin should be omitted.
+	// When unset, the plugin does not define any specific opinions on this aspect.
+	// EXPERIMENTAL: subject to change prior to the next official minor release
+	SupportedContextType []types.ContextType `json:"supportedContextType,omitempty" yaml:"supportedContextType,omitempty"`
 }


### PR DESCRIPTION
### What this PR does / why we need it

Introduce two additional fields in the PluginDescriptor, InvokedAs and SupportedContexttype, marked experimental are added to support plugin level remapping

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Introduce two experimental fields in the PluginDescriptor, InvokedAs and SupportedContexttype to support plugin-level remapping
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
