### PR TITLE
(outdated) Update generate-docs to account for command mapping

### DIFF
--- a/plugin/generate_docs.go
+++ b/plugin/generate_docs.go
@@ -7,6 +7,7 @@ package plugin
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -22,35 +23,102 @@ var (
 	docsDir string
 )
 
-func generateDocsBasic(cmd *cobra.Command, args []string) error {
-	if docsDir == "" {
-		docsDir = DefaultDocsDir
+func hierarchyFromPath(cmdPath string) []string {
+	return strings.Fields(cmdPath)
+}
+
+// mapCommand inserts a subcommand at the position of the tanzu command tree as
+// specified by mapEntry, ensuring that any ancestor commands are created as
+// well, if necessary.
+func mapCommand(tanzuCmd, subCommand *cobra.Command, mapEntry *CommandMapEntry) {
+	if mapEntry == nil || mapEntry.DestinationCommandPath == "" {
+		return
 	}
-	if dir, err := os.Stat(docsDir); err != nil || !dir.IsDir() {
-		return errors.Wrap(err, fmt.Sprintf(ErrorDocsOutputFolderNotExists, docsDir))
-	}
-	identity := func(s string) string {
-		if !strings.HasPrefix(s, "tanzu") {
-			return fmt.Sprintf("tanzu_%s", s)
+
+	dstHierarchy := hierarchyFromPath(mapEntry.DestinationCommandPath)
+	numParts := len(dstHierarchy)
+
+	for i := 1; i <= numParts; i++ {
+		cmd, cmdParent := findSubCommandByHierarchy(tanzuCmd, dstHierarchy[:i], matchOnCommandName)
+		if cmdParent == nil {
+			break
 		}
-		return s
-	}
-	emptyStr := func(s string) string { return "" }
 
-	tanzuCmd := cobra.Command{
-		Use: "tanzu",
+		if cmd == nil {
+			// dealing with actual command now
+			if i == numParts {
+				cmd = subCommand
+				cmd.Hidden = false
+				if mapEntry.Description != "" {
+					cmd.Short = mapEntry.Description
+				}
+				if len(mapEntry.Aliases) != 0 {
+					cmd.Aliases = append([]string{dstHierarchy[numParts-1]}, mapEntry.Aliases...)
+				}
+				subCommand.Use = dstHierarchy[numParts-1]
+			} else {
+				// create missing intermediate command
+				cmd = &cobra.Command{
+					Use: dstHierarchy[i-1],
+				}
+			}
+			cmdParent.AddCommand(cmd)
+		}
 	}
-	// Necessary to generate correct output
-	tanzuCmd.AddCommand(cmd.Parent())
-	if err := doc.GenMarkdownTreeCustom(cmd.Parent(), docsDir, emptyStr, identity); err != nil {
-		return fmt.Errorf("error generating docs %q", err)
+}
+
+// rebuildTanzuCommandTree reconstructs the tanzu CLI's placement of the
+// plugin's commands after accounting for the plugin descriptor's CommandMap.
+// It is primarily used to prep a Command tree for cobra's doc generation APIs
+// warning: commands will be mutated as a side effect
+func rebuildTanzuCommandTree(tanzuCmd, pluginRootCmd *cobra.Command, desc *PluginDescriptor) {
+	tanzuCmd.AddCommand(pluginRootCmd)
+
+	// straightfoward when no command mapping to account for
+	if desc == nil || len(desc.CommandMap) == 0 {
+		return
 	}
 
-	return nil
+	// reconstruct command tree by relocating all mapped commands, then
+	cmap := desc.CommandMap
+	sort.Slice(cmap, func(i, j int) bool { return cmap[i].SourceCommandPath > cmap[j].SourceCommandPath })
+
+	for _, v := range cmap {
+		mapEntry := v
+		cmd, _ := findSubCommandByHierarchy(pluginRootCmd, hierarchyFromPath(mapEntry.SourceCommandPath), matchOnCommandName)
+		mapCommand(tanzuCmd, cmd, &mapEntry)
+	}
 }
 
 func getGenDocFn(desc *PluginDescriptor) func(cmd *cobra.Command, args []string) error {
-	return generateDocsBasic
+	return func(cmd *cobra.Command, args []string) error {
+		if docsDir == "" {
+			docsDir = DefaultDocsDir
+		}
+		if dir, err := os.Stat(docsDir); err != nil || !dir.IsDir() {
+			return errors.Wrap(err, fmt.Sprintf(ErrorDocsOutputFolderNotExists, docsDir))
+		}
+		identity := func(s string) string {
+			if !strings.HasPrefix(s, "tanzu") {
+				return fmt.Sprintf("tanzu_%s", s)
+			}
+			return s
+		}
+		emptyStr := func(s string) string { return "" }
+
+		tanzuCmd := cobra.Command{
+			Use:   "tanzu",
+			Short: "The main Tanzu CLI",
+		}
+
+		rebuildTanzuCommandTree(&tanzuCmd, cmd.Parent(), desc)
+
+		if err := doc.GenMarkdownTreeCustom(&tanzuCmd, docsDir, emptyStr, identity); err != nil {
+			return fmt.Errorf("error generating docs %q", err)
+		}
+
+		return nil
+	}
 }
 
 func newGenDocsCmd(desc *PluginDescriptor) *cobra.Command {

--- a/plugin/generate_docs.go
+++ b/plugin/generate_docs.go
@@ -22,38 +22,45 @@ var (
 	docsDir string
 )
 
-func init() {
-	genDocsCmd.Flags().StringVarP(&docsDir, "docs-dir", "d", DefaultDocsDir, "destination for docs output")
+func generateDocsBasic(cmd *cobra.Command, args []string) error {
+	if docsDir == "" {
+		docsDir = DefaultDocsDir
+	}
+	if dir, err := os.Stat(docsDir); err != nil || !dir.IsDir() {
+		return errors.Wrap(err, fmt.Sprintf(ErrorDocsOutputFolderNotExists, docsDir))
+	}
+	identity := func(s string) string {
+		if !strings.HasPrefix(s, "tanzu") {
+			return fmt.Sprintf("tanzu_%s", s)
+		}
+		return s
+	}
+	emptyStr := func(s string) string { return "" }
+
+	tanzuCmd := cobra.Command{
+		Use: "tanzu",
+	}
+	// Necessary to generate correct output
+	tanzuCmd.AddCommand(cmd.Parent())
+	if err := doc.GenMarkdownTreeCustom(cmd.Parent(), docsDir, emptyStr, identity); err != nil {
+		return fmt.Errorf("error generating docs %q", err)
+	}
+
+	return nil
 }
 
-var genDocsCmd = &cobra.Command{
-	Use:    "generate-docs",
-	Short:  "Generate Cobra CLI docs for all subcommands",
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if docsDir == "" {
-			docsDir = DefaultDocsDir
-		}
-		if dir, err := os.Stat(docsDir); err != nil || !dir.IsDir() {
-			return errors.Wrap(err, fmt.Sprintf(ErrorDocsOutputFolderNotExists, docsDir))
-		}
-		identity := func(s string) string {
-			if !strings.HasPrefix(s, "tanzu") {
-				return fmt.Sprintf("tanzu_%s", s)
-			}
-			return s
-		}
-		emptyStr := func(s string) string { return "" }
+func getGenDocFn(desc *PluginDescriptor) func(cmd *cobra.Command, args []string) error {
+	return generateDocsBasic
+}
 
-		tanzuCmd := cobra.Command{
-			Use: "tanzu",
-		}
-		// Necessary to generate correct output
-		tanzuCmd.AddCommand(cmd.Parent())
-		if err := doc.GenMarkdownTreeCustom(cmd.Parent(), docsDir, emptyStr, identity); err != nil {
-			return fmt.Errorf("error generating docs %q", err)
-		}
+func newGenDocsCmd(desc *PluginDescriptor) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "generate-docs",
+		Short:  "Generate Cobra CLI docs for all subcommands",
+		Hidden: true,
+		RunE:   getGenDocFn(desc),
+	}
+	cmd.Flags().StringVarP(&docsDir, "docs-dir", "d", DefaultDocsDir, "destination for docs output")
 
-		return nil
-	},
+	return cmd
 }

--- a/plugin/generate_docs_test.go
+++ b/plugin/generate_docs_test.go
@@ -13,12 +13,25 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 func TestGenDocsCmd(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: aurora.Bold(`Test plugin command`).String(),
+	}
+
+	descriptor := PluginDescriptor{
+		Name:        "test",
+		Target:      types.TargetGlobal,
+		Description: "test plugin",
+		Version:     "v1.2.3",
+		BuildSHA:    "cafecafe",
+		Group:       "TestGroup",
+		DocURL:      "https://docs.example.com",
+		Hidden:      false,
 	}
 
 	assert := assert.New(t)
@@ -43,7 +56,7 @@ func TestGenDocsCmd(t *testing.T) {
 	os.Stdout = w
 	os.Stderr = w
 
-	docsCmd := genDocsCmd
+	docsCmd := newGenDocsCmd(&descriptor)
 	cmd.AddCommand(docsCmd)
 	args := []string{}
 	args = append(args, "generate-docs")

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -30,7 +30,7 @@ func NewPlugin(descriptor *PluginDescriptor) (*Plugin, error) {
 		Cmd: newRootCmd(descriptor),
 	}
 	p.Cmd.AddCommand(lintCmd)
-	p.Cmd.AddCommand(genDocsCmd)
+	p.Cmd.AddCommand(newGenDocsCmd(descriptor))
 	p.Cmd.AddCommand(newPostInstallCmd(descriptor))
 	return p, nil
 }

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -82,6 +82,11 @@ func matchOnCommandName(cmd *cobra.Command, value string) bool {
 }
 
 func findSubCommandByHierarchy(cmd *cobra.Command, hierarchy []string, matcher func(*cobra.Command, string) bool) (*cobra.Command, *cobra.Command) {
+	if len(hierarchy) == 0 {
+		parent := cmd.Parent()
+		return cmd, parent
+	}
+
 	childCmds := cmd.Commands()
 	for i := range childCmds {
 		if len(hierarchy) == 1 {
@@ -106,10 +111,7 @@ func hierarchyFromMappedCommandPath(mappedCommandPath string, cmd *cobra.Command
 	var fromCmd *cobra.Command
 	var additionalCmdNames []string
 
-	rootCmd := cmd
-	for rootCmd.HasParent() {
-		rootCmd = rootCmd.Parent()
-	}
+	rootCmd := cmd.Root()
 
 	if mappedCommandPath == "" {
 		fromCmd = rootCmd


### PR DESCRIPTION
### What this PR does / why we need it

```   
    The approach taken is to recreate the tanzu CLI command tree with only
    the plugin's commands, after accounting for the mapping directives,
    and hand said command tree to cobra's doc generation APIs.
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
ran plugin-binary generate-docs --docs-dir xxx
for sample plugin binaries with and without CommandMap entries

use Tanzu CLI (need to include PR...)'s generate-all-docs command
tanzu generate-all-docs --docs-dir xxx
with the above mentioned sample plugin binaries installed

and verified that a consistent set of md docs are generated

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
