### PR TITLE
Update GetKubeconfigForContext API to accept Project ID instead of Project Name

### DIFF
--- a/config/tanzu_context.go
+++ b/config/tanzu_context.go
@@ -21,6 +21,7 @@ import (
 // keys to Context's AdditionalMetadata map
 const (
 	OrgIDKey            = "tanzuOrgID"
+	OrgNameKey          = "tanzuOrgName"
 	ProjectNameKey      = "tanzuProjectName"
 	ProjectIDKey        = "tanzuProjectID"
 	SpaceNameKey        = "tanzuSpaceName"
@@ -108,8 +109,8 @@ func runCommand(commandPath string, args []string, opts *cmdOptions) (bytes.Buff
 
 // resourceOptions specifies the resources to use for kubeconfig generation
 type resourceOptions struct {
-	// projectName name of the Project
-	projectName string
+	// projectID UUID of the Project
+	projectID string
 	// spaceName name of the Space
 	spaceName string
 	// clusterGroupName name of the ClusterGroup
@@ -120,9 +121,9 @@ type resourceOptions struct {
 
 type ResourceOptions func(o *resourceOptions)
 
-func ForProject(projectName string) ResourceOptions {
+func ForProject(projectID string) ResourceOptions {
 	return func(o *resourceOptions) {
-		o.projectName = strings.TrimSpace(projectName)
+		o.projectID = strings.TrimSpace(projectID)
 	}
 }
 func ForSpace(spaceName string) ResourceOptions {
@@ -143,38 +144,38 @@ func ForCustomPath(customPath string) ResourceOptions {
 
 // GetKubeconfigForContext returns the kubeconfig for any arbitrary kubernetes resource or Tanzu resource in the Tanzu object hierarchy
 // referred by the Tanzu context
-// Pre-reqs: project, space and clustergroup names should be valid for retreiving Kubeconfig of Tanzu context
+// Pre-reqs: projectID, space and clustergroup names should be valid for retrieving Kubeconfig of Tanzu context
 //
 // Notes:
 //
 // Use Case 1: Get the kubeconfig pointing to Tanzu org
-// -> projectName        = ""
+// -> projectID          = ""
 // -> spaceName          = ""
 // -> clusterGroupName   = ""
 // ex: kubeconfig's cluster.server URL : https://endpoint/org/orgid
 //
 // Use Case 2: Get the kubeconfig pointing to Tanzu project
-// -> projectName        = "PROJECTNAME"
+// -> projectID          = "PROJECTNAME"
 // -> spaceName          = ""
 // -> clusterGroupName   = ""
-// ex: kubeconfig's cluster.server URL : https://endpoint/org/orgid/project/<projectName>
+// ex: kubeconfig's cluster.server URL : https://endpoint/org/orgid/project/<projectID>
 //
 // Use Case 3: Get the kubeconfig pointing to Tanzu space
-// -> projectName        = "PROJECTNAME"
+// -> projectID          = "PROJECTID"
 // -> spaceName          = "SPACENAME"
 // -> clusterGroupName   = ""
-// ex: kubeconfig's cluster.server URL : https://endpoint/org/orgid/project/<projectName>/space/<spaceName>
+// ex: kubeconfig's cluster.server URL : https://endpoint/org/orgid/project/<projectID>/space/<spaceName>
 //
 // Use Case 4: Get the kubeconfig pointing to Tanzu clustergroup
-// -> projectName        = "PROJECTNAME"
+// -> projectID          = "PROJECTID"
 // -> spaceName          = ""
 // -> clusterGroupName   = "CLUSTERGROUPNAME"
-// ex: kubeconfig's cluster.server URL : https://endpoint/org/orgid/project/<projectName>/clustergroup/<clustergroupName>
+// ex: kubeconfig's cluster.server URL : https://endpoint/org/orgid/project/<projectID>/clustergroup/<clustergroupName>
 //
 // Note: Specifying `spaceName` and `clusterGroupName` both at the same time is incorrect input.
 //
 // Use Case 5: Get the kubeconfig pointing to Kubernetes context
-// -> projectName        = ""
+// -> projectID          = ""
 // -> spaceName          = ""
 // -> clusterGroupName   = ""
 func GetKubeconfigForContext(contextName string, opts ...ResourceOptions) ([]byte, error) {
@@ -225,10 +226,10 @@ func prepareClusterServerURL(context *configtypes.Context, rOptions *resourceOpt
 		return fmt.Sprintf("%s/%s", strings.TrimRight(context.GlobalOpts.Endpoint, "/"), strings.TrimLeft(rOptions.customPath, "/"))
 	}
 
-	if rOptions.projectName == "" {
+	if rOptions.projectID == "" {
 		return serverURL
 	}
-	serverURL = serverURL + "/project/" + rOptions.projectName
+	serverURL = serverURL + "/project/" + rOptions.projectID
 
 	if rOptions.spaceName != "" {
 		return serverURL + "/space/" + rOptions.spaceName

--- a/config/tanzu_context_test.go
+++ b/config/tanzu_context_test.go
@@ -126,7 +126,7 @@ func TestGetKubeconfigForContext(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test getting the kubeconfig for a space within a project
-	kubeconfigBytes, err := GetKubeconfigForContext(c.Name, ForProject("project1"), ForSpace("space1"))
+	kubeconfigBytes, err := GetKubeconfigForContext(c.Name, ForProject("project1-id"), ForSpace("space1"))
 	assert.NoError(t, err)
 	c, err = GetContext("test-tanzu")
 	assert.NoError(t, err)
@@ -134,39 +134,39 @@ func TestGetKubeconfigForContext(t *testing.T) {
 	err = yaml.Unmarshal(kubeconfigBytes, &kc)
 	assert.NoError(t, err)
 	cluster := kubeconfig.GetCluster(&kc, "tanzu-cli-mytanzu/current")
-	assert.Equal(t, cluster.Cluster.Server, c.ClusterOpts.Endpoint+"/project/project1/space/space1")
+	assert.Equal(t, cluster.Cluster.Server, c.ClusterOpts.Endpoint+"/project/project1-id/space/space1")
 
 	// Test getting the kubeconfig for a project
-	kubeconfigBytes, err = GetKubeconfigForContext(c.Name, ForProject("project2"))
+	kubeconfigBytes, err = GetKubeconfigForContext(c.Name, ForProject("project2-id"))
 	assert.NoError(t, err)
 	c, err = GetContext("test-tanzu")
 	assert.NoError(t, err)
 	err = yaml.Unmarshal(kubeconfigBytes, &kc)
 	assert.NoError(t, err)
 	cluster = kubeconfig.GetCluster(&kc, "tanzu-cli-mytanzu/current")
-	assert.Equal(t, cluster.Cluster.Server, c.ClusterOpts.Endpoint+"/project/project2")
+	assert.Equal(t, cluster.Cluster.Server, c.ClusterOpts.Endpoint+"/project/project2-id")
 
 	// Test getting the kubeconfig for a clustergroup within a project
-	kubeconfigBytes, err = GetKubeconfigForContext(c.Name, ForProject("project2"), ForClusterGroup("clustergroup1"))
+	kubeconfigBytes, err = GetKubeconfigForContext(c.Name, ForProject("project2-id"), ForClusterGroup("clustergroup1"))
 	assert.NoError(t, err)
 	c, err = GetContext("test-tanzu")
 	assert.NoError(t, err)
 	err = yaml.Unmarshal(kubeconfigBytes, &kc)
 	assert.NoError(t, err)
 	cluster = kubeconfig.GetCluster(&kc, "tanzu-cli-mytanzu/current")
-	assert.Equal(t, cluster.Cluster.Server, c.ClusterOpts.Endpoint+"/project/project2/clustergroup/clustergroup1")
+	assert.Equal(t, cluster.Cluster.Server, c.ClusterOpts.Endpoint+"/project/project2-id/clustergroup/clustergroup1")
 
 	// Test getting the kubeconfig with incorrect resource combination (request kubeconfig for space and clustergroup)
 	c, err = GetContext("test-tanzu")
 	assert.NoError(t, err)
-	_, err = GetKubeconfigForContext(c.Name, ForProject("project2"), ForSpace("space1"), ForClusterGroup("clustergroup1"))
+	_, err = GetKubeconfigForContext(c.Name, ForProject("project2-id"), ForSpace("space1"), ForClusterGroup("clustergroup1"))
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "incorrect resource options provided. Both space and clustergroup are set but only one can be set")
 
 	// Test getting the kubeconfig for an arbitrary Tanzu resource for non Tanzu context
 	tmcCtx, err := GetContext("test-tmc")
 	assert.NoError(t, err)
-	_, err = GetKubeconfigForContext(tmcCtx.Name, ForProject("project2"))
+	_, err = GetKubeconfigForContext(tmcCtx.Name, ForProject("project2-id"))
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "context must be of type: tanzu or kubernetes")
 


### PR DESCRIPTION
### What this PR does / why we need it

This PR updates `GetKubeconfigForContext` API  logic to use/accept Project ID instead of Project Name

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update GetKubeconfigForContext API to accept Project ID instead of Project Name
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
