### PR TITLE
[Release-1.4] CherryPick: Add multiline prompt config support

### DIFF
--- a/component/prompt.go
+++ b/component/prompt.go
@@ -29,6 +29,9 @@ type PromptConfig struct {
 	// Sensitive information.
 	Sensitive bool
 
+	// Multiline response
+	Multiline bool
+
 	// Help for the prompt.
 	Help string
 }
@@ -86,6 +89,13 @@ func buildPrompt(p *PromptConfig, enableMultiSelect bool) survey.Prompt {
 		return &survey.Select{
 			Message: p.Message,
 			Options: p.Options,
+			Default: p.Default,
+			Help:    p.Help,
+		}
+	}
+	if p.Multiline {
+		return &survey.Multiline{
+			Message: p.Message,
 			Default: p.Default,
 			Help:    p.Help,
 		}

--- a/component/prompt_test.go
+++ b/component/prompt_test.go
@@ -31,6 +31,22 @@ func Test_translatePromptConfig_Sensitive(t *testing.T) {
 	assert.True(ok)
 }
 
+func Test_PromptConfig_WithMultilineResponse(t *testing.T) {
+	assert := assert.New(t)
+
+	promptConfig := PromptConfig{
+		Message:   "Write me a poem",
+		Default:   "Foo bar,\nbar foo",
+		Sensitive: false,
+		Help:      "Help will be given to those who need it",
+		Multiline: true,
+	}
+	prompt := buildPrompt(&promptConfig, true)
+	assert.NotNil(prompt)
+	_, ok := prompt.(*survey.Multiline)
+	assert.True(ok)
+}
+
 func Test_translatePromptConfig_OptionsSelect(t *testing.T) {
 	assert := assert.New(t)
 

--- a/hack/check/check-mdlint.sh
+++ b/hack/check/check-mdlint.sh
@@ -16,5 +16,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 # Additional configuration can be found in the .markdownlintrc file at
 # the root of the repo.
 docker run --rm -v "$(pwd)":/build \
-  gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.23.2 /md/lint \
+  ghcr.io/vmware-tanzu/tanzu-cli/ci-images/mdlint:0.23.2 /md/lint \
   -i **/CHANGELOG.md .


### PR DESCRIPTION
Cherry-pick: https://github.com/vmware-tanzu/tanzu-plugin-runtime/pull/216

---------

### What this PR does / why we need it
* add multiline response support

* update mdlint with present docker image



### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support `multiline = true` to PromptConfig and be able to add multiline strings as prompt inputs.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
