### PR TITLE
Disable syncing of "tanzu" contexts between legacy and latest CLI configuration files

### DIFF
--- a/config/contexts.go
+++ b/config/contexts.go
@@ -66,6 +66,9 @@ func SetContext(c *configtypes.Context, setCurrent bool) error {
 	}
 
 	// Back-fill servers based on contexts
+	if c.ContextType == configtypes.ContextTypeTanzu {
+		return nil
+	}
 	s := convertContextToServer(c)
 
 	// Add or update server

--- a/config/conversion.go
+++ b/config/conversion.go
@@ -25,8 +25,8 @@ func PopulateContexts(cfg *configtypes.ClientConfig) bool {
 		cfg.KnownContexts = make([]*configtypes.Context, 0, len(cfg.KnownServers))
 	}
 	for _, s := range cfg.KnownServers {
-		if cfg.HasContext(s.Name) {
-			// server already present in known contexts; skip
+		if s.Type == configtypes.ServerType(configtypes.ContextTypeTanzu) || cfg.HasContext(s.Name) {
+			// server of type "tanzu" or server already present in known contexts; skip
 			continue
 		}
 
@@ -100,8 +100,8 @@ func populateServers(cfg *configtypes.ClientConfig) {
 		fillMissingContextTypeInContext(c)
 		fillMissingTargetInContext(c)
 
-		if cfg.HasServer(c.Name) {
-			// context already present in known servers; skip
+		if c.ContextType == configtypes.ContextTypeTanzu || cfg.HasServer(c.Name) {
+			// "tanzu" context type or context already present in known servers; skip
 			continue
 		}
 

--- a/config/conversion_test.go
+++ b/config/conversion_test.go
@@ -197,6 +197,72 @@ func TestPopulateContexts(t *testing.T) {
 			},
 			delta: true,
 		},
+		{
+			name: "server of type 'tanzu' should be ignored for context population",
+			ip: &configtypes.ClientConfig{
+				KnownServers: []*configtypes.Server{
+					{
+						Name: "test-tanzu",
+						Type: configtypes.ServerType("tanzu"),
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test-tanzu-endpoint",
+						},
+					},
+					{
+						Name: "test-tmc",
+						Type: configtypes.GlobalServerType,
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test-endpoint",
+						},
+					},
+				},
+				CurrentServer: "test-tmc",
+				KnownContexts: []*configtypes.Context{
+					{
+						Name:   "test-tmc",
+						Target: configtypes.TargetTMC,
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test-endpoint",
+						},
+					},
+				},
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeTMC: "test-tmc",
+				},
+			},
+			op: &configtypes.ClientConfig{
+				KnownServers: []*configtypes.Server{
+					{
+						Name: "test-tanzu",
+						Type: configtypes.ServerType("tanzu"),
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test-tanzu-endpoint",
+						},
+					},
+					{
+						Name: "test-tmc",
+						Type: configtypes.GlobalServerType,
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test-endpoint",
+						},
+					},
+				},
+				CurrentServer: "test-tmc",
+				KnownContexts: []*configtypes.Context{
+					{
+						Name:   "test-tmc",
+						Target: configtypes.TargetTMC,
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test-endpoint",
+						},
+					},
+				},
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeTMC: "test-tmc",
+				},
+			},
+			delta: false,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -395,6 +461,94 @@ func TestPopulateServers(t *testing.T) {
 				CurrentContext: map[configtypes.ContextType]string{
 					configtypes.ContextTypeK8s: "test-mc",
 					configtypes.ContextTypeTMC: "test-tmc",
+				},
+			},
+		},
+		{
+			name: "context type of 'tanzu' should be ignored for server population",
+			ip: &configtypes.ClientConfig{
+				KnownServers: []*configtypes.Server{
+					{
+						Name: "test-mc",
+						Type: configtypes.ManagementClusterServerType,
+						ManagementClusterOpts: &configtypes.ManagementClusterServer{
+							Endpoint: "test-endpoint",
+							Path:     "test-path",
+							Context:  "test-context",
+						},
+					},
+				},
+				CurrentServer: "test-mc",
+				KnownContexts: []*configtypes.Context{
+					{
+						Name:   "test-tanzu",
+						Target: configtypes.Target(configtypes.ContextTypeTanzu),
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test--tanzu-endpoint",
+						},
+						ClusterOpts: &configtypes.ClusterServer{
+							Endpoint: "test-endpoint",
+							Path:     "test-path",
+							Context:  "test-context",
+						},
+					},
+					{
+						Name:   "test-tmc",
+						Target: configtypes.TargetTMC,
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test-endpoint",
+						},
+					},
+				},
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeTanzu: "test-tanzu",
+					configtypes.ContextTypeTMC:   "test-tmc",
+				},
+			},
+			op: &configtypes.ClientConfig{
+				KnownServers: []*configtypes.Server{
+					{
+						Name: "test-mc",
+						Type: configtypes.ManagementClusterServerType,
+						ManagementClusterOpts: &configtypes.ManagementClusterServer{
+							Endpoint: "test-endpoint",
+							Path:     "test-path",
+							Context:  "test-context",
+						},
+					},
+					{
+						Name: "test-tmc",
+						Type: configtypes.GlobalServerType,
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test-endpoint",
+						},
+					},
+				},
+				CurrentServer: "test-mc",
+				KnownContexts: []*configtypes.Context{
+					{
+						Name:   "test-tanzu",
+						Target: configtypes.Target(configtypes.ContextTypeTanzu),
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test--tanzu-endpoint",
+						},
+						ClusterOpts: &configtypes.ClusterServer{
+							Endpoint: "test-endpoint",
+							Path:     "test-path",
+							Context:  "test-context",
+						},
+					},
+					{
+						Name:   "test-tmc",
+						Target: configtypes.TargetTMC,
+						GlobalOpts: &configtypes.GlobalServer{
+							Endpoint: "test-endpoint",
+						},
+					},
+				},
+				CurrentContext: map[configtypes.ContextType]string{
+					configtypes.ContextTypeTanzu: "test-tanzu",
+					configtypes.ContextTypeTMC:   "test-tmc",
 				},
 			},
 		},


