### PR TITLE
Fix plugin command usage when the `mission-control`/`operations` target plugin remaps the commands 

### DIFF
--- a/plugin/usage.go
+++ b/plugin/usage.go
@@ -199,11 +199,11 @@ func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
 	base := indentStr + "tanzu"
 
 	if cmd.Runnable() {
-		if shouldPrintInvocationWithoutTarget(target) {
+		if shouldPrintInvocationWithoutTarget(target, ic) {
 			output.WriteString(buildInvocationString(base, useLineEx(cmd, ic)) + "\n")
 		}
 
-		if shouldPrintInvocationWithTarget(target) {
+		if shouldPrintInvocationWithTarget(target, ic) {
 			output.WriteString(buildInvocationString(base, string(target), useLineEx(cmd, ic)) + "\n")
 		}
 	}
@@ -215,11 +215,11 @@ func formatUsageHelpSection(cmd *cobra.Command, target types.Target) string {
 			output.WriteString("\n")
 		}
 
-		if shouldPrintInvocationWithoutTarget(target) {
+		if shouldPrintInvocationWithoutTarget(target, ic) {
 			output.WriteString(buildInvocationString(base, commandPathEx(cmd, ic), "[command]") + "\n")
 		}
 
-		if shouldPrintInvocationWithTarget(target) {
+		if shouldPrintInvocationWithTarget(target, ic) {
 			output.WriteString(buildInvocationString(base, string(target), commandPathEx(cmd, ic), "[command]") + "\n")
 		}
 	}
@@ -241,11 +241,11 @@ func formatHelpFooter(cmd *cobra.Command, target types.Target) string {
 		base = "Use \"tanzu"
 	}
 
-	if shouldPrintInvocationWithoutTarget(target) {
+	if shouldPrintInvocationWithoutTarget(target, ic) {
 		footer.WriteString(buildInvocationString(base, commandPathEx(cmd, ic), `[command] --help" for more information about a command.`+"\n"))
 	}
 
-	if shouldPrintInvocationWithTarget(target) {
+	if shouldPrintInvocationWithTarget(target, ic) {
 		footer.WriteString(buildInvocationString(base, string(target), commandPathEx(cmd, ic), `[command] --help" for more information about a command.`+"\n"))
 	}
 
@@ -377,12 +377,20 @@ var TemplateFuncs = template.FuncMap{
 	"beginsWith":              component.BeginsWith,
 }
 
-func shouldPrintInvocationWithoutTarget(target types.Target) bool {
+func shouldPrintInvocationWithoutTarget(target types.Target, ic *InvocationContext) bool {
+	// Do not show the target information if the InvocationContext is specified
+	if ic != nil && ic.invokedCommand != "" {
+		return true
+	}
 	// For kubernetes, k8s, global, or no target, display tanzu command path without target
 	return target == types.TargetK8s || target == types.TargetGlobal || target == types.TargetUnknown
 }
 
-func shouldPrintInvocationWithTarget(target types.Target) bool {
+func shouldPrintInvocationWithTarget(target types.Target, ic *InvocationContext) bool {
+	// Do not show the target information if the InvocationContext is specified
+	if ic != nil && ic.invokedCommand != "" {
+		return false
+	}
 	// For non global, or no target display tanzu command path with target
 	// Also, for the deprecated invocation using the kubernetes target, no longer display the command path with the target
 	return target != types.TargetGlobal && target != types.TargetUnknown && target != types.TargetK8s

--- a/plugin/usage_test.go
+++ b/plugin/usage_test.go
@@ -409,6 +409,66 @@ func TestGlobalTestFetchCommandHelpTextWithInvocationContext(t *testing.T) {
 
 	got := string(<-c)
 
+	//nolint:goconst
+	expected := `Fetch the plugin tests
+
+Usage:
+  tanzu fetch [flags]
+
+Examples:
+  sample example usage of the fetch command
+
+Flags:
+  -h, --help           help for fetch
+  -l, --local string   path to local repository
+  -u, --url string     url to remote repository
+
+Global Flags:
+  -e, --env string   env to test
+`
+
+	assert.Equal(t, expected, got)
+}
+
+func TestOperationsTestFetchCommandHelpTextWithInvocationContext(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Error(err)
+	}
+	c := make(chan []byte)
+	go readOutput(t, r, c)
+
+	// Set up for our test
+	stdout := os.Stdout
+	stderr := os.Stderr
+
+	os.Setenv("TANZU_CLI_COMMAND_MAPPED_FROM", "fetch")
+	os.Setenv("TANZU_CLI_INVOKED_COMMAND", "fetch")
+	os.Setenv("TANZU_CLI_INVOKED_GROUP", "")
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+		os.Unsetenv("TANZU_CLI_COMMAND_MAPPED_FROM")
+		os.Unsetenv("TANZU_CLI_INVOKED_COMMAND")
+		os.Unsetenv("TANZU_CLI_INVOKED_GROUP")
+	}()
+	os.Stdout = w
+	os.Stderr = w
+
+	// Prepare the root command with Operations target
+	p := usageTestPlugin(t, types.TargetOperations)
+
+	p.Cmd.SetArgs([]string{"fetch", "--help"})
+
+	// Execute the command which will trigger the help
+	err = p.Execute()
+	assert.Nil(t, err)
+
+	err = w.Close()
+	assert.Nil(t, err)
+
+	got := string(<-c)
+
 	expected := `Fetch the plugin tests
 
 Usage:


### PR DESCRIPTION
### What this PR does / why we need it

- This PR fixes the help text generation issue when `non-global` target plugin remaps the commands.

Before this change:
- Target information was shown even if the command gets remapped to the root level

After this change:
- Target information will not be used to show command help text if the command is remapped

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR
- Manual Testing
- Unit Test

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix plugin command usage when the `mission-control`/`operations` target plugin remaps the commands 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
