### PR TITLE
Add support for dynamic columns with the OutputWriter's `TableOutputType` output format

### DIFF
--- a/component/README.md
+++ b/component/README.md
@@ -61,7 +61,7 @@ func main() {
 
 ## Output Writer Component
 
-This package provides a way to write output to different formats. It defines the `OutputWriter` interface which consists of `SetKeys`, `AddRow`, and `Render` methods.
+This package provides a way to write output to different formats. It defines the `OutputWriter` interface which consists of `SetKeys`, `MarkDynamicKeys`, `AddRow`, and `Render` methods.
 
 ### How to use
 

--- a/component/output_spinner.go
+++ b/component/output_spinner.go
@@ -80,6 +80,14 @@ func WithHeaders(headers ...string) OutputWriterSpinnerOption {
 	}
 }
 
+// WithDynamicHeaders sets the headers as dynamic and only shows the column
+// if at least one row is non empty for the specified header
+func WithDynamicHeaders(dynamicHeaders ...string) OutputWriterSpinnerOption {
+	return func(ows *outputwriterspinner) {
+		ows.dynamicKeys = dynamicHeaders
+	}
+}
+
 // WithOutputFormat sets output format for the OutputWriterSpinner component
 func WithOutputFormat(outputFormat OutputType) OutputWriterSpinnerOption {
 	return func(ows *outputwriterspinner) {


### PR DESCRIPTION
### What this PR does / why we need it

- Add support for dynamic columns with the OutputWriter's `TableOutputType` output format

- Example usage:
```
outputPluginWriter := component.NewOutputWriterWithOptions(writer, component.TableOutputType, []component.OutputWriterOption{})

outputPluginWriter.SetKeys("Name", "Description", "Target", "Installed", "Recommended", "Status")
outputPluginWriter.MarkDynamicKeys("Recommended")  // Marking this column as dynamic so that it will only be shown if at least one row is non-empty
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Added unit test

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support for dynamic columns with the OutputWriter's `TableOutputType` output format
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
