### PR TITLE
Align example lines with rest of usage output

### DIFF
--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -179,7 +179,7 @@ Aliases:
   test, t
 
 Examples:
-sample example usage of the test command
+  sample example usage of the test command
 
 Available Commands:
   fetch         Fetch the plugin tests
@@ -240,7 +240,7 @@ Aliases:
   test, t
 
 Examples:
-sample example usage of the test command
+  sample example usage of the test command
 
 Available Commands:
   fetch         Fetch the plugin tests
@@ -301,7 +301,7 @@ Aliases:
   test, t
 
 Examples:
-sample example usage of the test command
+  sample example usage of the test command
 
 Available Commands:
   fetch         Fetch the plugin tests
@@ -357,7 +357,7 @@ Usage:
   tanzu test fetch [flags]
 
 Examples:
-sample example usage of the fetch command
+  sample example usage of the fetch command
 
 Flags:
   -h, --help           help for fetch
@@ -415,7 +415,7 @@ Usage:
   tanzu fetch [flags]
 
 Examples:
-sample example usage of the fetch command
+  sample example usage of the fetch command
 
 Flags:
   -h, --help           help for fetch
@@ -469,7 +469,7 @@ Usage:
   tanzu kubernetes test fetch [flags]
 
 Examples:
-sample example usage of the fetch command
+  sample example usage of the fetch command
 
 Flags:
   -h, --help           help for fetch
@@ -521,7 +521,7 @@ Usage:
   tanzu mission-control test fetch [flags]
 
 Examples:
-sample example usage of the fetch command
+  sample example usage of the fetch command
 
 Flags:
   -h, --help           help for fetch
@@ -584,8 +584,8 @@ Aliases:
   pu, psh
 
 Examples:
-sample example usage of the push command
-more sample example usage of the push command
+  sample example usage of the push command
+  more sample example usage of the push command
 
 Available Commands:
   more        Push more
@@ -657,4 +657,115 @@ Global Flags:
 `
 
 	assert.Equal(t, expected, got)
+}
+
+func TestExampleIndent(t *testing.T) {
+	tests := []struct {
+		test  string
+		input string
+		// add leading newline to align expected output for improved readability
+		expectedOutputWithLeadingNewline string
+	}{
+		{
+			test:  "single line - no indent",
+			input: "first line",
+			expectedOutputWithLeadingNewline: `
+  first line`,
+		},
+		{
+			test:  "single line - with indent",
+			input: "  first line",
+			expectedOutputWithLeadingNewline: `
+  first line`,
+		},
+		{
+			test:  "single line - with irregular indent",
+			input: "   first line",
+			expectedOutputWithLeadingNewline: `
+  first line`,
+		},
+		{
+			test:  "single line - with newline",
+			input: "first line\n",
+			expectedOutputWithLeadingNewline: `
+  first line
+`,
+		},
+		{
+			test:  "single line - with newlines",
+			input: "first line\n\n\n",
+			expectedOutputWithLeadingNewline: `
+  first line
+
+
+`,
+		},
+		{
+			test:  "multi line - no pre-indents",
+			input: "first line\nsecond line\nthird line",
+			expectedOutputWithLeadingNewline: `
+  first line
+  second line
+  third line`,
+		},
+		{
+			test:  "multi line - with pre-indents of all lines",
+			input: "  first line\n  second line\n  third line",
+			expectedOutputWithLeadingNewline: `
+  first line
+  second line
+  third line`,
+		},
+		{
+			test:  "multi line - with pre-indents of subsequent lines and newlines",
+			input: "first line\n\n  second line\n  third line\n\n\n",
+			expectedOutputWithLeadingNewline: `
+  first line
+
+  second line
+  third line
+
+
+`,
+		},
+
+		// when example lines have unrecognized indentation amounts
+		// no special handling other than shift all lines by same indent
+		{
+			test:  "multi line - lines having unexpected indent amounts - a",
+			input: "first line\n second line\n third line",
+			expectedOutputWithLeadingNewline: `
+  first line
+   second line
+   third line`,
+		},
+		{
+			test:  "multi line - lines having unexpected indent amounts - b",
+			input: "first line\n  para one\n  next\n    more indent\n    another",
+			expectedOutputWithLeadingNewline: `
+  first line
+    para one
+    next
+      more indent
+      another`,
+		},
+		{
+			test:  "multi line - lines having unexpected indent amounts and newlines",
+			input: "first line\n\n  second line\n    third line\n\n",
+			expectedOutputWithLeadingNewline: `
+  first line
+
+    second line
+      third line
+
+`,
+		},
+	}
+	for _, spec := range tests {
+		t.Run(spec.test, func(t *testing.T) {
+			assert := assert.New(t)
+			result := alignExampleForUsage(spec.input)
+			assert.Equal(spec.expectedOutputWithLeadingNewline, "\n"+result)
+		})
+	}
 }


### PR DESCRIPTION
Now that multi-line Example values do not need explicit indent to have them shown left-aligned in usage, update usage to ensure there is at least a designated amount of indent for each non-empty line, so as to match up with the rest of the usage sections.

Also correct for some specific situations where the explicit indent of subsequent lines is still present in the Example value by making the output for such value left aligned as well.

For Command with Example values that is 
- single line, 
- multiline with no explicit indent
- multiline with explicit 2 space indent for each line or for all but the first line
The example lines will be indent by 2 spaces.

For all other multiline values with arbitrary indents, all the lines will just be indented a further 2 spaces instead

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

See updated unit tests.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Plugins should refrain from introducing their own custom indentation in any multiline Example fields of their commands because Example lines will always be indented in usage output by at least two 2 spaces.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
