### PR TITLE
Add per-mapping required context type

### DIFF
--- a/plugin/info_test.go
+++ b/plugin/info_test.go
@@ -46,9 +46,11 @@ func TestInfo(t *testing.T) {
 		Hidden:               false,
 		SupportedContextType: []types.ContextType{types.ContextTypeTanzu},
 		CommandMap: []CommandMapEntry{
-			CommandMapEntry{
+			{
 				SourceCommandPath:      "subber",
 				DestinationCommandPath: "subber",
+				Overrides:              "somecommand",
+				RequiredContextType:    []types.ContextType{types.ContextTypeTanzu},
 			},
 		},
 	}
@@ -91,8 +93,11 @@ func TestInfo(t *testing.T) {
 	assert.Equal(expectedInfo.DocURL, gotInfo.DocURL)
 	assert.Equal(expectedInfo.Hidden, gotInfo.Hidden)
 	assert.Equal(expectedInfo.SupportedContextType, gotInfo.SupportedContextType)
+	assert.Equal("somecommand", gotInfo.CommandMap[0].Overrides)
+	assert.Equal([]types.ContextType{types.ContextTypeTanzu}, gotInfo.CommandMap[0].RequiredContextType)
 	assert.Equal(subCmd.Aliases, gotInfo.CommandMap[0].Aliases)
 	assert.Equal(subCmd.Short, gotInfo.CommandMap[0].Description)
+
 	assert.Equal(expectedInfo.BinaryArch, gotInfo.BinaryArch)
 	assert.Empty(gotInfo.PluginRuntimeVersion, "Should be empty since unit tests doesn't have the self (tanzu-plugin-runtime) module dependency")
 }

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -66,8 +66,8 @@ type CommandMapEntry struct {
 	DestinationCommandPath string `json:"dstPath" yaml:"dstPath"`
 	// By default, the command previously situated at the
 	// DestinationCommandPath of the Tanzu CLI, if one exist, will be the one
-	// overridden by this entry. If this mapping attempt is intended to
-	// override another part of the Tanzu CLI command tree, the override path should be used.
+	// overridden by this entry. If this mapping attempt is intended to override
+	// another part of the Tanzu CLI command tree, the override path should be used.
 	// Specified as a space-delimited path relative to the Tanzu CLI command tree.
 	Overrides string `json:"overrides" yaml:"overrides"`
 	// Required when remapping a subcommand of this plugin outside of the
@@ -83,6 +83,10 @@ type CommandMapEntry struct {
 	// sense that if unset, the aliases of the actual Command at the
 	// SourceCommandPath will be used.
 	Aliases []string `json:"aliases,omitempty" yaml:"aliases,omitempty"`
+	// RequiredContextType specifies one or more ContextType's that has to be active in order for this
+	// mapping to take effect. If unset, this entry's mapping will apply regardless of state of active
+	// contexts.
+	RequiredContextType []types.ContextType `json:"requiredContextType,omitempty" yaml:"requiredContextType,omitempty"`
 }
 
 // PluginDescriptor describes a plugin binary.


### PR DESCRIPTION
### What this PR does / why we need it

This provides explicit control at a command map entry level on whether the mapping should take effect conditionally on the type of context that is active.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
CommandMapEntry supports a RequiredContextType list, which controls whether the mapping should take effect based on the type of the active context.  
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
