### PR TITLE
Update SetTanzuContextActiveResource API and GetTanzuContextActiveResource to use Project ID along with Project Name

### DIFF
--- a/config/tanzu_context.go
+++ b/config/tanzu_context.go
@@ -22,6 +22,7 @@ import (
 const (
 	OrgIDKey            = "tanzuOrgID"
 	ProjectNameKey      = "tanzuProjectName"
+	ProjectIDKey        = "tanzuProjectID"
 	SpaceNameKey        = "tanzuSpaceName"
 	ClusterGroupNameKey = "tanzuClusterGroupName"
 )
@@ -39,6 +40,8 @@ type ResourceInfo struct {
 	OrgID string
 	// ProjectName name of the Project
 	ProjectName string
+	// ProjectID ID of the Project.
+	ProjectID string
 	// SpaceName name of the Space
 	SpaceName string
 	// ClusterGroupName name of the ClusterGroup
@@ -249,11 +252,11 @@ func updateKubeconfigServerURL(kc *kubeconfig.Config, cliContext *configtypes.Co
 // Pre-reqs: project and space/clustergroup names should be valid
 //
 // Note: To set
-//   - a space as active resource, both project and space names are required
-//   - a clustergroup as active resource, both project and clustergroup names are required
-//   - a project as active resource, only project name is required (space should be empty string)
-//   - org as active resource, project, space and clustergroup names should be empty strings
-func SetTanzuContextActiveResource(contextName string, resourceInfo ResourceInfo, opts ...CommandOptions) error {
+//   - a space as active resource, both project,projectID and space names are required
+//   - a clustergroup as active resource, both project,projectID and clustergroup names are required
+//   - a project as active resource, only project name and project ID are required (space should be empty string)
+//   - org as active resource, project name, project ID, space and clustergroup names should be empty strings
+func SetTanzuContextActiveResource(contextName string, resourceInfo ResourceInfo, opts ...CommandOptions) error { //nolint:gocritic
 	// For now, the implementation expects env var TANZU_BIN to be set and
 	// pointing to the core CLI binary used to invoke setting the active Tanzu resource.
 
@@ -268,7 +271,13 @@ func SetTanzuContextActiveResource(contextName string, resourceInfo ResourceInfo
 	}
 
 	altCommandArgs := []string{customCommandName}
-	args := []string{"context", "update", "tanzu-active-resource", contextName, "--project", resourceInfo.ProjectName}
+	args := []string{"context", "update", "tanzu-active-resource", contextName}
+	if resourceInfo.ProjectName != "" {
+		args = append(args, "--project", resourceInfo.ProjectName)
+	}
+	if resourceInfo.ProjectID != "" {
+		args = append(args, "--project-id", resourceInfo.ProjectID)
+	}
 	if resourceInfo.SpaceName != "" {
 		args = append(args, "--space", resourceInfo.SpaceName)
 	}
@@ -308,6 +317,7 @@ func GetTanzuContextActiveResource(contextName string) (*ResourceInfo, error) {
 	activeResourceInfo := &ResourceInfo{
 		OrgID:            stringValue(ctx.AdditionalMetadata[OrgIDKey]),
 		ProjectName:      stringValue(ctx.AdditionalMetadata[ProjectNameKey]),
+		ProjectID:        stringValue(ctx.AdditionalMetadata[ProjectIDKey]),
 		SpaceName:        stringValue(ctx.AdditionalMetadata[SpaceNameKey]),
 		ClusterGroupName: stringValue(ctx.AdditionalMetadata[ClusterGroupNameKey]),
 	}


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the SetTanzuContextActiveResource() API to accept the Project ID along with Project Name to set a Project as active in the Tanzu context. The GetTanzuContextActiveResource API is also updated to return the Project ID along with Project Name for an active project
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Tested with below Unit test and made sure the CLI context is updated with Project ID and Project Name.
```
func TestSetTanzuContextActvResource(t *testing.T) {
 
    os.Setenv("TANZU_BIN", "/Users/pkalle/projects/tanzu-cli/artifacts/darwin/amd64/cli/core/v1.3.0-dev/tanzu-cli-darwin_amd64")
    resInfo := ResourceInfo{
       OrgID: "b1d48027-bb69-4a56-a5b8-e941ef29fa4b",
       ProjectName: "unitel-project-ab",
       ProjectID:   "6d1e2d22-5785-43d7-a6da-1102d7aba83b",
       SpaceName: "store-dev",
    }
    err := SetTanzuContextActiveResource("prem-ucp-intg-lat", resInfo)
    assert.NoError(t, err)
}
```

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update SetTanzuContextActiveResource API and GetTanzuContextActiveResource to use Project ID along with Project Name
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information
This PR depends on  tanzu-cli changes (TODO) to update the `tanzu context update tanzu-active-resource ` command to accept the project-id. 
#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
