### PR TITLE
[Release-1.4] Increases the GraphQL subscription client buffer size to 1MB to handle larger event chunks

### DIFF
--- a/client/hub/request.go
+++ b/client/hub/request.go
@@ -96,7 +96,7 @@ func (c *hubClient) Subscribe(ctx context.Context, req *Request, handler EventRe
 
 	eventChan := make(chan EventResponse)
 	errChan := make(chan error)
-	reader := sse.NewEventStreamReader(httpResp.Body, 1024)
+	reader := sse.NewEventStreamReader(httpResp.Body, 1024*1024)
 
 	go func() {
 		errChan <- waitForEvents(reader, eventChan)


### PR DESCRIPTION
Cherry-pick: (#219)

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #

### Describe testing done for PR

<!-- Example: Verified plugin built with updated runtime shows colorized tabular output on windows GitBash. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Increases the GraphQL subscription client buffer size to 1MB to handle larger event chunks 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
