### PR TITLE
Support Self-Signed CA Cert and skip-cert-verify with Hub Client

### DIFF
--- a/config/certs.go
+++ b/config/certs.go
@@ -26,13 +26,16 @@ func GetCerts() ([]*configtypes.Cert, error) {
 	return getCerts(node)
 }
 
-// GetCert retrieves the cert configuration by host
+// GetCert retrieves the cert configuration by host or URI
 func GetCert(host string) (*configtypes.Cert, error) {
 	if host == "" {
 		return nil, errors.New("host is empty")
 	}
 	u, err := url.Parse(host)
-	if err == nil && u.Hostname() != "" {
+	if err != nil {
+		return nil, err
+	}
+	if u.Hostname() != "" {
 		host = u.Hostname()
 	}
 
@@ -96,7 +99,7 @@ func DeleteCert(host string) error {
 	return persistConfig(node)
 }
 
-// CertExists checks if cert config by host already exists
+// CertExists checks if cert config by host or URI already exists
 func CertExists(host string) (bool, error) {
 	if host == "" {
 		return false, errors.New("host is empty")

--- a/config/certs.go
+++ b/config/certs.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -30,6 +31,11 @@ func GetCert(host string) (*configtypes.Cert, error) {
 	if host == "" {
 		return nil, errors.New("host is empty")
 	}
+	u, err := url.Parse(host)
+	if err == nil && u.Hostname() != "" {
+		host = u.Hostname()
+	}
+
 	// Retrieve client config node
 	node, err := getClientConfigNode()
 	if err != nil {

--- a/config/certs_test.go
+++ b/config/certs_test.go
@@ -32,31 +32,47 @@ func TestSetGetDeleteCerts(t *testing.T) {
 		Insecure:       "false",
 	}
 
-	ctx, err := GetCert("test1")
+	cert, err := GetCert("test1")
 	assert.Equal(t, "cert configuration for test1 not found", err.Error())
-	assert.Nil(t, ctx)
+	assert.Nil(t, cert)
 
 	err = SetCert(cert1)
 	assert.NoError(t, err)
 
-	ctx, err = GetCert("test1")
+	cert, err = GetCert("test1")
 	assert.Nil(t, err)
-	assert.Equal(t, cert1, ctx)
+	assert.Equal(t, cert1, cert)
 
-	ctx, err = GetCert("https://test1")
+	cert, err = GetCert("https://test1")
 	assert.Nil(t, err)
-	assert.Equal(t, cert1, ctx)
+	assert.Equal(t, cert1, cert)
 
-	ctx, err = GetCert("https://test1/fake")
+	cert, err = GetCert("https://test1/fake")
 	assert.Nil(t, err)
-	assert.Equal(t, cert1, ctx)
+	assert.Equal(t, cert1, cert)
+
+	cert, err = GetCert("https://test1:1234/fake")
+	assert.Nil(t, err)
+	assert.Equal(t, cert1, cert)
+
+	cert, err = GetCert("ws://test1/fake")
+	assert.Nil(t, err)
+	assert.Equal(t, cert1, cert)
+
+	cert, err = GetCert("wss://test1/fake")
+	assert.Nil(t, err)
+	assert.Equal(t, cert1, cert)
 
 	err = SetCert(cert2)
 	assert.NoError(t, err)
 
-	ctx, err = GetCert("test2")
+	cert, err = GetCert("test2")
 	assert.Nil(t, err)
-	assert.Equal(t, cert2, ctx)
+	assert.Equal(t, cert2, cert)
+
+	cert, err = GetCert("https://tes t1/fak e")
+	assert.Nil(t, cert)
+	assert.Equal(t, "parse \"https://tes t1/fak e\": invalid character \" \" in host name", err.Error())
 
 	_, err = GetCert("")
 	assert.Equal(t, "host is empty", err.Error())
@@ -70,8 +86,8 @@ func TestSetGetDeleteCerts(t *testing.T) {
 	err = DeleteCert("test1")
 	assert.Nil(t, err)
 
-	ctx, err = GetCert("test1")
-	assert.Nil(t, ctx)
+	cert, err = GetCert("test1")
+	assert.Nil(t, cert)
 	assert.Equal(t, "cert configuration for test1 not found", err.Error())
 }
 

--- a/config/certs_test.go
+++ b/config/certs_test.go
@@ -43,6 +43,14 @@ func TestSetGetDeleteCerts(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, cert1, ctx)
 
+	ctx, err = GetCert("https://test1")
+	assert.Nil(t, err)
+	assert.Equal(t, cert1, ctx)
+
+	ctx, err = GetCert("https://test1/fake")
+	assert.Nil(t, err)
+	assert.Equal(t, cert1, ctx)
+
 	err = SetCert(cert2)
 	assert.NoError(t, err)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -89,6 +89,13 @@ func GetEnvConfigurations() map[string]string
 func GetEdition() (string, error)
 func SetEdition(val string) (err error)
 
+// Cert APIs
+func GetCert(host string) (*configtypes.Cert, error)
+func GetCerts() ([]*configtypes.Cert, error)
+func SetCert(c *configtypes.Cert) error
+func DeleteCert(host string) error
+func CertExists(host string) (bool, error)
+
 // Telemetry APIs
 func GetCEIPOptIn() (string, error)
 func SetCEIPOptIn(val string) (err error)


### PR DESCRIPTION
### What this PR does / why we need it

- The Hub Client will use the `GetCert` API to get the certificate data for the specified hub endpoint.
- If the certificate data is not found, it will skip the TLS configuration and let the client use default configuration.
- GetCert API now accepts URI along with hostname

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support Self-Signed CA Cert and skip-cert-verify with Hub Client
GetCert API now accepts URI along with hostname
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
