### PR TITLE
Update generate-docs to accounts for command mapping 2

### DIFF
--- a/plugin/generate_docs.go
+++ b/plugin/generate_docs.go
@@ -7,6 +7,7 @@ package plugin
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -22,35 +23,103 @@ var (
 	docsDir string
 )
 
-func generateDocsBasic(cmd *cobra.Command, args []string) error {
-	if docsDir == "" {
-		docsDir = DefaultDocsDir
+func hierarchyFromPath(cmdPath string) []string {
+	return strings.Fields(cmdPath)
+}
+
+// mapCommand inserts a subcommand at the position of the tanzu command tree as
+// specified by mapEntry, ensuring that any ancestor commands are created as
+// well, if necessary.
+func mapCommand(tanzuCmd, subCommand *cobra.Command, mapEntry *CommandMapEntry) {
+	if mapEntry == nil || mapEntry.DestinationCommandPath == "" {
+		return
 	}
-	if dir, err := os.Stat(docsDir); err != nil || !dir.IsDir() {
-		return errors.Wrap(err, fmt.Sprintf(ErrorDocsOutputFolderNotExists, docsDir))
-	}
-	identity := func(s string) string {
-		if !strings.HasPrefix(s, "tanzu") {
-			return fmt.Sprintf("tanzu_%s", s)
+
+	dstHierarchy := hierarchyFromPath(mapEntry.DestinationCommandPath)
+	numParts := len(dstHierarchy)
+
+	for i := 1; i <= numParts; i++ {
+		cmd, cmdParent := findSubCommandByHierarchy(tanzuCmd, dstHierarchy[:i], matchOnCommandName)
+		if cmdParent == nil {
+			break
 		}
-		return s
-	}
-	emptyStr := func(s string) string { return "" }
 
-	tanzuCmd := cobra.Command{
-		Use: "tanzu",
+		if cmd == nil {
+			// dealing with actual command now
+			if i == numParts {
+				cmd = subCommand
+				cmd.Hidden = false
+				if mapEntry.Description != "" {
+					cmd.Short = mapEntry.Description
+				}
+				if len(mapEntry.Aliases) != 0 {
+					cmd.Aliases = append([]string{dstHierarchy[numParts-1]}, mapEntry.Aliases...)
+				}
+				subCommand.Use = dstHierarchy[numParts-1]
+			} else {
+				// create missing intermediate command
+				cmd = &cobra.Command{
+					Use: dstHierarchy[i-1],
+				}
+			}
+			cmdParent.AddCommand(cmd)
+		}
 	}
-	// Necessary to generate correct output
-	tanzuCmd.AddCommand(cmd.Parent())
-	if err := doc.GenMarkdownTreeCustom(cmd.Parent(), docsDir, emptyStr, identity); err != nil {
-		return fmt.Errorf("error generating docs %q", err)
+}
+
+// rebuildTanzuCommandTree reconstructs the tanzu CLI's placement of the
+// plugin's commands after accounting for the plugin descriptor's CommandMap.
+// It is primarily used to prep a Command tree for cobra's doc generation APIs
+// warning: commands could be mutated as a side effect
+func rebuildTanzuCommandTree(tanzuCmd, pluginRootCmd *cobra.Command, desc *PluginDescriptor) {
+	tanzuCmd.AddCommand(pluginRootCmd)
+
+	// straightfoward when no command mapping to account for
+	if desc == nil || len(desc.CommandMap) == 0 {
+		return
 	}
 
-	return nil
+	// reconstruct command tree by relocating all mapped commands
+	cmap := desc.CommandMap
+	sort.Slice(cmap, func(i, j int) bool { return cmap[i].SourceCommandPath > cmap[j].SourceCommandPath })
+
+	for _, v := range cmap {
+		mapEntry := v
+		cmd, _ := findSubCommandByHierarchy(pluginRootCmd, hierarchyFromPath(mapEntry.SourceCommandPath), matchOnCommandName)
+		mapCommand(tanzuCmd, cmd, &mapEntry)
+	}
 }
 
 func getGenDocFn(desc *PluginDescriptor) func(cmd *cobra.Command, args []string) error {
-	return generateDocsBasic
+	return func(cmd *cobra.Command, args []string) error {
+		if docsDir == "" {
+			docsDir = DefaultDocsDir
+		}
+		if dir, err := os.Stat(docsDir); err != nil || !dir.IsDir() {
+			return errors.Wrap(err, fmt.Sprintf(ErrorDocsOutputFolderNotExists, docsDir))
+		}
+		identity := func(s string) string {
+			if !strings.HasPrefix(s, "tanzu") {
+				return fmt.Sprintf("tanzu_%s", s)
+			}
+			return s
+		}
+		emptyStr := func(s string) string { return "" }
+
+		tanzuCmd := cobra.Command{
+			Use:               "tanzu",
+			Short:             "The main Tanzu CLI",
+			DisableAutoGenTag: true,
+		}
+
+		rebuildTanzuCommandTree(&tanzuCmd, cmd.Parent(), desc)
+
+		if err := doc.GenMarkdownTreeCustom(&tanzuCmd, docsDir, emptyStr, identity); err != nil {
+			return fmt.Errorf("error generating docs %q", err)
+		}
+
+		return nil
+	}
 }
 
 func newGenDocsCmd(desc *PluginDescriptor) *cobra.Command {

--- a/plugin/generate_docs.go
+++ b/plugin/generate_docs.go
@@ -22,38 +22,45 @@ var (
 	docsDir string
 )
 
-func init() {
-	genDocsCmd.Flags().StringVarP(&docsDir, "docs-dir", "d", DefaultDocsDir, "destination for docs output")
+func generateDocsBasic(cmd *cobra.Command, args []string) error {
+	if docsDir == "" {
+		docsDir = DefaultDocsDir
+	}
+	if dir, err := os.Stat(docsDir); err != nil || !dir.IsDir() {
+		return errors.Wrap(err, fmt.Sprintf(ErrorDocsOutputFolderNotExists, docsDir))
+	}
+	identity := func(s string) string {
+		if !strings.HasPrefix(s, "tanzu") {
+			return fmt.Sprintf("tanzu_%s", s)
+		}
+		return s
+	}
+	emptyStr := func(s string) string { return "" }
+
+	tanzuCmd := cobra.Command{
+		Use: "tanzu",
+	}
+	// Necessary to generate correct output
+	tanzuCmd.AddCommand(cmd.Parent())
+	if err := doc.GenMarkdownTreeCustom(cmd.Parent(), docsDir, emptyStr, identity); err != nil {
+		return fmt.Errorf("error generating docs %q", err)
+	}
+
+	return nil
 }
 
-var genDocsCmd = &cobra.Command{
-	Use:    "generate-docs",
-	Short:  "Generate Cobra CLI docs for all subcommands",
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if docsDir == "" {
-			docsDir = DefaultDocsDir
-		}
-		if dir, err := os.Stat(docsDir); err != nil || !dir.IsDir() {
-			return errors.Wrap(err, fmt.Sprintf(ErrorDocsOutputFolderNotExists, docsDir))
-		}
-		identity := func(s string) string {
-			if !strings.HasPrefix(s, "tanzu") {
-				return fmt.Sprintf("tanzu_%s", s)
-			}
-			return s
-		}
-		emptyStr := func(s string) string { return "" }
+func getGenDocFn(desc *PluginDescriptor) func(cmd *cobra.Command, args []string) error {
+	return generateDocsBasic
+}
 
-		tanzuCmd := cobra.Command{
-			Use: "tanzu",
-		}
-		// Necessary to generate correct output
-		tanzuCmd.AddCommand(cmd.Parent())
-		if err := doc.GenMarkdownTreeCustom(cmd.Parent(), docsDir, emptyStr, identity); err != nil {
-			return fmt.Errorf("error generating docs %q", err)
-		}
+func newGenDocsCmd(desc *PluginDescriptor) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "generate-docs",
+		Short:  "Generate Cobra CLI docs for all subcommands",
+		Hidden: true,
+		RunE:   getGenDocFn(desc),
+	}
+	cmd.Flags().StringVarP(&docsDir, "docs-dir", "d", DefaultDocsDir, "destination for docs output")
 
-		return nil
-	},
+	return cmd
 }

--- a/plugin/generate_docs_test.go
+++ b/plugin/generate_docs_test.go
@@ -271,6 +271,99 @@ func TestGenerateDocsWithPlugin(t *testing.T) {
 				},
 			},
 		},
+		{
+			test: "top level plugin command mapped to top level of CLI",
+			commandMap: []CommandMapEntry{
+				{
+					SourceCommandPath:      "foo",
+					DestinationCommandPath: "foo",
+				},
+			},
+			hiddenCommands: []string{"foo", "deeper baz"},
+			expected: markdownState{
+				expectedFiles: []string{"tanzu.md", "tanzu_plug.md", "tanzu_foo.md", "tanzu_plug_bar.md"},
+				filesContent: map[string]fileContent{
+					"tanzu.md": fileContent{
+						contains: []string{"tanzu", "[tanzu plug](tanzu_plug.md)", "[tanzu foo](tanzu_foo.md)"},
+					},
+					"tanzu_plug.md": fileContent{
+						contains: []string{"[tanzu plug bar](tanzu_plug_bar.md)"},
+						omits: []string{
+							"tanzu plug deeper",
+							"tanzu plug foo",
+						},
+					},
+					"tanzu_foo.md": fileContent{
+						contains: []string{"foo command", "[tanzu](tanzu.md)"},
+						omits:    []string{"tanzu plug foo"},
+					},
+				},
+			},
+		},
+		{
+			test: "command and plugin level mapping",
+			commandMap: []CommandMapEntry{
+				{
+					SourceCommandPath:      "",
+					DestinationCommandPath: "pi",
+				},
+				{
+					SourceCommandPath:      "foo",
+					DestinationCommandPath: "foo",
+				},
+			},
+			hiddenCommands: []string{"foo", "deeper baz"},
+			expected: markdownState{
+				expectedFiles: []string{"tanzu.md", "tanzu_pi.md", "tanzu_foo.md", "tanzu_pi_bar.md"},
+				filesContent: map[string]fileContent{
+					"tanzu.md": fileContent{
+						contains: []string{"tanzu", "[tanzu pi](tanzu_pi.md)", "[tanzu foo](tanzu_foo.md)"},
+					},
+					"tanzu_pi.md": fileContent{
+						contains: []string{"[tanzu pi bar](tanzu_pi_bar.md)"},
+						omits: []string{
+							"tanzu pi deeper",
+							"tanzu pi foo",
+						},
+					},
+					"tanzu_foo.md": fileContent{
+						contains: []string{"foo command", "[tanzu](tanzu.md)"},
+						omits:    []string{"tanzu pi foo"},
+					},
+				},
+			},
+		},
+		{
+			test: "plugin level mapping to multiple destination paths",
+			commandMap: []CommandMapEntry{
+				{
+					SourceCommandPath:      "",
+					DestinationCommandPath: "pi",
+				},
+				{
+					SourceCommandPath:      "",
+					DestinationCommandPath: "hi",
+				},
+			},
+			hiddenCommands: []string{"foo", "deeper baz"},
+			expected: markdownState{
+				expectedFiles: []string{"tanzu.md", "tanzu_pi.md", "tanzu_hi.md", "tanzu_pi_bar.md", "tanzu_hi_bar.md"},
+				filesContent: map[string]fileContent{
+					"tanzu.md": fileContent{
+						contains: []string{"tanzu", "[tanzu pi](tanzu_pi.md)", "[tanzu hi](tanzu_hi.md)"},
+						omits:    []string{"plug"},
+					},
+					"tanzu_pi.md": fileContent{
+						contains: []string{"[tanzu pi bar](tanzu_pi_bar.md)"},
+						omits:    []string{"tanzu pi deeper", "tanzu pi foo"},
+					},
+					"tanzu_hi.md": fileContent{
+						contains: []string{"[tanzu hi bar](tanzu_hi_bar.md)", "[tanzu](tanzu.md)"},
+						omits:    []string{"tanzu pi"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, spec := range tests {

--- a/plugin/generate_docs_test.go
+++ b/plugin/generate_docs_test.go
@@ -13,12 +13,25 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/vmware-tanzu/tanzu-plugin-runtime/config/types"
 )
 
 func TestGenDocsCmd(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:   "test",
 		Short: aurora.Bold(`Test plugin command`).String(),
+	}
+
+	descriptor := PluginDescriptor{
+		Name:        "test",
+		Target:      types.TargetGlobal,
+		Description: "test plugin",
+		Version:     "v1.2.3",
+		BuildSHA:    "cafecafe",
+		Group:       "TestGroup",
+		DocURL:      "https://docs.example.com",
+		Hidden:      false,
 	}
 
 	assert := assert.New(t)
@@ -43,7 +56,7 @@ func TestGenDocsCmd(t *testing.T) {
 	os.Stdout = w
 	os.Stderr = w
 
-	docsCmd := genDocsCmd
+	docsCmd := newGenDocsCmd(&descriptor)
 	cmd.AddCommand(docsCmd)
 	args := []string{}
 	args = append(args, "generate-docs")

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -30,7 +30,7 @@ func NewPlugin(descriptor *PluginDescriptor) (*Plugin, error) {
 		Cmd: newRootCmd(descriptor),
 	}
 	p.Cmd.AddCommand(lintCmd)
-	p.Cmd.AddCommand(genDocsCmd)
+	p.Cmd.AddCommand(newGenDocsCmd(descriptor))
 	p.Cmd.AddCommand(newPostInstallCmd(descriptor))
 	return p, nil
 }

--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -82,6 +82,11 @@ func matchOnCommandName(cmd *cobra.Command, value string) bool {
 }
 
 func findSubCommandByHierarchy(cmd *cobra.Command, hierarchy []string, matcher func(*cobra.Command, string) bool) (*cobra.Command, *cobra.Command) {
+	if len(hierarchy) == 0 {
+		parent := cmd.Parent()
+		return cmd, parent
+	}
+
 	childCmds := cmd.Commands()
 	for i := range childCmds {
 		if len(hierarchy) == 1 {
@@ -106,10 +111,7 @@ func hierarchyFromMappedCommandPath(mappedCommandPath string, cmd *cobra.Command
 	var fromCmd *cobra.Command
 	var additionalCmdNames []string
 
-	rootCmd := cmd
-	for rootCmd.HasParent() {
-		rootCmd = rootCmd.Parent()
-	}
+	rootCmd := cmd.Root()
 
 	if mappedCommandPath == "" {
 		fromCmd = rootCmd

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -46,7 +46,7 @@ func TestUsageFunc(t *testing.T) {
 	assert.Contains(t, string(got), "Usage:")
 }
 
-func SampleTestPlugin(t *testing.T, target types.Target) *Plugin {
+func usageTestPlugin(t *testing.T, target types.Target) *Plugin {
 	var pluginsCmd = &cobra.Command{
 		Use:   "plugin",
 		Short: "Plugin tests",
@@ -92,10 +92,10 @@ func SampleTestPlugin(t *testing.T, target types.Target) *Plugin {
 		Version:     "v1.1.0",
 		BuildSHA:    "1234567",
 		CommandMap: []CommandMapEntry{
-			CommandMapEntry{
+			{
 				DestinationCommandPath: "test",
 			},
-			CommandMapEntry{
+			{
 				DestinationCommandPath: "fetch",
 				SourceCommandPath:      "fetch",
 			},
@@ -150,7 +150,7 @@ func TestGlobalTestPluginCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Global target
-	p := SampleTestPlugin(t, types.TargetGlobal)
+	p := usageTestPlugin(t, types.TargetGlobal)
 
 	// Set the arguments as if the user typed them in the command line
 	p.Cmd.SetArgs([]string{"--help"})
@@ -216,7 +216,7 @@ func TestKubernetesTestPluginCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Kubernetes target
-	p := SampleTestPlugin(t, types.TargetK8s)
+	p := usageTestPlugin(t, types.TargetK8s)
 
 	// Set the arguments as if the user typed them in the command line
 	p.Cmd.SetArgs([]string{"--help"})
@@ -278,7 +278,7 @@ func TestMissionControlTestPluginCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with MissionControl target
-	p := SampleTestPlugin(t, types.TargetTMC)
+	p := usageTestPlugin(t, types.TargetTMC)
 
 	// Set the arguments as if the user typed them in the command line
 	p.Cmd.SetArgs([]string{"--help"})
@@ -338,7 +338,7 @@ func TestGlobalTestPluginFetchCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Global target
-	p := SampleTestPlugin(t, types.TargetGlobal)
+	p := usageTestPlugin(t, types.TargetGlobal)
 
 	// Set the arguments as if the user typed them in the command line
 	p.Cmd.SetArgs([]string{"fetch", "--help"})
@@ -396,7 +396,7 @@ func TestGlobalTestFetchCommandHelpTextWithInvocationContext(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Global target
-	p := SampleTestPlugin(t, types.TargetGlobal)
+	p := usageTestPlugin(t, types.TargetGlobal)
 
 	p.Cmd.SetArgs([]string{"fetch", "--help"})
 
@@ -448,7 +448,7 @@ func TestKubernetesTestPluginFetchCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Kubernetes target
-	p := SampleTestPlugin(t, types.TargetK8s)
+	p := usageTestPlugin(t, types.TargetK8s)
 
 	// Set the arguments as if the user typed them in the command line
 	p.Cmd.SetArgs([]string{"fetch", "--help"})
@@ -501,7 +501,7 @@ func TestMissionControlTestPluginFetchCommandHelpText(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with MissionControl target
-	p := SampleTestPlugin(t, types.TargetTMC)
+	p := usageTestPlugin(t, types.TargetTMC)
 
 	// Set the arguments as if the user typed them in the command line
 	p.Cmd.SetArgs([]string{"fetch", "--help"})
@@ -560,7 +560,7 @@ func TestCommandMappedCommandWithInvocationContext(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Global target
-	p := SampleTestPlugin(t, types.TargetGlobal)
+	p := usageTestPlugin(t, types.TargetGlobal)
 
 	p.Cmd.SetArgs([]string{"push", "--help"})
 
@@ -627,7 +627,7 @@ func TestCommandMappedCommandSubCommandWithInvocationContext(t *testing.T) {
 	os.Stderr = w
 
 	// Prepare the root command with Global target
-	p := SampleTestPlugin(t, types.TargetGlobal)
+	p := usageTestPlugin(t, types.TargetGlobal)
 
 	p.Cmd.SetArgs([]string{"push", "more", "--help"})
 


### PR DESCRIPTION
### What this PR does / why we need it

```   
    The approach taken is to recreate the tanzu CLI command tree with only
    the plugin's commands, after accounting for the mapping directives,
    and hand said command tree to cobra's doc generation APIs.
```

Note: this superceds #182 (retained temporarily for reference)

### Which issue(s) this PR fixes

### Describe testing done for PR

* Added new unit tests to generate-docs using a Plugin with various CommandMap configuration
and verifies generated file set and expected content of the files.


* Run `plugin-binary generate-docs --docs-dir xxx` for sample plugin binaries with and without CommandMap entries and verified that a consistent set of md docs are generated

* Use Tanzu CLI (need to include https://github.com/vmware-tanzu/tanzu-cli/pull/752)'s generate-all-docs command
`tanzu generate-all-docs --docs-dir xxx` with the above mentioned sample plugin binaries installed and verified that a consistent set of md docs are generated

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix generate-docs for plugins with command mapping directives
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
