### PR TITLE
Add null pointer checks in GetKubeconfigForContext API

### DIFF
--- a/config/clientconfig_test.go
+++ b/config/clientconfig_test.go
@@ -344,6 +344,35 @@ func TestEndpointFromContext(t *testing.T) {
 				},
 			},
 		},
+		// Test case for Kubernetes context type with missing cluster options
+		{
+			name: "Kubernetes Context with Missing Cluster Options",
+			ctx: &configtypes.Context{
+				Name:        "test-tmc",
+				ContextType: configtypes.ContextTypeK8s,
+			},
+			errStr: "invalid context. Required fields missing in the context",
+		},
+
+		// Test case for TMC context type with missing global options
+		{
+			name: "TMC Context with Missing Global Options",
+			ctx: &configtypes.Context{
+				Name:        "test-tmc",
+				ContextType: configtypes.ContextTypeTMC,
+			},
+			errStr: "invalid context. Required fields missing in the context",
+		},
+		// Test case for Tanzu context type with missing cluster options
+		{
+			name: "Tanzu Context with Missing Cluster Options",
+			ctx: &configtypes.Context{
+				Name:        "test-tmc",
+				ContextType: configtypes.ContextTypeTanzu,
+			},
+			errStr: "invalid context. Required fields missing in the context",
+		},
+
 		{
 			name: "failure",
 			ctx: &configtypes.Context{

--- a/config/contexts.go
+++ b/config/contexts.go
@@ -307,12 +307,22 @@ func RemoveActiveContext(contextType configtypes.ContextType) error {
 
 // EndpointFromContext retrieved the endpoint from the specified context
 func EndpointFromContext(s *configtypes.Context) (endpoint string, err error) {
+	missingFieldsErrMsg := "invalid context. Required fields missing in the context"
 	switch s.ContextType {
 	case configtypes.ContextTypeK8s:
+		if s.ClusterOpts == nil {
+			return endpoint, errors.New(missingFieldsErrMsg)
+		}
 		return s.ClusterOpts.Endpoint, nil
 	case configtypes.ContextTypeTMC:
+		if s.GlobalOpts == nil {
+			return endpoint, errors.New(missingFieldsErrMsg)
+		}
 		return s.GlobalOpts.Endpoint, nil
 	case configtypes.ContextTypeTanzu:
+		if s.ClusterOpts == nil {
+			return endpoint, errors.New(missingFieldsErrMsg)
+		}
 		return s.ClusterOpts.Endpoint, nil
 	default:
 		return endpoint, fmt.Errorf("unknown context type %q", s.ContextType)

--- a/config/tanzu_context.go
+++ b/config/tanzu_context.go
@@ -197,6 +197,10 @@ func GetKubeconfigForContext(contextName string, opts ...ResourceOptions) ([]byt
 		return nil, errors.Errorf("incorrect resource options provided. Both space and clustergroup are set but only one can be set")
 	}
 
+	if ctx.ClusterOpts == nil {
+		return nil, errors.Errorf("invalid context. context missing kubeconfig details")
+	}
+
 	kc, err := kubeconfig.ReadKubeConfig(ctx.ClusterOpts.Path)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read the Tanzu context kubeconfig")

--- a/config/tanzu_context_test.go
+++ b/config/tanzu_context_test.go
@@ -189,6 +189,19 @@ func TestGetKubeconfigForContext(t *testing.T) {
 	assert.NoError(t, err)
 	cluster = kubeconfig.GetCluster(&kc, "k8s-cluster")
 	assert.Equal(t, cluster.Cluster.Server, k8sCtx.ClusterOpts.Endpoint)
+
+	// Test if tanzu context ClusterOpts is set to nil
+	tanzuCtx, err = GetContext("test-tanzu")
+	assert.NoError(t, err)
+	// update context to remove clusterOtps
+	tanzuCtx.Name = "test-tanzu-withoutClusterOpts"
+	tanzuCtx.ClusterOpts = nil
+	err = AddContext(tanzuCtx, false)
+	assert.NoError(t, err)
+	_, err = GetKubeconfigForContext(tanzuCtx.Name)
+	assert.ErrorContains(t, err, "invalid context. context missing kubeconfig details")
+	err = DeleteContext(tanzuCtx.Name)
+	assert.NoError(t, err)
 }
 
 func TestGetTanzuContextActiveResource(t *testing.T) {


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds null pointer checks in APIs
Summary:
- Add null pointer checks in GetKubeconfigForContext API for ClusterOpts in context.
- Added null pointer checks in EndpointFromContext API as well

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
 Unit tests and CI
<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
