### PR TITLE
Ensure flags suffix is added to useline

### DIFF
--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -133,6 +133,20 @@ func hierarchyFromMappedCommandPath(mappedCommandPath string, cmd *cobra.Command
 }
 
 func useLineEx(cmd *cobra.Command, ic *InvocationContext) string {
+	useline := getInvocationStringForUseLine(cmd, ic)
+
+	if cmd.DisableFlagsInUseLine {
+		return useline
+	}
+
+	if cmd.HasAvailableFlags() && !strings.Contains(useline, "[flags]") {
+		useline += " [flags]"
+	}
+
+	return useline
+}
+
+func getInvocationStringForUseLine(cmd *cobra.Command, ic *InvocationContext) string {
 	// by checking sourceCommandPath we limit the use of the InvocationContext
 	// to only command-level (not plugin level) mapping
 	if ic == nil || ic.sourceCommandPath == "" {

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -412,7 +412,7 @@ func TestGlobalTestFetchCommandHelpTextWithInvocationContext(t *testing.T) {
 	expected := `Fetch the plugin tests
 
 Usage:
-  tanzu fetch
+  tanzu fetch [flags]
 
 Examples:
   sample example usage of the fetch command
@@ -576,7 +576,7 @@ func TestCommandMappedCommandWithInvocationContext(t *testing.T) {
 	expected := `Push the plugin tests
 
 Usage:
-  tanzu pu SOMESTUFF
+  tanzu pu SOMESTUFF [flags]
 
   tanzu pu [command]
 
@@ -643,7 +643,7 @@ func TestCommandMappedCommandSubCommandWithInvocationContext(t *testing.T) {
 	expected := `Push more
 
 Usage:
-  tanzu pu more
+  tanzu pu more [flags]
 
 Aliases:
   more, mo


### PR DESCRIPTION
If a mapped command is runnable and has flags,
make sure its useline includes the ' [flags]' suffix

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

See updated unit tests

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Ensure flags suffix is added to useline
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
