### PR TITLE
Remove invocation with "kubernetes" in the help

### DIFF
--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -199,13 +199,11 @@ func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
 	base := indentStr + "tanzu"
 
 	if cmd.Runnable() {
-		// For kubernetes, k8s, global, or no target display tanzu command path without target
-		if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
+		if shouldPrintInvocationWithoutTarget(target) {
 			output.WriteString(buildInvocationString(base, useLineEx(cmd, ic)) + "\n")
 		}
 
-		// For non global, or no target ;display tanzu command path with target
-		if target != types.TargetGlobal && target != types.TargetUnknown {
+		if shouldPrintInvocationWithTarget(target) {
 			output.WriteString(buildInvocationString(base, string(target), useLineEx(cmd, ic)) + "\n")
 		}
 	}
@@ -216,13 +214,12 @@ func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
 			// line between the usage for the Runnable and the one for the sub-commands
 			output.WriteString("\n")
 		}
-		// For kubernetes, k8s, global, or no target display tanzu command path without target
-		if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
+
+		if shouldPrintInvocationWithoutTarget(target) {
 			output.WriteString(buildInvocationString(base, commandPathEx(cmd, ic), "[command]") + "\n")
 		}
 
-		// For non global, or no target display tanzu command path with target
-		if target != types.TargetGlobal && target != types.TargetUnknown {
+		if shouldPrintInvocationWithTarget(target) {
 			output.WriteString(buildInvocationString(base, string(target), commandPathEx(cmd, ic), "[command]") + "\n")
 		}
 	}
@@ -244,13 +241,11 @@ func formatHelpFooter(cmd *cobra.Command, target types.Target) string {
 		base = "Use \"tanzu"
 	}
 
