### PR TITLE
Extend plugin mapping to command-level remapping (older)

### DIFF
--- a/plugin/invoke_context.go
+++ b/plugin/invoke_context.go
@@ -1,0 +1,49 @@
+// Copyright 2024 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"os"
+	"strings"
+)
+
+// InvocationContext provides details regarding how a plugin's command is being
+// called by the Tanzu CLI. These details allow the plugin to, among other things,
+// construct proper help information, and learn if the command being invoked
+// is done via a command-level mapping or not.
+type InvocationContext struct {
+	// invokedGroup is a space-delimited portion of the Tanzu CLI command
+	// invocation between the CLI binary and the command name itself.
+	// Empty when invoking a top-level command, e.g. "tanzu apply".
+	invokedGroup string
+
+	// invokedCommand is the name of the command in a Tanzu CLI command invocation
+	invokedCommand string
+
+	// sourceCommandPath is a space-delimited path relative to the plugin's
+	// root command of the command being invoked.
+	// This value is empty when the CLI command invoked is mapped to the
+	// plugin's root command,
+	sourceCommandPath string
+}
+
+func (ic *InvocationContext) String() string {
+	return strings.TrimSpace(ic.invokedGroup + " " + ic.invokedCommand)
+}
+
+func GetInvocationContext() *InvocationContext {
+	invokedGroup := os.Getenv("TANZU_CLI_INVOKED_GROUP")
+	invokedCommand := os.Getenv("TANZU_CLI_INVOKED_COMMAND")
+	sourceCommandPath := os.Getenv("TANZU_CLI_COMMAND_MAPPED_FROM")
+
+	if invokedGroup != "" || invokedCommand != "" {
+		return &InvocationContext{
+			invokedGroup:      invokedGroup,
+			invokedCommand:    invokedCommand,
+			sourceCommandPath: sourceCommandPath,
+		}
+	}
+
+	return nil
+}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -70,8 +70,22 @@ func TestAddCommands(t *testing.T) {
 		Group:                "TestGroup",
 		DocURL:               "https://docs.example.com",
 		Hidden:               false,
-		InvokedAs:            []string{"dummy2"},
 		SupportedContextType: []types.ContextType{types.ContextTypeTanzu},
+		CommandMap: []CommandMapEntry{
+			CommandMapEntry{
+				DestinationCommandPath: "dummy2",
+			},
+			CommandMapEntry{
+				SourceCommandPath:      "delete",
+				DestinationCommandPath: "delete",
+				Description:            "Delete the dummy and all the related resources",
+			},
+			CommandMapEntry{
+				SourceCommandPath:      "deeper delete2",
+				DestinationCommandPath: "deepdel2",
+				Description:            "Delete a dummy, much deeply",
+			},
+		},
 	}
 
 	cmd, err := NewPlugin(&descriptor)

--- a/plugin/root.go
+++ b/plugin/root.go
@@ -4,22 +4,17 @@
 package plugin
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 )
 
 func getPluginInvokedAs(descriptor *PluginDescriptor) string {
-	var invokedAsString string
 	name := descriptor.Name
 
-	if len(descriptor.InvokedAs) != 0 {
-		invokedAsString = strings.TrimSpace(descriptor.InvokedAs[0])
-	}
-
-	if invokedAsString != "" {
-		cmdParts := strings.Split(invokedAsString, " ")
-		name = cmdParts[len(cmdParts)-1]
+	for _, entry := range descriptor.CommandMap {
+		// this is a plugin-level map
+		if entry.SourceCommandPath == "" {
+			name = entry.DestinationCommandPath
+		}
 	}
 
 	return name

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -56,6 +56,26 @@ const (
 	ExtraCmdGroup CmdGroup = "Extra"
 )
 
+// CommandMapEntry describes how a command or subcommand should be remapped in the Tanzu CLI
+type CommandMapEntry struct {
+	// SourceCommandPath is a space-delimited path to the command relative to
+	// the root Command of this plugin, with the root Command's path being ""
+	SourceCommandPath string `json:"srcPath" yaml:"srcPath"`
+	// DestinationCommandPath is a space-delimited path to the command relative
+	// to the root Command of the Tanzu CLI
+	DestinationCommandPath string `json:"dstPath" yaml:"dstPath"`
+	// By default, the command previously situated at the
+	// DestinationCommandPath of the Tanzu CLI, if exist, will be the one
+	// overridden by this entry. If this mapping attempt in intended to
+	// override another part of the Tanzu CLI command tree, the override path should be used.
+	Overrides string `json:"overrides" yaml:"overrides"`
+	// Required when remapping a subcommand of this plugin outside of the
+	// plugin's command tree (e.g. whe elevating a subcommand to a top level
+	// command of the Tanzu CLI). This enables the CLI to provide better help
+	// information about the remapped command.
+	Description string `json:"description" yaml:"description"`
+}
+
 // PluginDescriptor describes a plugin binary.
 type PluginDescriptor struct {
 	// Name is the name of the plugin.
@@ -105,18 +125,15 @@ type PluginDescriptor struct {
 	// DefaultFeatureFlags is default featureflags to be configured if missing when invoking plugin
 	DefaultFeatureFlags map[string]bool `json:"defaultFeatureFlags,omitempty" yaml:"defaultFeatureFlags,omitempty"`
 
-	// InvokedAs provides a specific mapping to how any command provided by this plugin should be invoked as.
-	// If unset (which is equivalent to setting it to ["<PluginDescriptor.Name>"]), commands will typically be invocable
-	// with the Tanzu CLI using "<PluginDescriptor.Name> <command name> commandargs...."
-	// Can be used to specify additional levels in the command hierarchy via values with space-delimited parts.
-	// e.g. ["operations cluster"] implies plugin's command foo will be invoked by the Tanzu CLI using
-	// 'tanzu operations cluster foo...'
-	// EXPERIMENTAL: subject to change prior to the next official minor release
-	InvokedAs []string `json:"invokedAs,omitempty" yaml:"invokedAs,omitempty"`
-
 	// SupportedContextType specifies one or more ContextType that this plugin will specifically apply to.
 	// When no context of matching type is active, the command tree specified by this plugin should be omitted.
 	// When unset, the plugin does not define any specific opinions on this aspect.
 	// EXPERIMENTAL: subject to change prior to the next official minor release
 	SupportedContextType []types.ContextType `json:"supportedContextType,omitempty" yaml:"supportedContextType,omitempty"`
+
+	// CommandMap specifies one or more CommandMapEntry's and describes how one
+	// or more parts of the plugin's command tree will be remapped in the Tanzu CLI
+	// Empty when the plugin does not offer any specific mapping opinions.
+	// EXPERIMENTAL: subject to change prior to the next official minor release
+	CommandMap []CommandMapEntry `json:"commandMap,omitempty" yaml:"commandMap,omitempty"`
 }


### PR DESCRIPTION
Replaces InvokedAs field in the PluginDescriptor with a list of CommandMapEntry's that can provide additional mapping details. In particular it can specify a destination command path of the Tanzu CLI to map to a specific non root command path in the plugin.

Adds support for capturing the invocation "context" by consuming environment variables that are expected to be set by the Tanzu CLI.

Information in this context allows the plugin to construct proper Help information, and learn if the its command being invoked is done via a command-level mapping or not.

Updates the usage to provides better output when help is invoked on a command-level mapping.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
