### PR TITLE
Fix usage of commands involved in command-level mapping

### DIFF
--- a/plugin/invoke_context.go
+++ b/plugin/invoke_context.go
@@ -31,7 +31,7 @@ type InvocationContext struct {
 }
 
 func (ic *InvocationContext) CLIInvocationString() string {
-	return strings.TrimSpace(ic.invokedGroup + " " + ic.invokedCommand)
+	return buildInvocationString(ic.invokedGroup, ic.invokedCommand)
 }
 
 func (ic *InvocationContext) MappedSourceCommandPath() string {
@@ -48,14 +48,14 @@ func (ic *InvocationContext) InvokedGroupPath() string {
 
 // CLIInvocationStringForCommand returns the CLI invocation string when cmd was
 // invoked under this invocation context.
-// Invoking "tanzu + (the string returned) as a CLI command would equivalent to
-// the running of cmd with no arguments
+// Invoking "tanzu + (the string returned) as a CLI command would be equivalent to
+// executing cmd with no arguments
 func (ic *InvocationContext) CLIInvocationStringForCommand(cmd *cobra.Command) string {
-	hierarchy, err := hierarchyFromMappedCommand(cmd, ic.sourceCommandPath)
-	if err != nil {
-		return strings.TrimSpace(ic.invokedGroup + " " + ic.invokedCommand)
+	hierarchy, err := hierarchyFromMappedCommandPath(ic.sourceCommandPath, cmd)
+	if err != nil || len(hierarchy) == 0 {
+		return buildInvocationString(ic.invokedGroup, ic.invokedCommand)
 	}
-	return strings.TrimSpace(ic.invokedGroup+" "+ic.invokedCommand) + " " + strings.Join(hierarchy, " ")
+	return buildInvocationString(ic.invokedGroup, ic.invokedCommand, strings.Join(hierarchy, " "))
 }
 
 // GetInvocationContext returns information about how a Tanzu CLI command is

--- a/plugin/invoke_context_test.go
+++ b/plugin/invoke_context_test.go
@@ -1,0 +1,130 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
+)
+
+func SetupTestPlugin(t *testing.T) *Plugin {
+	var topCmd *cobra.Command
+
+	// build long Command chain to attach to the root command of the plugin
+	for i := 7; i >= 0; i-- {
+		cmdName := fmt.Sprintf("c%d", i)
+		cmd := &cobra.Command{
+			Use: cmdName,
+		}
+		if topCmd == nil {
+			topCmd = cmd
+		} else {
+			cmd.AddCommand(topCmd)
+			topCmd = cmd
+		}
+	}
+
+	var descriptor = PluginDescriptor{
+		Name:        "test",
+		Target:      types.TargetGlobal,
+		Aliases:     []string{"t"},
+		Description: "Test CLI invocation context",
+		Group:       AdminCmdGroup,
+		Version:     "v1.1.0",
+		BuildSHA:    "1234567",
+	}
+
+	p, err := NewPlugin(&descriptor)
+	assert.Nil(t, err)
+
+	p.AddCommands(
+		topCmd,
+	)
+
+	return p
+}
+
+func subCommandAtLevel(cmd *cobra.Command, level int) *cobra.Command {
+	curr := cmd
+	for l := 0; l <= level; l++ {
+		wantCommandName := fmt.Sprintf("c%d", l)
+		var found bool
+		for _, cmd := range curr.Commands() {
+			cname := cmd.Name()
+			//if cmd.Name() == wantCommandName {
+			if cname == wantCommandName {
+				curr = cmd
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
+	}
+	return curr
+}
+
+func TestInvocationContext(t *testing.T) {
+	defer func() {
+		os.Unsetenv("TANZU_CLI_COMMAND_MAPPED_FROM")
+		os.Unsetenv("TANZU_CLI_INVOKED_COMMAND")
+		os.Unsetenv("TANZU_CLI_INVOKED_GROUP")
+	}()
+
+	p := SetupTestPlugin(t)
+	assert.NotNil(t, p)
+
+	os.Setenv("TANZU_CLI_COMMAND_MAPPED_FROM", "c0 c1 c2 c3")
+	os.Setenv("TANZU_CLI_INVOKED_COMMAND", "To3")
+	os.Setenv("TANZU_CLI_INVOKED_GROUP", "jump")
+
+	ic := GetInvocationContext()
+	assert.NotNil(t, ic)
+
+	result := ic.MappedSourceCommandPath()
+	assert.Equal(t, "c0 c1 c2 c3", result)
+
+	result = ic.InvokedCommandName()
+	assert.Equal(t, "To3", result)
+
+	result = ic.InvokedGroupPath()
+	assert.Equal(t, "jump", result)
+
+	result = ic.CLIInvocationString()
+	assert.Equal(t, "jump To3", result)
+
+	// right at mapped command
+	cmd := subCommandAtLevel(p.Cmd, 3)
+	assert.NotNil(t, cmd)
+	result = ic.CLIInvocationStringForCommand(cmd)
+	assert.Equal(t, "jump To3", result)
+
+	// command not found below mapped command
+	cmd = subCommandAtLevel(p.Cmd, 2)
+	assert.NotNil(t, cmd)
+	result = ic.CLIInvocationStringForCommand(cmd)
+	assert.Equal(t, "jump To3", result)
+
+	// deeper command
+	cmd = subCommandAtLevel(p.Cmd, 5)
+	assert.NotNil(t, cmd)
+	result = ic.CLIInvocationStringForCommand(cmd)
+	assert.Equal(t, "jump To3 c4 c5", result)
+
+	// same command under different invocation context
+	os.Setenv("TANZU_CLI_COMMAND_MAPPED_FROM", "c0 c1")
+	os.Setenv("TANZU_CLI_INVOKED_COMMAND", "To1")
+	os.Setenv("TANZU_CLI_INVOKED_GROUP", "")
+	ic = GetInvocationContext()
+	assert.NotNil(t, ic)
+	result = ic.CLIInvocationStringForCommand(cmd)
+	assert.Equal(t, "To1 c2 c3 c4 c5", result)
+}

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -84,14 +84,14 @@ func useLineEx(cmd *cobra.Command, ic *InvocationContext) string {
 	}
 
 	// TODO(vuil) look into still incorporating relevant parts of UseLine into output
-	return ic.String()
+	return ic.CLIInvocationString()
 }
 
 func commandPathEx(cmd *cobra.Command, ic *InvocationContext) string {
 	if ic == nil || ic.sourceCommandPath == "" {
 		return cmd.CommandPath()
 	}
-	return ic.String()
+	return ic.CLIInvocationString()
 }
 
 // Helper to format the usage help section.

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -243,9 +243,20 @@ func formatHelpFooter(cmd *cobra.Command, target types.Target) string {
 
 func aliasesWithMappedName(cmd *cobra.Command) string {
 	cmdName := cmd.Name()
+	// if root cmd
 	if v, ok := cmd.Annotations[cobra.CommandDisplayNameAnnotation]; ok {
 		cmdName = v
+	} else {
+		ic := GetInvocationContext()
+		if ic != nil && ic.MappedSourceCommandPath() != "" {
+			hierarchy, err := hierarchyFromMappedCommandPath(ic.MappedSourceCommandPath(), cmd)
+			// cmd is actually the one being command-level mapped
+			if err == nil && len(hierarchy) == 0 {
+				cmdName = ic.InvokedCommandName()
+			}
+		}
 	}
+
 	return strings.Join(append([]string{cmdName}, cmd.Aliases...), ", ")
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

Among the changes
 - Fix usage output of a descendant command of the command-level mapped command.
 - Leverage the invoked command's .Use as long as it is prefixed by the premap command name
 - Update aliases list to included the mapped command name instead of the premapped one

In addition, provide a set of functions to obtain useful information about the InvocationContext

```
    CLIInvocationString : return base CLI invocation string up to the mapped command
    CLIInvocationStringForCommand : return full CLI invocation string that would have led to the invocation of the provided Command
    MappedSourceCommandPath : returns the mapped command path used as the source of the command mapping
    InvokedGroupPath : returns the command path CLI uses prior to the mapped command
    InvokedCommandName : returns named of the command CLI uses to invoke the mapped command
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

See unit tests updates.

manual tests:
(dpr is mapped command name of command `deeper`)
```
> tz dpr dshout --help
dshout something

Usage:
  tanzu dpr dshout MESSAGE

Aliases:
  dshout, sh, sht

Flags:
  -h, --help           help for dshout
  -v, --value string   value to add to shout
```

```
> tz dpr --help
deeper commands

Usage:
  tanzu dpr (with no additional arguments)

  tanzu dpr [command]

Aliases:
  dpr, deep

Available Commands:
  dshout      dshout something

Flags:
  -h, --help   help for deeper

Use "tanzu dpr [command] --help" for more information about a command.
```

(dshout prints invocation context and invocation string for the dshout command)
```
tz dpr dshout foo
 foo!!
Invocation Context:
&plugin.InvocationContext{invokedGroup:"", invokedCommand:"dpr", sourceCommandPath:"deeper"}
Invocation String:
dpr dshout
```



### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix usage string and aliases of help for commands involved in command-level mapping
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