-	// For kubernetes, k8s, global, or no target display tanzu command path without target
-	if target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown {
+	if shouldPrintInvocationWithoutTarget(target) {
 		footer.WriteString(buildInvocationString(base, commandPathEx(cmd, ic), `[command] --help" for more information about a command.`+"\n"))
 	}
 
-	// For non global, or no target display tanzu command path with target
-	if target != types.TargetGlobal && target != types.TargetUnknown {
+	if shouldPrintInvocationWithTarget(target) {
 		footer.WriteString(buildInvocationString(base, string(target), commandPathEx(cmd, ic), `[command] --help" for more information about a command.`+"\n"))
 	}
 
@@ -380,4 +375,15 @@ var TemplateFuncs = template.FuncMap{
 	"underline":               component.Underline,
 	"trimTrailingWhitespaces": component.TrimRightSpace,
 	"beginsWith":              component.BeginsWith,
+}
+
+func shouldPrintInvocationWithoutTarget(target types.Target) bool {
+	// For kubernetes, k8s, global, or no target, display tanzu command path without target
+	return target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown
+}
+
+func shouldPrintInvocationWithTarget(target types.Target) bool {
+	// For non global, or no target display tanzu command path with target
+	// Also, for the deprecated invocation using the kubernetes target, no longer display the command path with the target
+	return target != types.TargetGlobal && target != types.TargetUnknown && target != types.TargetK8s
 }

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -170,6 +170,7 @@ func TestGlobalTestPluginCommandHelpText(t *testing.T) {
 	//
 	// is a known bug in cobra 1.8.0 that should be fixed in the next patch or
 	// minor release
+	//nolint:goconst
 	expected := `Test the CLI
 
 Usage:
@@ -234,7 +235,6 @@ func TestKubernetesTestPluginCommandHelpText(t *testing.T) {
 
 Usage:
   tanzu test [command]
-  tanzu kubernetes test [command]
 
 Aliases:
   test, t
@@ -254,7 +254,6 @@ Additional help topics:
   test plugin        Plugin tests
 
 Use "tanzu test [command] --help" for more information about a command.
-Use "tanzu kubernetes test [command] --help" for more information about a command.
 `
 	assert.Equal(t, expected, got)
 }
@@ -351,6 +350,7 @@ func TestGlobalTestPluginFetchCommandHelpText(t *testing.T) {
 	assert.Nil(t, err)
 
 	got := string(<-c)
+	//nolint:goconst
 	expected := `Fetch the plugin tests
 
 Usage:
@@ -466,7 +466,6 @@ func TestKubernetesTestPluginFetchCommandHelpText(t *testing.T) {
 
 Usage:
   tanzu test fetch [flags]
-  tanzu kubernetes test fetch [flags]
 
 Examples:
   sample example usage of the fetch command


### PR DESCRIPTION
### What this PR does / why we need it

Today plugins created with TargetK8s target type have their commands visible/invocable via both `tanzu <pluginname> ...` and `tanzu kubernetes|k8s <plugingname> ...`

The form without a target prefix is available only to kubernetes target for historical and compatibility reasons, but is the predominant invocation style. Since Tanzu Platform's plugin functionality are delivered through a mix of kubernetes-targeted and nonkubernetes-targeted plugins, encouraging this more compact form is important in promoting consistent and intuitive invocation styles. 

This PR removes the invocation using the `kubernetes` target from the help output of plugins.

Note that a plugin must be recompiled with this PR for the change to take effect.  Therefore it will only start taking effect as new versions of plugins get released.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

Note that I'm using the CLI build with https://github.com/vmware-tanzu/tanzu-cli/pull/781 which adds a deprecation message for the invocation with the `kubernetes` target prefix.

Before the change this was the output of the help for the `services` plugin which has a target of `kubernetes`:
```$ tz services -h
Commands for working with services, classes and claims

Usage:
  tanzu services [command]
  tanzu kubernetes services [command]

Aliases:
  services, service

Available Commands:
  bind          Bind a service to an app
  create        Create a new service
  delete        Delete a service
  get           Get a service
  list          List the available services
  type          Commands for working with service types
  unbind        Unbind a service from an app

Flags:
      --context string      name of the kubeconfig context to use (default is current-context defined by kubeconfig)
  -h, --help                help for services
      --kubeconfig string   kubeconfig file (default is /Users/kmarc/.kube/config)
      --no-color            turn off color output in terminals

Use "tanzu services [command] --help" for more information about a command.
Use "tanzu kubernetes services [command] --help" for more information about a command.
$ tz k8s services -h
Command "services" is deprecated, when called with the "kubernetes" prefix. Please invoke "services" directly without the "kubernetes" prefix.
Commands for working with services, classes and claims

Usage:
  tanzu services [command]
  tanzu kubernetes services [command]

Aliases:
  services, service

Available Commands:
  bind          Bind a service to an app
  create        Create a new service
  delete        Delete a service
  get           Get a service
  list          List the available services
  type          Commands for working with service types
  unbind        Unbind a service from an app

Flags:
      --context string      name of the kubeconfig context to use (default is current-context defined by kubeconfig)
  -h, --help                help for services
      --kubeconfig string   kubeconfig file (default is /Users/kmarc/.kube/config)
      --no-color            turn off color output in terminals

Use "tanzu services [command] --help" for more information about a command.
Use "tanzu kubernetes services [command] --help" for more information about a command.
$ tz services list -h
List the available services

Usage:
  tanzu services list [flags]
  tanzu kubernetes services list [flags]

Examples:
  tanzu services list

Flags:
  -h, --help   help for list

Global Flags:
      --context string      name of the kubeconfig context to use (default is current-context defined by kubeconfig)
      --kubeconfig string   kubeconfig file (default is /Users/kmarc/.kube/config)
      --no-color            turn off color output in terminals
```

After recompiling the plugin using a plugin-runtime with this PR, the help no longer shows the invocation with `kubernetes`:
```
$ tz services -h
Commands for working with services, classes and claims

Usage:
  tanzu services [command]

Aliases:
  services, service

Available Commands:
  bind          Bind a service to an app
  create        Create a new service
  delete        Delete a service
  get           Get a service
  list          List the available services
  type          Commands for working with service types
  unbind        Unbind a service from an app

Flags:
      --context string      name of the kubeconfig context to use (default is current-context defined by kubeconfig)
  -h, --help                help for services
      --kubeconfig string   kubeconfig file (default is /Users/kmarc/.kube/config)
      --no-color            turn off color output in terminals

Use "tanzu services [command] --help" for more information about a command.

$ tz k8s services -h
Command "services" is deprecated, when called with the "kubernetes" prefix. Please invoke "services" directly without the "kubernetes" prefix.
Commands for working with services, classes and claims

Usage:
  tanzu services [command]

Aliases:
  services, service

Available Commands:
  bind          Bind a service to an app
  create        Create a new service
  delete        Delete a service
  get           Get a service
  list          List the available services
  type          Commands for working with service types
  unbind        Unbind a service from an app

Flags:
      --context string      name of the kubeconfig context to use (default is current-context defined by kubeconfig)
  -h, --help                help for services
      --kubeconfig string   kubeconfig file (default is /Users/kmarc/.kube/config)
      --no-color            turn off color output in terminals

Use "tanzu services [command] --help" for more information about a command.

$ tz services list -h
List the available services

Usage:
  tanzu services list [flags]

Examples:
  tanzu services list

Flags:
  -h, --help   help for list

Global Flags:
      --context string      name of the kubeconfig context to use (default is current-context defined by kubeconfig)
      --kubeconfig string   kubeconfig file (default is /Users/kmarc/.kube/config)
      --no-color            turn off color output in terminals
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
No longer show the invocation with the `kubernetes` target prefix in the help output.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
