### PR TITLE
Enable multi selection support in Prompt and Select components

### DIFF
--- a/component/README.md
+++ b/component/README.md
@@ -277,7 +277,7 @@ fmt.Println("You entered:", response)
 
 The `PromptConfig` struct also provides the Sensitive option to hide user input, and the `Options` field to provide a list of choices for the user to select from.
 
-``` go
+```go
 var response string
 p := &PromptConfig{
     Message: "Enter your password:",
@@ -298,6 +298,26 @@ if err != nil {
     // Handle error
 }
 fmt.Println("You selected:", response)
+```
+
+### Multi-selection support
+
+When the prompt is configured with a valid Options list, how the prompt is
+presented depends on whether the variable used to collect the response(s) is a
+scalar or a slice. In other words, in the preceding example, had the response
+variable been declared as
+
+```go
+    var response []string
+```
+
+instead, the displayed prompt will allow multiple selection
+
+```bash
+? Please select an option:  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter, ? for more help]
+> [x]  Option 1
+  [ ]  Option 2
+  [x]  Option 3
 ```
 
 ### Example
@@ -424,3 +444,7 @@ func main() {
     fmt.Println(response)
 }
 ```
+
+### Multi-selection support
+
+Like the Prompt component, multiple-selection can be provided by the component if it is invoked to collect a slice of values.

--- a/component/prompt_test.go
+++ b/component/prompt_test.go
@@ -23,7 +23,7 @@ func Test_translatePromptConfig_Sensitive(t *testing.T) {
 		Help:      "Help will be given to those who need it",
 	}
 
-	prompt := translatePromptConfig(&promptConfig)
+	prompt := buildPrompt(&promptConfig, false)
 	assert.NotNil(prompt)
 
 	// Secure should return a password prompt
@@ -42,13 +42,19 @@ func Test_translatePromptConfig_OptionsSelect(t *testing.T) {
 		Help:      "Help will be given to those who need it",
 	}
 
-	prompt := translatePromptConfig(&promptConfig)
+	// Prompt with options should return a Select or MultiSelect prompt
+	// depending on whether multiselection is needed
+	prompt := buildPrompt(&promptConfig, false)
 	assert.NotNil(prompt)
-
-	// Prompt with options should return a select prompt
 	selectPrompt, ok := prompt.(*survey.Select)
 	assert.True(ok)
 	assert.Equal(len(promptConfig.Options), len(selectPrompt.Options))
+
+	prompt = buildPrompt(&promptConfig, true)
+	assert.NotNil(prompt)
+	multiSelectPrompt, ok := prompt.(*survey.MultiSelect)
+	assert.True(ok)
+	assert.Equal(len(promptConfig.Options), len(multiSelectPrompt.Options))
 }
 
 func Test_translatePromptConfig_Input(t *testing.T) {
@@ -61,7 +67,7 @@ func Test_translatePromptConfig_Input(t *testing.T) {
 		Help:      "Help will be given to those who need it",
 	}
 
-	prompt := translatePromptConfig(&promptConfig)
+	prompt := buildPrompt(&promptConfig, false)
 	assert.NotNil(prompt)
 
 	// Prompt without options should return an input prompt

--- a/component/select.go
+++ b/component/select.go
@@ -4,6 +4,8 @@
 package component
 
 import (
+	"errors"
+
 	"github.com/AlecAivazis/survey/v2"
 )
 
@@ -35,11 +37,25 @@ func (p *SelectConfig) Run(response interface{}) error {
 
 // Select an option.
 func Select(p *SelectConfig, response interface{}) error {
-	prompt := translateSelectConfig(p)
+	if response == nil {
+		return errors.New("no response reference provided to record answers")
+	}
+	needMultipleSelect := isPointerToSlice(response)
+
+	prompt := buildSelect(p, needMultipleSelect)
 	return survey.AskOne(prompt, response)
 }
 
-func translateSelectConfig(p *SelectConfig) survey.Prompt {
+func buildSelect(p *SelectConfig, enableMultiSelect bool) survey.Prompt {
+	if enableMultiSelect {
+		return &survey.MultiSelect{
+			Message:  p.Message,
+			Options:  p.Options,
+			Default:  p.Default,
+			Help:     p.Help,
+			PageSize: p.PageSize,
+		}
+	}
 	return &survey.Select{
 		Message:  p.Message,
 		Options:  p.Options,


### PR DESCRIPTION
An useful extension to both the Prompt and Select component. The usage of the component is unchanged. However, providing a slice of strings to record answers from a list of selected options will enable multiple selection of said options.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->


### Describe testing done for PR

Updated unit tests + manual testing, using a test command exercising the multiselect functionality, shown below

[![asciicast](https://asciinema.org/a/Gz1UhQqMq8G1OX9OZPRKtfSFn.svg)](https://asciinema.org/a/Gz1UhQqMq8G1OX9OZPRKtfSFn)

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Enable multi selection in Prompt and Select components.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