### PR DESCRIPTION
### What this PR does / why we need it
This PR disables syncing of "tanzu" type contexts between legacy and latest CLI config files. 
Summary:
Currently when tanzu context type is created , a corresponding server entry would be created. This would result in loss of some fileds(as per the legacy server structure type). Also, this syncing is bi-directional(context <> server). If the latest CLI configuration files is deleted or messed up, the syncing of server types to context type with incomplete data would cause issues for tanzu operations. So disabling the "tanzu" context type syncing between servers) and contexts would solve this issue.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Unit tests and CI

-Deleted the legacy config file and had the below latest config file (config-ng.yaml) . Now if I execute any CLI command CLI regenerated servers in the legacy config file except the tanzy type server(populated from tanzu context)
```
contexts:
    - name: tt-test-selfmg
      target: mission-control
      contextType: mission-control
      globalOpts:
        endpoint: tmc-sm-main.local-dev.7infra.com:443
        auth:
            issuer: https://pinniped-supervisor.tmc-sm-main.local-dev.7infra.com/provider/pinniped
            accessToken: <REDACTED>
            IDToken: <REDACTED>
            refresh_token: <REDACTED>
            expiration: 2023-02-13T16:06:27.596807-08:00
            type: id-token
      discoverySources: []
 
    - name: tkg-mgmt-vc
      target: kubernetes
      contextType: kubernetes
      clusterOpts:
        path: /Users/pkalle/temp/tkgCluster_admin.kfg
        context: tkg-mgmt-vc-admin@tkg-mgmt-vc
        isManagementCluster: true
      discoverySources: []
    - name: Tap-SaaS-Beta3
      target: tanzu
      contextType: tanzu
      globalOpts:
        endpoint: https://api.tanzu.cloud.vmware.com
        auth:
            issuer: https://console.cloud.vmware.com/csp/gateway/am/api
            userName: vuichiap
            permissions:
                - external/5ee4ea09-ce47-4e3e-9658-d131511674d4/tap:viewer
                - external/5ee4ea09-ce47-4e3e-9658-d131511674d4/tap:admin
                - csp:org_member
                - external/5ee4ea09-ce47-4e3e-9658-d131511674d4/tap:member
                - external/c939cbfa-190a-4c2b-b09e-7fb6e9716583/ensemble:admin
            accessToken: <REDACTED>
            IDToken: <REDACTED>
            refresh_token: <REDACTED>
            expiration: 2024-05-02T11:50:28.802179-07:00
            type: api-token
      discoverySources: []
cli:
    discoverySources:
        - oci:
            name: default
            image: projects.packages.broadcom.com/tanzu_cli/plugins/plugin-inventory:latest
    cliId: <REDACTED>
    telemetry:
        source: /Users/pkalle/.config/tanzu-cli-telemetry/cli_metrics.db
    eulaStatus: accepted
    eulaAcceptedVersions: v1.1.0
    ceipOptIn: "true"
```

Now ran the `tanzu version` with tanzu binary compiled using this PR plugin-runtime changes
```
❯ rm ~/.config/tanzu/config.yaml
❯ ls ~/.config/tanzu/config.yaml
ls: /Users/pkalle/.config/tanzu/config.yaml: No such file or directory
❯ ./bin/tanzu version
version: v1.3.0-dev
buildDate: 2024-05-02
sha: dd2a15f0-dirty
arch: amd64
❯ ls ~/.config/tanzu/config.yaml
/Users/pkalle/.config/tanzu/config.yaml
```
The below is the legacy file regenerated/populated  and it doesn't contain the `tanzu` type servers
```
servers:
    - name: tt-test-selfmg
      type: global
      globalOpts:
        endpoint: tmc-sm-main.local-dev.7infra.com:443
        auth:
            issuer: https://pinniped-supervisor.tmc-sm-main.local-dev.7infra.com/provider/pinniped
            accessToken: <REDACTED>
            IDToken: <REDACTED>
            refresh_token: <REDACTED>
            expiration: 2023-02-13T16:06:27.596807-08:00
            type: id-token
    - name: tkg-mgmt-vc
      type: managementcluster
      managementClusterOpts:
        path: /Users/pkalle/temp/tkgCluster_admin.kfg
        context: tkg-mgmt-vc-admin@tkg-mgmt-vc
```

- Performed the similar test by deleting the latest CLI config file( config-ng.yaml) and verified the tanzu type servers existing in the legacy config file are not populated as tanzu type contexts.

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Disable syncing of "tanzu" contexts between legacy and latest CLI configuration files
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
