### PR TITLE
Set command displayname annotation when command is mapped

### DIFF
--- a/plugin/root.go
+++ b/plugin/root.go
@@ -4,10 +4,30 @@
 package plugin
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
+func getPluginInvokedAs(descriptor *PluginDescriptor) string {
+	var invokedAsString string
+	name := descriptor.Name
+
+	if len(descriptor.InvokedAs) != 0 {
+		invokedAsString = strings.TrimSpace(descriptor.InvokedAs[0])
+	}
+
+	if invokedAsString != "" {
+		cmdParts := strings.Split(invokedAsString, " ")
+		name = cmdParts[len(cmdParts)-1]
+	}
+
+	return name
+}
+
 func newRootCmd(descriptor *PluginDescriptor) *cobra.Command {
+	cmdName := getPluginInvokedAs(descriptor)
+
 	cmd := &cobra.Command{
 		Use:     descriptor.Name,
 		Short:   descriptor.Description,
@@ -26,7 +46,8 @@ func newRootCmd(descriptor *PluginDescriptor) *cobra.Command {
 			HiddenDefaultCmd: true,
 		},
 		Annotations: map[string]string{
-			"target": string(descriptor.Target),
+			"target":                           string(descriptor.Target),
+			cobra.CommandDisplayNameAnnotation: cmdName,
 		},
 	}
 	cobra.AddTemplateFuncs(TemplateFuncs)

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -132,6 +132,14 @@ func formatHelpFooter(cmd *cobra.Command, target types.Target) string {
 	return footer.String()
 }
 
+func aliasesWithMappedName(cmd *cobra.Command) string {
+	cmdName := cmd.Name()
+	if v, ok := cmd.Annotations[cobra.CommandDisplayNameAnnotation]; ok {
+		cmdName = v
+	}
+	return strings.Join(append([]string{cmdName}, cmd.Aliases...), ", ")
+}
+
 func printHelp(cmd *cobra.Command) string {
 	var output strings.Builder
 	target := types.StringToTarget(cmd.Annotations["target"])
@@ -140,7 +148,7 @@ func printHelp(cmd *cobra.Command) string {
 
 	if len(cmd.Aliases) > 0 {
 		output.WriteString("\n" + component.Bold(aliasesStr) + "\n")
-		output.WriteString(indentStr + cmd.NameAndAliases() + "\n")
+		output.WriteString(indentStr + aliasesWithMappedName(cmd) + "\n")
 	}
 
 	if cmd.HasExample() {

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -71,13 +71,14 @@ func SampleTestPlugin(t *testing.T, target types.Target) *Plugin {
 	}
 
 	var descriptor = PluginDescriptor{
-		Name:        "test",
+		Name:        "testNotUserVisible",
 		Target:      target,
 		Aliases:     []string{"t"},
 		Description: "Test the CLI",
 		Group:       AdminCmdGroup,
 		Version:     "v1.1.0",
 		BuildSHA:    "1234567",
+		InvokedAs:   []string{"test"},
 	}
 
 	var local string
@@ -140,6 +141,12 @@ func TestGlobalTestPluginCommandHelpText(t *testing.T) {
 
 	got := string(<-c)
 
+	// note: reference to the unmapped name, as in
+	//
+	// '-h, --help         help for testNotUserVisible'
+	//
+	// is a known bug in cobra 1.8.0 that should be fixed in the next patch or
+	// minor release
 	expected := `Test the CLI
 
 Usage:
@@ -157,7 +164,7 @@ Available Commands:
 
 Flags:
   -e, --env string   env to test
-  -h, --help         help for test
+  -h, --help         help for testNotUserVisible
 
 Additional help topics:
   test plugin        Plugin tests
@@ -218,7 +225,7 @@ Available Commands:
 
 Flags:
   -e, --env string   env to test
-  -h, --help         help for test
+  -h, --help         help for testNotUserVisible
 
 Additional help topics:
   test plugin        Plugin tests
@@ -279,7 +286,7 @@ Available Commands:
 
 Flags:
   -e, --env string   env to test
-  -h, --help         help for test
+  -h, --help         help for testNotUserVisible
 
 Additional help topics:
   test plugin        Plugin tests


### PR DESCRIPTION
### What this PR does / why we need it

When a plugin is mapped via PluginDescriptor.InvokedAs, set the command display name annotation introduced in cobra 1.8.0. This enables the runtime to construct more accurate usage text based on the the mapped command name instead. 

In the future the mapping could also be provided out-of-band by the caller binary (Tanzu CLI).

Also, updated aliases computation in the usage output to take advantage of said annotation.

Behavior of the toplevel and command-specific help of plugin (e.g. appsv2 here, mapped to apps) built with runtime ..

Before the change:

```
tanzu-cli (main)> tanzu apps
Application on Kubernetes

Usage:
  tanzu appsv2 [command]
  tanzu kubernetes appsv2 [command]

Aliases:
  appsv2, app

Available Commands:
  apply                Apply the app from the files in the filepath
  cluster-supply-chain patterns for building and configuring workloads
...

Flags:
      --context name      name of the kubeconfig context to use (default is current-context defined by kubeconfig)
  -h, --help              help for appsv2
      --kubeconfig file   kubeconfig file (default is $HOME/.kube/config)
      --no-color          deactivate color, bold, animations, and emoji output
  -v, --verbose int32     number for the log level verbosity (default 1)

Use "tanzu appsv2 [command] --help" for more information about a command.
Use "tanzu kubernetes appsv2 [command] --help" for more information about a command.
tanzu-cli (main)> tanzu apps apply
Usage:
  tanzu appsv2 apply [flags]
  tanzu kubernetes appsv2 apply [flags]

Examples:
  tanzu appsv2 apply NAME --file .

Flags:
  -f, --file strings            files or directories where the manifest of the resources to be created or updated. Use value "-" to read from stdin (default [.])
  -h, --help                    help for apply
...

Global Flags:
      --context name      name of the kubeconfig context to use (default is current-context defined by kubeconfig)
 ...
```

After the change:
```
tanzu-cli (main)> tanzu apps
Application on Kubernetes

Usage:
  tanzu apps [command]
  tanzu kubernetes apps [command]

Aliases:
  apps, app

Available Commands:
  apply                Apply the app from the files in the filepath
  cluster-supply-chain patterns for building and configuring workloads
  delete               Delete the app and all the resources associated with it.
 ...

Flags:
      --context name      name of the kubeconfig context to use (default is current-context defined by kubeconfig)
  -h, --help              help for appsv2
      --kubeconfig file   kubeconfig file (default is $HOME/.kube/config)
      --no-color          deactivate color, bold, animations, and emoji output
  -v, --verbose int32     number for the log level verbosity (default 1)

Use "tanzu apps [command] --help" for more information about a command.
Use "tanzu kubernetes apps [command] --help" for more information about a command.
tanzu-cli (main)> tanzu apps apply
Usage:
  tanzu apps apply [flags]
  tanzu kubernetes apps apply [flags]

Examples:
  tanzu appsv2 apply NAME --file .

Flags:
  -f, --file strings            files or directories where the manifest of the resources to be created or updated. Use value "-" to read from stdin (default [.])
  -h, --help                    help for apply
...
..
```




### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Updated unit tests. See description above for additional testing done.

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Set command displayname annotation when command is mapped
```

NOTE: there is a known issue with the default -h flag being described using the unmapped name. This a known issue in cobra 1.8.0 that is expected to be fixed in an upcoming release.

There are still some instances where the unmapped name is exposed (e.g. in the example output). This requires changes in the plugin's implementation to also account for the mapping.

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
