### PR TITLE
Fix OutputWriter Table to show rows when no headers are specified

### DIFF
--- a/component/output.go
+++ b/component/output.go
@@ -269,7 +269,9 @@ func renderListTable(ow *outputwriter) {
 // renderTable prints output as a table
 func renderTable(ow *outputwriter) {
 	// Filter keys and values based on dynamic keys
-	ow.keys, ow.values = filterDynamicColumns(ow.keys, ow.dynamicKeys, ow.values)
+	if len(ow.keys) != 0 {
+		ow.keys, ow.values = filterDynamicColumns(ow.keys, ow.dynamicKeys, ow.values)
+	}
 
 	table := tablewriter.NewWriter(ow.out)
 	table.SetBorder(false)

--- a/component/output_test.go
+++ b/component/output_test.go
@@ -76,7 +76,7 @@ func TestNewOutputWriterTableWithTabularApproach(t *testing.T) {
   NAME  STATUS     AGE  
   foo   READY      1d   
   bar   Not READY  1d   
-		`,
+`,
 		},
 
 		{
@@ -90,18 +90,48 @@ func TestNewOutputWriterTableWithTabularApproach(t *testing.T) {
   bar   [31mNot READY[0m  1d   
 `,
 		},
+
+		{
+			"verify table without headers with 2 columns",
+			[]string{},
+			[]interface{}{[]interface{}{"foo", "READY"}, []interface{}{"bar", "Not READY"}},
+			`
+  foo  READY      
+  bar  Not READY  
+`,
+		},
+		{
+			"verify table without headers with 1 columns",
+			[]string{},
+			[]interface{}{[]interface{}{"row1"}, []interface{}{"row2"}, []interface{}{"row3"}},
+			`
+  row1  
+  row2  
+  row3  
+`,
+		},
+		{
+			"verify table without headers with different columns per row",
+			[]string{},
+			[]interface{}{[]interface{}{"row1a", "row1b"}, []interface{}{"row2a", "row2b", "row2c"}, []interface{}{"row3"}},
+			`
+  row1a  row1b  
+  row2a  row2b  row2c  
+  row3   
+`,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var b bytes.Buffer
-			tab := NewOutputWriter(&b, string(TableOutputType), "NAME", "STATUS", "AGE")
+			tab := NewOutputWriter(&b, string(TableOutputType), tt.header...)
 			require.NotNil(t, tab)
 			for _, r := range tt.rows {
 				tab.AddRow(r.([]interface{})...)
 			}
 			tab.Render()
-			assert.Equal(t, strings.TrimSpace(tt.output), strings.TrimSpace(b.String()))
+			assert.Equal(t, strings.Replace(tt.output, "\n", "", 1), b.String())
 		})
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it

- Fix OutputWriter Table to show rows when no headers are specified
- This will make sure that we support Tables without headers as well.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Added unit tests
<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix OutputWriter Table to show rows when no headers are specified
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
