### PR TITLE
Update Spinner API with UnsetFinalText

### DIFF
--- a/component/output_spinner.go
+++ b/component/output_spinner.go
@@ -30,6 +30,8 @@ type OutputWriterSpinner interface {
 	// SetFinalText sets the spinner final text and prefix
 	// log indicator (log.LogTypeOUTPUT can be used for no prefix)
 	SetFinalText(finalText string, prefix log.LogType)
+	// UnSetFinalText unsets the spinner final text
+	UnSetFinalText()
 }
 
 // outputwriterspinner is our internal implementation.
@@ -210,6 +212,14 @@ func StopAllSpinners() {
 func (ows *outputwriterspinner) SetFinalText(finalText string, prefix log.LogType) {
 	if ows.spinner != nil {
 		ows.spinnerFinalText = fmt.Sprintf("%s%s", log.GetLogTypeIndicator(prefix), finalText)
+		spinner.WithFinalMSG(ows.spinnerFinalText)(ows.spinner)
+	}
+}
+
+// UnSetFinalText unsets the spinner final text if set
+func (ows *outputwriterspinner) UnSetFinalText() {
+	if ows.spinner != nil {
+		ows.spinnerFinalText = ""
 		spinner.WithFinalMSG(ows.spinnerFinalText)(ows.spinner)
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds a new Spinner API to unset the spinner's final text if it has already been set.

This new API helps to handle use cases where the final text needs to be unset. For example, if an error message has been set as the final text to display in case the command fails or is terminated, and the command ends up being successful, you may want to unset the error text as the final text and not display any text at the end.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
