### PR TITLE
The Hub UT framework should send what it received

### DIFF
--- a/client/hub/testing/operations.go
+++ b/client/hub/testing/operations.go
@@ -59,7 +59,7 @@ type Operation struct {
 	Variables map[string]interface{}
 
 	// Response represents the response that should be returned whenever the server makes
-	// a match on Operation.opType, Operation.Identifier, and Operation.Variables.
+	// a match on Operation.opType, Operation.Identifier, and Operation.Variables keys.
 	// Response is to be used for Query and Mutation operations only.
 	// Note: User can define either `Response` or implement `Responder` function but should
 	// not be defining both.
@@ -67,15 +67,15 @@ type Operation struct {
 
 	// Responder implements the function that based on some operation parameters should respond
 	// differently.
-	// Tests that do not need flexibility in returning different responses based on the Operation
-	// should just configure the `Response` field instead.
+	// Tests that do not need flexibility in returning different responses based on the received
+	// request should just configure the `Response` field instead.
 	// Responder is to be used for Query and Mutation operations only.
 	// Note: User can define either `Response` or implement `Responder` function but should
 	// not be defining both.
 	Responder Responder
 
 	// EventGenerator should implement a eventData generator for testing and
-	// send mock event response to the `eventData` channel. To suggest end of
+	// send mock event response to the `eventData` channel. To suggest the end of
 	// the event responses from server side, you can close the eventData channel
 	// Note: This is only to be used for the Subscription where you will need to
 	// mock the generation of the events. This should not be used with Query or Mutation.
@@ -115,10 +115,10 @@ type OperationError struct {
 
 // Responder implements the function that based on some operation parameters should respond
 // differently. This type of Responder implementation is more useful when you want
-// to implement a generic function that returns data based on the operation
-type Responder func(ctx context.Context, op Operation) hub.Response
+// to implement a generic function that returns data based on the received Request
+type Responder func(ctx context.Context, receivedRequest Request) hub.Response
 
 // EventGenerator should implement a eventData generator for testing and
-// send mock event response to the `eventData` channel. To suggest end of
-// the event responses from server side, you can close the eventData channel
-type EventGenerator func(ctx context.Context, op Operation, eventData chan<- Response)
+// send mock event response to the `eventData` channel. To suggest the end of
+// the event responses from the server side, you can close the eventData channel
+type EventGenerator func(ctx context.Context, receivedRequest Request, eventData chan<- Response)

--- a/client/hub/testing/server.go
+++ b/client/hub/testing/server.go
@@ -134,7 +134,7 @@ func NewServer(t *testing.T, opts ...ServerOptions) *Server { //nolint:gocyclo
 				if strings.Contains(reqBody.Query, s.mutations[i].Identifier) {
 					if s.equalVariables(s.mutations[i].Variables, reqBody.Variables) {
 						if s.mutations[i].Responder != nil {
-							s.respond(w, http.StatusOK, s.mutations[i].Responder(r.Context(), s.mutations[i]))
+							s.respond(w, http.StatusOK, s.mutations[i].Responder(r.Context(), reqBody))
 						} else {
 							s.respond(w, http.StatusOK, s.mutations[i].Response)
 						}
@@ -147,7 +147,7 @@ func NewServer(t *testing.T, opts ...ServerOptions) *Server { //nolint:gocyclo
 				if strings.Contains(reqBody.Query, s.queries[i].Identifier) {
 					if s.equalVariables(s.queries[i].Variables, reqBody.Variables) {
 						if s.queries[i].Responder != nil {
-							s.respond(w, http.StatusOK, s.queries[i].Responder(r.Context(), s.queries[i]))
+							s.respond(w, http.StatusOK, s.queries[i].Responder(r.Context(), reqBody))
 						} else {
 							s.respond(w, http.StatusOK, s.queries[i].Response)
 						}
@@ -169,7 +169,7 @@ func NewServer(t *testing.T, opts ...ServerOptions) *Server { //nolint:gocyclo
 
 						respChan := make(chan Response)
 
-						go s.subscriptions[i].EventGenerator(r.Context(), s.subscriptions[i], respChan)
+						go s.subscriptions[i].EventGenerator(r.Context(), reqBody, respChan)
 
 						for eventResp := range respChan {
 							event, err := formatServerSentEvent("update", eventResp)


### PR DESCRIPTION
### What this PR does / why we need it

Before this PR the UT framework would send the registered operation.  This was not useful for unit tests as it is those same tests that registered the operation, so they are aware of what it is.  What the tests need is for the framework to send the actual received GraphQL request so that it can be verified. 

This PR does this.
NOTE: This change is not backwards-compatible.  However, I feel it is early enough in the use of the UT framework and that the only ones using it are probably the CLI team, that we can easily adapt.

The unit tests of the UT framework are updated to check that the sent value is the actual query received by the mock server.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Follow-up to #202 

### Describe testing done for PR

I have an internal set of unit tests that now detects more failures by comparing the received graphql request with what the tests expect.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Hub unit test framework now sends back the GraphQL request it received for more thorough testing.  This change breaks backwards-compatibility of the API used to write unit test for GraphQL: the `Responder` and `EventGenerator` types have a slightly different signature.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
