### PR TITLE
Improvements to Hub client unit testing framework

### DIFF
--- a/client/hub/types.go
+++ b/client/hub/types.go
@@ -24,7 +24,7 @@ type Request struct {
 	// The GraphQL operation name. The server typically doesn't
 	// require this unless there are multiple queries in the
 	// document.
-	OpName string `json:"operationName"`
+	OpName string `json:"operationName,omitempty"`
 }
 
 // Response that contains data returned by the GraphQL API.


### PR DESCRIPTION
### What this PR does / why we need it

- Support throwing errors for Query and Mutations
- Make `OperationName` optional when sending requests
- Make mock response more flexible to return by implementing the `Responder` function which includes the mock variables

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Make OperationName optional for Hub Client requests. Improvements to the Hub client unit test framework
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
