### PR TITLE
Fix file lock issue on windows

### DIFF
--- a/config/clientconfignextgen_lock.go
+++ b/config/clientconfignextgen_lock.go
@@ -57,7 +57,7 @@ func ReleaseTanzuConfigNextGenLock() {
 	if cfgNextGenLock == nil {
 		return
 	}
-	if errUnlock := cfgNextGenLock.Unlock(); errUnlock != nil {
+	if errUnlock := cfgNextGenLock.Close(); errUnlock != nil {
 		panic(fmt.Sprintf("cannot release lock for tanzu config file, reason: %v", errUnlock))
 	}
 

--- a/config/lock.go
+++ b/config/lock.go
@@ -69,7 +69,7 @@ func ReleaseTanzuConfigLock() {
 	if tanzuConfigLock == nil {
 		return
 	}
-	if errUnlock := tanzuConfigLock.Unlock(); errUnlock != nil {
+	if errUnlock := tanzuConfigLock.Close(); errUnlock != nil {
 		panic(fmt.Sprintf("cannot release lock for tanzu config file, reason: %v", errUnlock))
 	}
 
@@ -103,7 +103,7 @@ func getFileLockWithTimeOut(lockPath string, lockDuration time.Duration) (*filem
 		select {
 		case <-cancel:
 			// Timed out, cleanup if necessary.
-			_ = flock.Unlock()
+			_ = flock.Close()
 		case result <- err:
 		}
 	}()

--- a/config/metadata_lock.go
+++ b/config/metadata_lock.go
@@ -57,7 +57,7 @@ func ReleaseTanzuMetadataLock() {
 	if tanzuMetadataLock == nil {
 		return
 	}
-	if errUnlock := tanzuMetadataLock.Unlock(); errUnlock != nil {
+	if errUnlock := tanzuMetadataLock.Close(); errUnlock != nil {
 		panic(fmt.Sprintf("cannot release lock for tanzu config metadata file, reason: %v", errUnlock))
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it

**Background:**
- As part of https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/200 we switched to use `github.com/alexflint/go-filemutex` package instead of `github.com/juju/fslock`.
- The `Unlock` function between the two libraries behaves differently. The main difference is the `go-filemutex.Unlock` does not close the file whereas the `fslock.Unlock` does close the file, automatically releasing any acquired lock.
- Because of the above difference we noticed that when the following sequence of operations are performed the acquiring the lock fails because the file was kept open by the first lock call.
   - `go-filemutex.Lock`
   - `go-filemutex.Unlock` 
   - `fslock.Lock`
- The above behavior can be noticed when the Tanzu CLI uses `go-filemutex` to lock the file using newer version of tanzu-plugin-runtime and plugins use `fslock` to lock the file using an older version of tanzu-plugin-runtime

**Fix:**
- Instead of using `go-filemutex.Unlock` use `go-filemutex.Close` to unlock the file and close the file descriptor. Doing this will make the newer version of library using `go-filemutex` compatible with older version of library which uses `fslock`


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

- Manual tests using a custom code that uses both libraries together.
```
// Copyright 2022 VMware, Inc. All Rights Reserved.
// SPDX-License-Identifier: Apache-2.0

package main

import (
	"os"

	"github.com/anujc/test-locking/filemutex"
	"github.com/anujc/test-locking/juju"
)

func main() {
	if len(os.Args) < 2 {
		panic("argument is required. Values: '1' or '2'")
	}

	arg := os.Args[1]
	if arg == "1" {
		filemutex.AcquireLock()
		filemutex.ReleaseLock()

		juju.AcquireLock()
		juju.ReleaseLock()

	} else if arg == "2" {
		juju.AcquireLock()
		juju.ReleaseLock()

		filemutex.AcquireLock()
		filemutex.ReleaseLock()
	} else {
		panic("incorrect argument")
	}
}
```

- Without the fix the above test program results are as follows:
   - Mac & Linux: 
      - `1` -> Success
      - `2` -> Success
   - Windows:
      - `1` -> Failed
      - `2` -> Success

- With the fix the above test program results are as follows:
   - Mac & Linux: 
      - `1` -> Success
      - `2` -> Success
   - Windows:
      - `1` -> Success
      - `2` -> Success

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix file lock issue on windows
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
