### PR TITLE
Don't use templating to allow for dead-code elimination

### DIFF
--- a/plugin/root.go
+++ b/plugin/root.go
@@ -45,8 +45,12 @@ func newRootCmd(descriptor *PluginDescriptor) *cobra.Command {
 			cobra.CommandDisplayNameAnnotation: cmdName,
 		},
 	}
+	// Instead of using templates, use go functions.
+	// This allows for dead-code-elimination.
+	// The below call will set the format for both usage and help printouts.
+	cmd.SetUsageFunc(UsageFunc)
+	// Keep this call for backwards-compatibility, in case a plugin uses the templating
 	cobra.AddTemplateFuncs(TemplateFuncs)
-	cmd.SetUsageTemplate(cmdTemplate)
 
 	cmd.AddCommand(
 		newDescribeCmd(descriptor.Description),

--- a/plugin/root_test.go
+++ b/plugin/root_test.go
@@ -4,6 +4,11 @@
 package plugin
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,4 +31,64 @@ func Test_newRootCmd(t *testing.T) {
 	cmd := newRootCmd(&descriptor)
 	assert.Equal("Test Plugin", cmd.Use)
 	assert.Equal(("Description of the plugin"), cmd.Short)
+}
+
+// TestDeadcodeElimination checks that a simple program using the tanzu-plugin-runtime
+// is linked taking full advantage of the linker's deadcode elimination step.
+//
+// If reflect.Value.MethodByName/reflect.Value.Method are reachable the
+// linker will not always be able to prove that exported methods are
+// unreachable, making deadcode elimination less effective. Using
+// text/template and html/template makes reflect.Value.MethodByName
+// reachable.
+//
+// This test checks that those function can be proven to be unreachable by
+// the linker.
+//
+// Taken from https://github.com/spf13/cobra/blob/f98cf4216d3cb5235e6e0cd00ee00959deb1dc65/cobra_test.go#L245
+// See also: https://github.com/spf13/cobra/pull/1956
+func TestDeadcodeElimination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("go tool nm fails on windows")
+	}
+
+	// check that a simple program using tanzu-plugin-runtime is
+	// linked with deadcode elimination enabled.
+	const (
+		dirname  = "test_deadcode"
+		progname = "test_deadcode_elimination"
+	)
+	_ = os.Mkdir(dirname, 0770)
+	defer os.RemoveAll(dirname)
+	filename := filepath.Join(dirname, progname+".go")
+	err := os.WriteFile(filename, []byte(`package main
+
+import "github.com/vmware-tanzu/tanzu-plugin-runtime/plugin"
+
+func main() {
+	p, _ := plugin.NewPlugin(&plugin.PluginDescriptor{
+		Name:        "deadcode-check",
+		Description: "some desc",
+		Group:       "Manage",
+		Target:      "global",
+		Version:     "v0.0.0",
+	})
+	_ = p.Execute()
+}
+`), 0600)
+	if err != nil {
+		t.Fatalf("could not write test program: %v", err)
+	}
+	buf, err := exec.Command("go", "build", filename).CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not compile test program: %s", string(buf))
+	}
+	defer os.Remove(progname)
+	buf, err = exec.Command("go", "tool", "nm", progname).CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not run go tool nm: %v", err)
+	}
+	if strings.Contains(string(buf), "MethodByName") {
+		t.Error("compiled programs contains MethodByName symbol")
+	}
 }


### PR DESCRIPTION
This PR is on top of #227 so that the new test that checks for dead-code elimination works (or else the old Cobra version would prevent dead-code elimination and the test would fail).

### What this PR does / why we need it

When templating is used, the linker cannot know which functions are called and which one are not; this is because templating use calls to `MethodByName()` which can be used to call any function (similar to reflection). 

With the release of Cobra 1.9.1, templates are no longer used by default in Cobra. By also not using templates in the tanzu-plugin-runtime it now gives an opportunity for plugins to try to avoid templates to allow dead-code elimination to work, if they so choose.

This PR therefore removes the use of templates in tanzu-plugin-runtime.
Note that we had technically already moved to using go code but we just had kept the template engine calling the go code.

Note that the new `TestDeadcodeElimination` test is meant to notify us if templates are added.  However, if any new dependency used by tanzu-plugin-runtime uses templates or reflection, it would also turn off dead-code elimination and fail the test.  If there is a justification for that to happen, we will just need to disable the test.

Ref: https://github.com/spf13/cobra/pull/1956

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes # N/A

### Describe testing done for PR

I built a plugin using this new PR and verified that both its usage and help printouts were not changed:
```
$ tz project list -h
List the projects in the current workspace.

Project list configuration options include:
- Output the project formatted

Usage:
  tanzu project list [flags]

Aliases:
  list, ls

Examples:
  tanzu project list
  tanzu project list --wide

Flags:
  -h, --help   help for list
  -w, --wide   output the project list with additional information
$ tz project list --invalid
Usage:
  tanzu project list [flags]

Aliases:
  list, ls

Examples:
  tanzu project list
  tanzu project list --wide

Flags:
  -h, --help   help for list
  -w, --wide   output the project list with additional information

Error: unknown flag: --invalid
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Do not use templates so that dead-code elimination is not turned off.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-plugin-runtime/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one commit or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
