### PR TITLE
add multiline prompt config support

### DIFF
--- a/component/prompt.go
+++ b/component/prompt.go
@@ -29,6 +29,9 @@ type PromptConfig struct {
 	// Sensitive information.
 	Sensitive bool
 
+	// Multiline response
+	Multiline bool
+
 	// Help for the prompt.
 	Help string
 }
@@ -86,6 +89,13 @@ func buildPrompt(p *PromptConfig, enableMultiSelect bool) survey.Prompt {
 		return &survey.Select{
 			Message: p.Message,
 			Options: p.Options,
+			Default: p.Default,
+			Help:    p.Help,
+		}
+	}
+	if p.Multiline {
+		return &survey.Multiline{
+			Message: p.Message,
 			Default: p.Default,
 			Help:    p.Help,
 		}

--- a/component/prompt_test.go
+++ b/component/prompt_test.go
@@ -31,6 +31,22 @@ func Test_translatePromptConfig_Sensitive(t *testing.T) {
 	assert.True(ok)
 }
 
+func Test_PromptConfig_WithMultilineResponse(t *testing.T) {
+	assert := assert.New(t)
+
+	promptConfig := PromptConfig{
+		Message:   "Write me a poem",
+		Default:   "Foo bar,\nbar foo",
+		Sensitive: false,
+		Help:      "Help will be given to those who need it",
+		Multiline: true,
+	}
+	prompt := buildPrompt(&promptConfig, true)
+	assert.NotNil(prompt)
+	_, ok := prompt.(*survey.Multiline)
+	assert.True(ok)
+}
+
 func Test_translatePromptConfig_OptionsSelect(t *testing.T) {
 	assert := assert.New(t)
 

--- a/hack/check/check-mdlint.sh
+++ b/hack/check/check-mdlint.sh
@@ -16,5 +16,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 # Additional configuration can be found in the .markdownlintrc file at
 # the root of the repo.
 docker run --rm -v "$(pwd)":/build \
-  gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.23.2 /md/lint \
+  ghcr.io/vmware-tanzu/tanzu-cli/ci-images/mdlint:0.23.2 /md/lint \
   -i **/CHANGELOG.md .


### PR DESCRIPTION
### What this PR does / why we need it
Tanzu services plug-ins requires more multiline input for operations like configuring preprovisioned services with certificates.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes TANZU-5670
-->
Fixes #

### Describe testing done for PR

Written unit tests + manual testing of survey.Multiline
### Release note
```release-note
Support `multiline = true` to PromptConfig and be able to add multiline strings as prompt inputs.
```
